### PR TITLE
WIP: Add typescript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.1.2",
   "description": "high performance css-in-js",
   "main": "lib/index.js",
+  "typings": "styled.d.ts",
   "files": [
     "babel.js",
     "src",
@@ -29,6 +30,7 @@
   },
   "dependencies": {
     "babel-plugin-syntax-jsx": "^6.18.0",
+    "@types/react": "^15.0.33",
     "styled-components": "2.0.0",
     "touch": "^1.0.0"
   },

--- a/src/styled.js
+++ b/src/styled.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { css } from './index'
 
-export default function (tag, cls, vars = [], content) {
+export default function (tag, cls = '', vars = [], content) {
   if (!tag) {
     throw new Error(
       'You are trying to create a styled element with an undefined component.\nYou may have forgotten to import it.'

--- a/styled.d.ts
+++ b/styled.d.ts
@@ -1,14 +1,48 @@
-declare module "emotion/styled" {
-  import { Component } from "react";
+declare module "emotion" {
+  export type InputValue = string | number;
 
-  export type Styler = (
+  export function flush(): void;
+  export function css(
+    cls: string,
     content: TemplateStringsArray,
-    vars?: string[] | number[],
-  ) => Component;
+    ...vars: InputValue[],
+  ): string;
 
-  export default function(tag: Component): Styler;
+  export function fragment(
+    content: TemplateStringsArray,
+    ...vars: InputValue[],
+  ): string;
+
+  export function keyframes(
+    kfm: string,
+    content: TemplateStringsArray,
+    ...vars: InputValue[],
+  ): string;
+
+  export function fontFace(
+    fontRules: string,
+    content: TemplateStringsArray,
+    ...vars: InputValue[],
+  ): string;
+
+  export function hydrate(ids: string[]): void;
+}
+
+declare module "emotion/styled" {
+  import { ComponentClass, StatelessComponent } from "react";
+
+  type Component<P> = ComponentClass<P> | StatelessComponent<P>;
+
+  export type InterpolationValue = string | number;
+
+  export type Tagged = (
+    content: TemplateStringsArray,
+    ...vars: InterpolationValue[],
+  ) => Component<any>;
+
+  export default function(tag: Component<any>): Tagged;
   export default function(
     tag: keyof HTMLElementTagNameMap,
     cls?: string,
-  ): Styler;
+  ): Tagged;
 }

--- a/styled.d.ts
+++ b/styled.d.ts
@@ -22,22 +22,22 @@ declare module "emotion" {
 }
 
 declare module "emotion/styled" {
-  import { ComponentClass, StatelessComponent } from "react";
+  import { ComponentClass, StatelessComponent, HTMLProps } from "react";
 
   type Component<P> = ComponentClass<P> | StatelessComponent<P>;
 
   export type InterpolationValue = string | number;
 
-  export type Tagged = (
+  export type Tagged<P> = (
     content: TemplateStringsArray,
     ...vars: InterpolationValue[],
-  ) => Component<any>;
+  ) => Component<P>;
 
-  export default function(tag: Component<any>): Tagged;
+  export default function<P>(tag: Component<P>): Tagged<P>;
   export default function(
     tag: keyof HTMLElementTagNameMap,
     cls?: string,
-  ): Tagged;
+  ): Tagged<HTMLProps<P>>;
 }
 
 declare module "emotion/server" {

--- a/styled.d.ts
+++ b/styled.d.ts
@@ -1,29 +1,22 @@
 declare module "emotion" {
+  export const inserted: Record<string, boolean | undefined>;
+
   export type InputValue = string | number;
 
+  export function values(cls: string, vars: InputValue[]): string;
+
   export function flush(): void;
+
   export function css(
     cls: string,
     content: TemplateStringsArray,
     ...vars: InputValue[],
   ): string;
 
-  export function fragment(
-    content: TemplateStringsArray,
-    ...vars: InputValue[],
-  ): string;
+  export function injectGlobal(src: string[]): void;
+  export const fontFace = injectGlobal;
 
-  export function keyframes(
-    kfm: string,
-    content: TemplateStringsArray,
-    ...vars: InputValue[],
-  ): string;
-
-  export function fontFace(
-    fontRules: string,
-    content: TemplateStringsArray,
-    ...vars: InputValue[],
-  ): string;
+  export function keyframes(kfm: string, src: string[]): string;
 
   export function hydrate(ids: string[]): void;
 }
@@ -45,4 +38,20 @@ declare module "emotion/styled" {
     tag: keyof HTMLElementTagNameMap,
     cls?: string,
   ): Tagged;
+}
+
+declare module "emotion/server" {
+  export interface Rule {
+    cssText: string;
+  }
+
+  export interface Result {
+    html: string;
+    ids: Record<string, boolean | undefined>;
+    css: string;
+    rules: Rule[];
+  }
+
+  export function renderStatic(fn: () => string | undefined): Result;
+  export function renderStaticOptimized(fn: () => string | undefined): Result;
 }

--- a/styled.d.ts
+++ b/styled.d.ts
@@ -1,10 +1,14 @@
 declare module "emotion/styled" {
   import { Component } from "react";
 
+  export type Styler = (
+    content: TemplateStringsArray,
+    vars?: string[] | number[],
+  ) => Component;
+
+  export default function(tag: Component): Styler;
   export default function(
-    tag: keyof HTMLElementTagNameMap | Component,
+    tag: keyof HTMLElementTagNameMap,
     cls?: string,
-    vars?: any[],
-    content?: () => string[],
-  ): Component;
+  ): Styler;
 }

--- a/styled.d.ts
+++ b/styled.d.ts
@@ -1,0 +1,10 @@
+declare module "emotion/styled" {
+  import { Component } from "react";
+
+  export default function(
+    tag: keyof HTMLElementTagNameMap | Component,
+    cls?: string,
+    vars?: any[],
+    content?: () => string[],
+  ): Component;
+}


### PR DESCRIPTION
This PR adds typing so that the `styled` function will type-check when using typescript.

Still marked as `wip` because somehow the template tags are not recognized yet

Fixes #40 