### PR TITLE
Configurable imports

### DIFF
--- a/docs/configurable-imports.md
+++ b/docs/configurable-imports.md
@@ -32,6 +32,10 @@ a prop other than `css` for processing.
 }
 ```
 
+Beware that if you use the babel configuration, you must import as the
+same name. In the previous example, we would have to `import { css as
+cows } from 'emotion';` then use `cows` to construct the template
+literals. 
 
 # Use Case
 
@@ -40,7 +44,7 @@ styled-jsx application. When compiling the following file with emotion
 and styled-jsx.
 
 ```js
-import styled from "react-emotion";
+import styled, { css } from "react-emotion";
 
 export default () => (
   <div>
@@ -61,8 +65,7 @@ outputs.
 
 ```js
 import _JSXStyle from "styled-jsx/style";
-import { css as _css } from "emotion";
-import styled from "react-emotion";
+import styled, { css } from "react-emotion";
 
 export default (() => <div data-jsx={2648947580}>
     <p data-jsx={2648947580}>only this paragraph will get the style :)</p>
@@ -88,11 +91,12 @@ By adding the babel opt config rename as such.
 }
 ```
 
-We can avoid re-compiling the `css` props from styled-jsx.
+We can avoid re-compiling the `css` props and instead use `cows` for
+our template literals, etc.
 
 ```js
 import _JSXStyle from "styled-jsx/style";
-import styled, { css } from "react-emotion";
+import styled, { css as cows } from "react-emotion";
 
 export default (() => <div data-jsx={2648947580}>
     <p data-jsx={2648947580}>only this paragraph will get the style :)</p>
@@ -100,3 +104,4 @@ export default (() => <div data-jsx={2648947580}>
     <_JSXStyle styleId={2648947580} css={"p[data-jsx=\"2648947580\"]{color:red}"} />
   </div>);
 ```
+

--- a/docs/configurable-imports.md
+++ b/docs/configurable-imports.md
@@ -1,12 +1,13 @@
 # Configurable Imports
 
-If you are using ES Module imports (`import styled from 'emotion'`)
-the emotion babel plugin can handle two types of import renaming.
+If you are using ES Module imports (`import styled from
+'react-emotion'`) the emotion babel plugin can handle two types of
+import renaming.
 
 ## Dynamic
 
 ```js
-import something, { css as cows } from 'emotion';
+import something, { css as cows } from 'react-emotion';
 
 const classes = cows`
   color: red;
@@ -39,7 +40,7 @@ styled-jsx application. When compiling the following file with emotion
 and styled-jsx.
 
 ```js
-import styled, { css } from "emotion";
+import styled from "react-emotion";
 
 export default () => (
   <div>
@@ -61,7 +62,7 @@ outputs.
 ```js
 import _JSXStyle from "styled-jsx/style";
 import { css as _css } from "emotion";
-import styled, { css } from "emotion";
+import styled from "react-emotion";
 
 export default (() => <div data-jsx={2648947580}>
     <p data-jsx={2648947580}>only this paragraph will get the style :)</p>
@@ -91,7 +92,7 @@ We can avoid re-compiling the `css` props from styled-jsx.
 
 ```js
 import _JSXStyle from "styled-jsx/style";
-import styled, { css } from "emotion";
+import styled, { css } from "react-emotion";
 
 export default (() => <div data-jsx={2648947580}>
     <p data-jsx={2648947580}>only this paragraph will get the style :)</p>

--- a/docs/configurable-imports.md
+++ b/docs/configurable-imports.md
@@ -1,0 +1,101 @@
+# Configurable Imports
+
+If you are using ES Module imports (`import styled from 'emotion'`)
+the emotion babel plugin can handle two types of import renaming.
+
+## Dynamic
+
+```js
+import something, { css as cows } from 'emotion';
+
+const classes = cows`
+  color: red;
+`
+
+export default something.div`
+  background: blue;
+`
+```
+
+## Babel Opts
+
+The emotion babel plugin can also handle using babel options to handle
+processing via the `importedNames` key. This is useful for targetting
+a prop other than `css` for processing.
+
+```js
+{
+  "plugins": [
+    ["emotion", { "importedNames": { "css": 'cows' }}]
+  ]
+}
+```
+
+
+# Use Case
+
+One use case for this functionality is to migrate incrementally from a
+styled-jsx application. When compiling the following file with emotion
+and styled-jsx.
+
+```js
+import styled, { css } from "emotion";
+
+export default () => (
+  <div>
+    <p>only this paragraph will get the style :)</p>
+    {/* you can include <Component />s here that include
+         other <p>s that don't get unexpected styles! */}
+    <style jsx>{`
+      p {
+        color: red;
+      }
+    `}</style>
+  </div>
+);
+```
+
+The old combination would conflict on the `css` prop that styled-jsx
+outputs.
+
+```js
+import _JSXStyle from "styled-jsx/style";
+import { css as _css } from "emotion";
+import styled, { css } from "emotion";
+
+export default (() => <div data-jsx={2648947580}>
+    <p data-jsx={2648947580}>only this paragraph will get the style :)</p>
+    {}
+    <_JSXStyle styleId={2648947580} className={/*#__PURE__*/_css([], [], function createEmotionStyledRules() {
+    return [{
+      "p[data-jsx=\"2648947580\"]": {
+        "color": "red"
+      }
+    }];
+  })} />
+  </div>);
+```
+
+By adding the babel opt config rename as such.
+
+```js
+{
+  "plugins": [
+    "styled-jsx/babel",
+    ["emotion", { "importedNames": { "css": 'cows' }}]
+  ]
+}
+```
+
+We can avoid re-compiling the `css` props from styled-jsx.
+
+```js
+import _JSXStyle from "styled-jsx/style";
+import styled, { css } from "emotion";
+
+export default (() => <div data-jsx={2648947580}>
+    <p data-jsx={2648947580}>only this paragraph will get the style :)</p>
+    {}
+    <_JSXStyle styleId={2648947580} css={"p[data-jsx=\"2648947580\"]{color:red}"} />
+  </div>);
+```

--- a/packages/babel-plugin-emotion/src/css-prop.js
+++ b/packages/babel-plugin-emotion/src/css-prop.js
@@ -10,7 +10,7 @@ export default function(path, state, t) {
     const attrPath = openElPath.get('name')
     const name = attrPath.node.name
 
-    if (name === 'css') {
+    if (name === state.importedNames.css) {
       cssPath = attrPath
     }
 
@@ -91,11 +91,13 @@ export default function(path, state, t) {
   function getCssIdentifer() {
     if (state.opts.autoImportCssProp !== false) {
       if (!state.cssPropIdentifier) {
-        state.cssPropIdentifier = path.scope.generateUidIdentifier('css')
+        state.cssPropIdentifier = path.scope.generateUidIdentifier(
+          state.importedNames.css
+        )
       }
       return state.cssPropIdentifier
     } else {
-      return t.identifier('css')
+      return t.identifier(state.importedNames.css)
     }
   }
   function createCssTemplateExpression(templateLiteral) {

--- a/packages/babel-plugin-emotion/src/index.js
+++ b/packages/babel-plugin-emotion/src/index.js
@@ -265,7 +265,10 @@ export default function(babel) {
     visitor: {
       Program: {
         enter(path, state) {
-          state.importedNames = defaultImportedNames
+          state.importedNames = {
+            ...defaultImportedNames,
+            ...state.opts.importedNames // babel opts
+          }
           state.extractStatic =
             // path.hub.file.opts.filename !== 'unknown' ||
             state.opts.extractStatic
@@ -348,11 +351,15 @@ export default function(babel) {
             )
           }
           if (
-            path.node.callee.name === 'css' &&
+            path.node.callee.name === state.importedNames.css &&
             !path.node.arguments[1] &&
             path.node.arguments[0]
           ) {
-            replaceCssObjectCallExpression(path, t.identifier('css'), t)
+            replaceCssObjectCallExpression(
+              path,
+              t.identifier(state.importedNames.css),
+              t
+            )
           }
         } catch (e) {
           throw path.buildCodeFrameError(e)
@@ -390,8 +397,13 @@ export default function(babel) {
             )
           )
         } else if (t.isIdentifier(path.node.tag)) {
-          if (path.node.tag.name === 'css') {
-            replaceCssWithCallExpression(path, t.identifier('css'), state, t)
+          if (path.node.tag.name === state.importedNames.css) {
+            replaceCssWithCallExpression(
+              path,
+              t.identifier(state.importedNames.css),
+              state,
+              t
+            )
           } else if (path.node.tag.name === 'keyframes') {
             replaceCssWithCallExpression(
               path,

--- a/packages/babel-plugin-emotion/src/index.js
+++ b/packages/babel-plugin-emotion/src/index.js
@@ -242,7 +242,7 @@ const parseImports = (node, currentNames) => {
       names[singleImport.imported.name] = singleImport.local.name
     } else {
       // Is default import
-      names.default = singleImport.local.name
+      names.styled = singleImport.local.name
     }
   })
 
@@ -250,7 +250,7 @@ const parseImports = (node, currentNames) => {
 }
 
 const defaultImportedNames = {
-  default: 'styled',
+  styled: 'styled',
   css: 'css',
   keyframes: 'keyframes',
   injectGlobal: 'injectGlobal'
@@ -338,10 +338,10 @@ export default function(babel) {
         try {
           if (
             (t.isCallExpression(path.node.callee) &&
-              path.node.callee.callee.name === state.importedNames.default) ||
+              path.node.callee.callee.name === state.importedNames.styled) ||
             (t.isMemberExpression(path.node.callee) &&
               t.isIdentifier(path.node.callee.object) &&
-              path.node.callee.object.name === state.importedNames.default)
+              path.node.callee.object.name === state.importedNames.styled)
           ) {
             const identifier = t.isCallExpression(path.node.callee)
               ? path.node.callee.callee
@@ -371,7 +371,7 @@ export default function(babel) {
         if (
           // styled.h1`color:${color};`
           t.isMemberExpression(path.node.tag) &&
-          path.node.tag.object.name === state.importedNames.default
+          path.node.tag.object.name === state.importedNames.styled
         ) {
           path.replaceWith(
             buildStyledCallExpression(
@@ -385,7 +385,7 @@ export default function(babel) {
         } else if (
           // styled('h1')`color:${color};`
           t.isCallExpression(path.node.tag) &&
-          path.node.tag.callee.name === state.importedNames.default
+          path.node.tag.callee.name === state.importedNames.styled
         ) {
           path.replaceWith(
             buildStyledCallExpression(

--- a/packages/babel-plugin-emotion/test/__snapshots__/css-prop.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/css-prop.test.js.snap
@@ -97,6 +97,15 @@ exports[`babel css prop noClassName 1`] = `
 })}></div>;"
 `;
 
+exports[`babel css prop redefined-import: basic inline 1`] = `
+"import { css as _cows } from \\"emotion\\";
+<div className={\\"a\\" + \\" \\" + /*#__PURE__*/_cows([], [], function createEmotionStyledRules() {
+  return [{
+    \\"color\\": \\"brown\\"
+  }];
+})}></div>;"
+`;
+
 exports[`babel css prop with spread arg in jsx opening tag 1`] = `
 "import { css as _css } from \\"emotion\\";
 <div className={\\"a\\" + \\" \\" + /*#__PURE__*/_css([], [], function createEmotionStyledRules() {

--- a/packages/babel-plugin-emotion/test/__snapshots__/css.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/css.test.js.snap
@@ -94,6 +94,12 @@ css({
 });"
 `;
 
+exports[`babel css extract dynamically renamed-import: basic object support 1`] = `
+"import { css as cows } from 'emotion';cows({
+  'display': '-webkit-box; display: -ms-flexbox; display: flex'
+});"
+`;
+
 exports[`babel css extract prefixed array of objects 1`] = `
 "
 css([{
@@ -279,6 +285,25 @@ exports[`babel css inline css basic 2`] = `
       \\"lineHeight\\": \\"40px\\"
     },
     \\"width\\": x0
+  }];
+});"
+`;
+
+exports[`babel css inline css basic 3`] = `
+"
+import { css as cows } from 'emotion';
+/*#__PURE__*/cows([], [widthVar], function createEmotionStyledRules(x0) {
+  return [{
+    'margin': '12px 48px',
+    'color': '#ffffff; color: blue',
+    'display': '-webkit-box; display: -ms-flexbox; display: flex',
+    'WebkitBoxFlex': '1',
+    'msFlex': '1 0 auto',
+    'flex': '1 0 auto',
+    '@media (min-width: 420px)': {
+      'lineHeight': '40px'
+    },
+    'width': x0
   }];
 });"
 `;

--- a/packages/babel-plugin-emotion/test/__snapshots__/css.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/css.test.js.snap
@@ -127,6 +127,12 @@ css({
 });"
 `;
 
+exports[`babel css extract renamed-import: basic object support 1`] = `
+"cows({
+  'display': '-webkit-box; display: -ms-flexbox; display: flex'
+});"
+`;
+
 exports[`babel css inline ::placeholder 1`] = `
 "
 const cls1 = css({
@@ -244,6 +250,24 @@ const cls2 = /*#__PURE__*/css(['one-class', 'another-class', cls1], ['center'], 
 exports[`babel css inline css basic 1`] = `
 "
 /*#__PURE__*/css([], [widthVar], function createEmotionStyledRules(x0) {
+  return [{
+    \\"margin\\": \\"12px 48px\\",
+    \\"color\\": \\"#ffffff; color: blue\\",
+    \\"display\\": \\"-webkit-box; display: -ms-flexbox; display: flex\\",
+    \\"WebkitBoxFlex\\": \\"1\\",
+    \\"msFlex\\": \\"1 0 auto\\",
+    \\"flex\\": \\"1 0 auto\\",
+    \\"@media (min-width: 420px)\\": {
+      \\"lineHeight\\": \\"40px\\"
+    },
+    \\"width\\": x0
+  }];
+});"
+`;
+
+exports[`babel css inline css basic 2`] = `
+"
+/*#__PURE__*/cows([], [widthVar], function createEmotionStyledRules(x0) {
   return [{
     \\"margin\\": \\"12px 48px\\",
     \\"color\\": \\"#ffffff; color: blue\\",

--- a/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
@@ -317,3 +317,11 @@ const Figure = styled(\\"figure\\", \\"css-Figure-1mp0w960\\", [{
   ...defaultText
 }]);"
 `;
+
+exports[`babel styled component renamed import: inline variable import: no dynamic 1`] = `
+"import what from 'emotion'; /*#__PURE__*/what('h1', 'css-nl5a7v0', [], [], function createEmotionStyledRules() {
+  return {
+    'color': 'blue'
+  };
+});"
+`;

--- a/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
@@ -318,6 +318,14 @@ const Figure = styled(\\"figure\\", \\"css-Figure-1mp0w960\\", [{
 }]);"
 `;
 
+exports[`babel styled component renamed import: inline config rename 1`] = `
+"/*#__PURE__*/what(\\"h1\\", \\"css-1jhrj9p0\\", [], [], function createEmotionStyledRules() {
+  return {
+    \\"color\\": \\"blue\\"
+  };
+});"
+`;
+
 exports[`babel styled component renamed import: inline variable import: no dynamic 1`] = `
 "import what from 'emotion'; /*#__PURE__*/what('h1', 'css-nl5a7v0', [], [], function createEmotionStyledRules() {
   return {

--- a/packages/babel-plugin-emotion/test/css-prop.test.js
+++ b/packages/babel-plugin-emotion/test/css-prop.test.js
@@ -117,4 +117,12 @@ describe('babel css prop', () => {
     })
     expect(code).toMatchSnapshot()
   })
+
+  test('redefined-import: basic inline', () => {
+    const basic = '(<div className="a" cows={`color: brown;`}></div>)'
+    const { code } = babel.transform(basic, {
+      plugins: [[plugin, { importedNames: { css: 'cows' } }]]
+    })
+    expect(code).toMatchSnapshot()
+  })
 })

--- a/packages/babel-plugin-emotion/test/css.test.js
+++ b/packages/babel-plugin-emotion/test/css.test.js
@@ -1,14 +1,14 @@
-import * as babel from "babel-core";
-import plugin from "babel-plugin-emotion";
-import * as fs from "fs";
-jest.mock("fs");
+import * as babel from 'babel-core'
+import plugin from 'babel-plugin-emotion'
+import * as fs from 'fs'
+jest.mock('fs')
 
-fs.existsSync.mockReturnValue(true);
-fs.statSync.mockReturnValue({ isFile: () => false });
+fs.existsSync.mockReturnValue(true)
+fs.statSync.mockReturnValue({ isFile: () => false })
 
-describe("babel css", () => {
-  describe("inline", () => {
-    test("css basic", () => {
+describe('babel css', () => {
+  describe('inline', () => {
+    test('css basic', () => {
       const basic = `
         css\`
         margin: 12px 48px;
@@ -20,14 +20,14 @@ describe("babel css", () => {
           line-height: 40px;
         }
         width: \${widthVar};
-      \``;
+      \``
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
+      })
+      expect(code).toMatchSnapshot()
+    })
 
-    test("css basic", () => {
+    test('css basic', () => {
       const basic = `
         cows\`
         margin: 12px 48px;
@@ -39,14 +39,14 @@ describe("babel css", () => {
           line-height: 40px;
         }
         width: \${widthVar};
-      \``;
+      \``
       const { code } = babel.transform(basic, {
-        plugins: [[plugin, { importedNames: { css: "cows" } }]]
-      });
-      expect(code).toMatchSnapshot();
-    });
+        plugins: [[plugin, { importedNames: { css: 'cows' } }]]
+      })
+      expect(code).toMatchSnapshot()
+    })
 
-    test("css basic", () => {
+    test('css basic', () => {
       const basic = `
         import { css as cows } from 'emotion';
         cows\`
@@ -59,25 +59,25 @@ describe("babel css", () => {
           line-height: 40px;
         }
         width: \${widthVar};
-      \``;
+      \``
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
+      })
+      expect(code).toMatchSnapshot()
+    })
 
-    test("css with float property", () => {
+    test('css with float property', () => {
       const basic = `
         css\`
           float: left;
-      \``;
+      \``
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
+      })
+      expect(code).toMatchSnapshot()
+    })
 
-    test("css random expression", () => {
+    test('css random expression', () => {
       const basic = `css\`
         font-size: 20px;
         @media(min-width: 420px) {
@@ -88,28 +88,28 @@ describe("babel css", () => {
         background: green;
         \${{ backgroundColor: "hotpink" }};
       \`
-      `;
+      `
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
+      })
+      expect(code).toMatchSnapshot()
+    })
 
-    test("nested expanded properties", () => {
+    test('nested expanded properties', () => {
       const basic = `
         css\`
         margin: 12px 48px;
         & .div {
           display: 'flex';
         }
-      \``;
+      \``
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
+      })
+      expect(code).toMatchSnapshot()
+    })
 
-    test("interpolation in selector", () => {
+    test('interpolation in selector', () => {
       const basic = `
         const cls2 = css\`
         margin: 12px 48px;
@@ -118,14 +118,14 @@ describe("babel css", () => {
           display: none;
         }
         \`
-      `;
+      `
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
+      })
+      expect(code).toMatchSnapshot()
+    })
 
-    test("composes", () => {
+    test('composes', () => {
       const basic = `
         const cls1 = css\`
           display: flex;
@@ -135,28 +135,28 @@ describe("babel css", () => {
           justify-content: center;
           align-items: \${'center'}
         \`
-      `;
+      `
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
+      })
+      expect(code).toMatchSnapshot()
+    })
 
-    test("lots of composes", () => {
+    test('lots of composes', () => {
       const basic = `
         const cls2 = css\`
           composes: \${'one-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'};
           justify-content: center;
           align-items: \${'center'}
         \`
-      `;
+      `
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
+      })
+      expect(code).toMatchSnapshot()
+    })
 
-    test("::placeholder", () => {
+    test('::placeholder', () => {
       const basic = `
         const cls1 = css({
           '::placeholder': {
@@ -170,13 +170,13 @@ describe("babel css", () => {
             display: flex;
           }
         \`
-      `;
+      `
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
-    test(":fullscreen", () => {
+      })
+      expect(code).toMatchSnapshot()
+    })
+    test(':fullscreen', () => {
       const basic = `
       const cls1 = css({
         ':fullscreen': {
@@ -190,13 +190,13 @@ describe("babel css", () => {
           display: flex;
         }
       \`
-    `;
+    `
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
-    test("only composes", () => {
+      })
+      expect(code).toMatchSnapshot()
+    })
+    test('only composes', () => {
       const basic = `
         const cls1 = css\`
           display: flex;
@@ -204,14 +204,14 @@ describe("babel css", () => {
         const cls2 = css\`
           composes: \${'one-class'} \${'another-class'}\${cls1};
         \`
-      `;
+      `
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
+      })
+      expect(code).toMatchSnapshot()
+    })
 
-    test("only styles on nested selector", () => {
+    test('only styles on nested selector', () => {
       const basic = `
         const cls1 = css\`
           display: flex;
@@ -221,14 +221,14 @@ describe("babel css", () => {
             background: pink;
           }
         \`
-      `;
+      `
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
+      })
+      expect(code).toMatchSnapshot()
+    })
 
-    test("throws correct error when composes is not the first rule", () => {
+    test('throws correct error when composes is not the first rule', () => {
       const basic = `
         const cls1 = css\`
           display: flex;
@@ -238,14 +238,14 @@ describe("babel css", () => {
           composes: \${'one-class'} \${'another-class'}\${cls1};
           align-items: \${'center'}
         \`
-      `;
+      `
       expect(() =>
         babel.transform(basic, {
           plugins: [[plugin]]
         })
-      ).toThrowErrorMatchingSnapshot();
-    });
-    test("throws correct error when the value of composes is not an interpolation", () => {
+      ).toThrowErrorMatchingSnapshot()
+    })
+    test('throws correct error when the value of composes is not an interpolation', () => {
       const basic = `
         const cls1 = css\`
           display: flex;
@@ -255,14 +255,14 @@ describe("babel css", () => {
           justify-content: center;
           align-items: \${'center'}
         \`
-      `;
+      `
       expect(() =>
         babel.transform(basic, {
           plugins: [[plugin]]
         })
-      ).toThrowErrorMatchingSnapshot();
-    });
-    test("throws correct error when composes is on a nested selector", () => {
+      ).toThrowErrorMatchingSnapshot()
+    })
+    test('throws correct error when composes is on a nested selector', () => {
       const basic = `
         const cls1 = css\`
           display: flex;
@@ -274,14 +274,14 @@ describe("babel css", () => {
             composes: \${cls1};
           }
         \`
-      `;
+      `
       expect(() =>
         babel.transform(basic, {
           plugins: [[plugin]]
         })
-      ).toThrowErrorMatchingSnapshot();
-    });
-    test("object with a bunch of stuff", () => {
+      ).toThrowErrorMatchingSnapshot()
+    })
+    test('object with a bunch of stuff', () => {
       const basic = `
       const cls2 = css({
         float: 'left',
@@ -289,13 +289,13 @@ describe("babel css", () => {
         flex: 1,
         alignItems: \`\${'center'}\`
       })
-    `;
+    `
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
-    test("array of objects", () => {
+      })
+      expect(code).toMatchSnapshot()
+    })
+    test('array of objects', () => {
       const basic = `
       const cls2 = css([{
         display: 'flex',
@@ -304,15 +304,15 @@ describe("babel css", () => {
       }, {
         justifyContent: 'flex-start'
       }])
-    `;
+    `
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
-  });
-  describe("extract", () => {
-    test("css basic", () => {
+      })
+      expect(code).toMatchSnapshot()
+    })
+  })
+  describe('extract', () => {
+    test('css basic', () => {
       const basic = `
         css\`
         margin: 12px 48px;
@@ -320,18 +320,18 @@ describe("babel css", () => {
         display: flex;
         flex: 1 0 auto;
         color: blue;
-      \``;
+      \``
       const { code } = babel.transform(basic, {
         plugins: [[plugin, { extractStatic: true }]],
         filename: __filename,
         babelrc: false
-      });
-      expect(code).toMatchSnapshot();
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
-      expect(fs.writeFileSync.mock.calls[0][1]).toMatchSnapshot();
-    });
+      })
+      expect(code).toMatchSnapshot()
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(1)
+      expect(fs.writeFileSync.mock.calls[0][1]).toMatchSnapshot()
+    })
 
-    test("composes", () => {
+    test('composes', () => {
       const basic = `
         const cls1 = css\`
           display: flex;
@@ -341,17 +341,17 @@ describe("babel css", () => {
           justify-content: center;
           align-items: \${'center'}
         \`
-      `;
+      `
       const { code } = babel.transform(basic, {
         plugins: [[plugin, { extractStatic: true }]],
         filename: __filename,
         babelrc: false
-      });
-      expect(code).toMatchSnapshot();
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
-      expect(fs.writeFileSync.mock.calls[1][1]).toMatchSnapshot();
-    });
-    test("composes no dynamic", () => {
+      })
+      expect(code).toMatchSnapshot()
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(2)
+      expect(fs.writeFileSync.mock.calls[1][1]).toMatchSnapshot()
+    })
+    test('composes no dynamic', () => {
       const basic = `
         const cls1 = css\`
           display: flex;
@@ -361,42 +361,42 @@ describe("babel css", () => {
           justify-content: center;
           align-items: center
         \`
-      `;
+      `
       const { code } = babel.transform(basic, {
         plugins: [[plugin, { extractStatic: true }]],
         filename: __filename,
         babelrc: false
-      });
-      expect(code).toMatchSnapshot();
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(3);
-      expect(fs.writeFileSync.mock.calls[2][1]).toMatchSnapshot();
-    });
+      })
+      expect(code).toMatchSnapshot()
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(3)
+      expect(fs.writeFileSync.mock.calls[2][1]).toMatchSnapshot()
+    })
 
-    test("basic object support", () => {
-      const basic = `css({display: 'flex'})`;
+    test('basic object support', () => {
+      const basic = `css({display: 'flex'})`
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
+      })
+      expect(code).toMatchSnapshot()
+    })
 
-    test("renamed-import: basic object support", () => {
-      const basic = `cows({display: 'flex'})`;
+    test('renamed-import: basic object support', () => {
+      const basic = `cows({display: 'flex'})`
       const { code } = babel.transform(basic, {
-        plugins: [[plugin, { importedNames: { css: "cows" } }]]
-      });
-      expect(code).toMatchSnapshot();
-    });
+        plugins: [[plugin, { importedNames: { css: 'cows' } }]]
+      })
+      expect(code).toMatchSnapshot()
+    })
 
-    test("dynamically renamed-import: basic object support", () => {
-      const basic = `import { css as cows } from 'emotion'; cows({display: 'flex'})`;
+    test('dynamically renamed-import: basic object support', () => {
+      const basic = `import { css as cows } from 'emotion'; cows({display: 'flex'})`
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
+      })
+      expect(code).toMatchSnapshot()
+    })
 
-    test("prefixed objects", () => {
+    test('prefixed objects', () => {
       const basic = `
           css({
             borderRadius: '50%',
@@ -407,27 +407,27 @@ describe("babel css", () => {
                 transform: 'scale(1.2)'
             }
         })
-   `;
+   `
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
+      })
+      expect(code).toMatchSnapshot()
+    })
 
-    test("dynamic property objects", () => {
+    test('dynamic property objects', () => {
       const basic = `
         css({
           fontSize: 10,
           [\`w$\{'idth'}\`]: 20
         })
-       `;
+       `
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
+      })
+      expect(code).toMatchSnapshot()
+    })
 
-    test("prefixed array of objects", () => {
+    test('prefixed array of objects', () => {
       const basic = `
           css([{
             borderRadius: '50%',
@@ -439,14 +439,14 @@ describe("babel css", () => {
         }, {
           transition: 'transform 400ms ease-in-out',
         }])
-    `;
+    `
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      });
-      expect(code).toMatchSnapshot();
-    });
+      })
+      expect(code).toMatchSnapshot()
+    })
 
-    test("composes with objects", () => {
+    test('composes with objects', () => {
       const basic = `
         const cls1 = css({display: 'flex'})
         const cls2 = css\`
@@ -454,16 +454,16 @@ describe("babel css", () => {
           height: 20;
           justifyContent: center;
         \`
-      `;
+      `
       const { code } = babel.transform(basic, {
         plugins: [[plugin, { extractStatic: true }]],
         filename: __filename,
         babelrc: false
-      });
+      })
 
-      expect(code).toMatchSnapshot();
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(3);
-      expect(fs.writeFileSync.mock.calls[2][1]).toMatchSnapshot();
-    });
-  });
-});
+      expect(code).toMatchSnapshot()
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(3)
+      expect(fs.writeFileSync.mock.calls[2][1]).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/babel-plugin-emotion/test/css.test.js
+++ b/packages/babel-plugin-emotion/test/css.test.js
@@ -1,14 +1,14 @@
-import * as babel from 'babel-core'
-import plugin from 'babel-plugin-emotion'
-import * as fs from 'fs'
-jest.mock('fs')
+import * as babel from "babel-core";
+import plugin from "babel-plugin-emotion";
+import * as fs from "fs";
+jest.mock("fs");
 
-fs.existsSync.mockReturnValue(true)
-fs.statSync.mockReturnValue({ isFile: () => false })
+fs.existsSync.mockReturnValue(true);
+fs.statSync.mockReturnValue({ isFile: () => false });
 
-describe('babel css', () => {
-  describe('inline', () => {
-    test('css basic', () => {
+describe("babel css", () => {
+  describe("inline", () => {
+    test("css basic", () => {
       const basic = `
         css\`
         margin: 12px 48px;
@@ -20,14 +20,14 @@ describe('babel css', () => {
           line-height: 40px;
         }
         width: \${widthVar};
-      \``
+      \``;
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      })
-      expect(code).toMatchSnapshot()
-    })
+      });
+      expect(code).toMatchSnapshot();
+    });
 
-    test('css basic', () => {
+    test("css basic", () => {
       const basic = `
         cows\`
         margin: 12px 48px;
@@ -39,25 +39,45 @@ describe('babel css', () => {
           line-height: 40px;
         }
         width: \${widthVar};
-      \``
+      \``;
       const { code } = babel.transform(basic, {
-        plugins: [[plugin, { importedNames: { css: 'cows' } }]]
-      })
-      expect(code).toMatchSnapshot()
-    })
+        plugins: [[plugin, { importedNames: { css: "cows" } }]]
+      });
+      expect(code).toMatchSnapshot();
+    });
 
-    test('css with float property', () => {
+    test("css basic", () => {
+      const basic = `
+        import { css as cows } from 'emotion';
+        cows\`
+        margin: 12px 48px;
+        color: #ffffff;
+        display: flex;
+        flex: 1 0 auto;
+        color: blue;
+        @media(min-width: 420px) {
+          line-height: 40px;
+        }
+        width: \${widthVar};
+      \``;
+      const { code } = babel.transform(basic, {
+        plugins: [[plugin]]
+      });
+      expect(code).toMatchSnapshot();
+    });
+
+    test("css with float property", () => {
       const basic = `
         css\`
           float: left;
-      \``
+      \``;
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      })
-      expect(code).toMatchSnapshot()
-    })
+      });
+      expect(code).toMatchSnapshot();
+    });
 
-    test('css random expression', () => {
+    test("css random expression", () => {
       const basic = `css\`
         font-size: 20px;
         @media(min-width: 420px) {
@@ -68,28 +88,28 @@ describe('babel css', () => {
         background: green;
         \${{ backgroundColor: "hotpink" }};
       \`
-      `
+      `;
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      })
-      expect(code).toMatchSnapshot()
-    })
+      });
+      expect(code).toMatchSnapshot();
+    });
 
-    test('nested expanded properties', () => {
+    test("nested expanded properties", () => {
       const basic = `
         css\`
         margin: 12px 48px;
         & .div {
           display: 'flex';
         }
-      \``
+      \``;
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      })
-      expect(code).toMatchSnapshot()
-    })
+      });
+      expect(code).toMatchSnapshot();
+    });
 
-    test('interpolation in selector', () => {
+    test("interpolation in selector", () => {
       const basic = `
         const cls2 = css\`
         margin: 12px 48px;
@@ -98,14 +118,14 @@ describe('babel css', () => {
           display: none;
         }
         \`
-      `
+      `;
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      })
-      expect(code).toMatchSnapshot()
-    })
+      });
+      expect(code).toMatchSnapshot();
+    });
 
-    test('composes', () => {
+    test("composes", () => {
       const basic = `
         const cls1 = css\`
           display: flex;
@@ -115,28 +135,28 @@ describe('babel css', () => {
           justify-content: center;
           align-items: \${'center'}
         \`
-      `
+      `;
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      })
-      expect(code).toMatchSnapshot()
-    })
+      });
+      expect(code).toMatchSnapshot();
+    });
 
-    test('lots of composes', () => {
+    test("lots of composes", () => {
       const basic = `
         const cls2 = css\`
           composes: \${'one-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'} \${'another-class'};
           justify-content: center;
           align-items: \${'center'}
         \`
-      `
+      `;
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      })
-      expect(code).toMatchSnapshot()
-    })
+      });
+      expect(code).toMatchSnapshot();
+    });
 
-    test('::placeholder', () => {
+    test("::placeholder", () => {
       const basic = `
         const cls1 = css({
           '::placeholder': {
@@ -150,13 +170,13 @@ describe('babel css', () => {
             display: flex;
           }
         \`
-      `
+      `;
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      })
-      expect(code).toMatchSnapshot()
-    })
-    test(':fullscreen', () => {
+      });
+      expect(code).toMatchSnapshot();
+    });
+    test(":fullscreen", () => {
       const basic = `
       const cls1 = css({
         ':fullscreen': {
@@ -170,13 +190,13 @@ describe('babel css', () => {
           display: flex;
         }
       \`
-    `
+    `;
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      })
-      expect(code).toMatchSnapshot()
-    })
-    test('only composes', () => {
+      });
+      expect(code).toMatchSnapshot();
+    });
+    test("only composes", () => {
       const basic = `
         const cls1 = css\`
           display: flex;
@@ -184,14 +204,14 @@ describe('babel css', () => {
         const cls2 = css\`
           composes: \${'one-class'} \${'another-class'}\${cls1};
         \`
-      `
+      `;
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      })
-      expect(code).toMatchSnapshot()
-    })
+      });
+      expect(code).toMatchSnapshot();
+    });
 
-    test('only styles on nested selector', () => {
+    test("only styles on nested selector", () => {
       const basic = `
         const cls1 = css\`
           display: flex;
@@ -201,14 +221,14 @@ describe('babel css', () => {
             background: pink;
           }
         \`
-      `
+      `;
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      })
-      expect(code).toMatchSnapshot()
-    })
+      });
+      expect(code).toMatchSnapshot();
+    });
 
-    test('throws correct error when composes is not the first rule', () => {
+    test("throws correct error when composes is not the first rule", () => {
       const basic = `
         const cls1 = css\`
           display: flex;
@@ -218,14 +238,14 @@ describe('babel css', () => {
           composes: \${'one-class'} \${'another-class'}\${cls1};
           align-items: \${'center'}
         \`
-      `
+      `;
       expect(() =>
         babel.transform(basic, {
           plugins: [[plugin]]
         })
-      ).toThrowErrorMatchingSnapshot()
-    })
-    test('throws correct error when the value of composes is not an interpolation', () => {
+      ).toThrowErrorMatchingSnapshot();
+    });
+    test("throws correct error when the value of composes is not an interpolation", () => {
       const basic = `
         const cls1 = css\`
           display: flex;
@@ -235,14 +255,14 @@ describe('babel css', () => {
           justify-content: center;
           align-items: \${'center'}
         \`
-      `
+      `;
       expect(() =>
         babel.transform(basic, {
           plugins: [[plugin]]
         })
-      ).toThrowErrorMatchingSnapshot()
-    })
-    test('throws correct error when composes is on a nested selector', () => {
+      ).toThrowErrorMatchingSnapshot();
+    });
+    test("throws correct error when composes is on a nested selector", () => {
       const basic = `
         const cls1 = css\`
           display: flex;
@@ -254,14 +274,14 @@ describe('babel css', () => {
             composes: \${cls1};
           }
         \`
-      `
+      `;
       expect(() =>
         babel.transform(basic, {
           plugins: [[plugin]]
         })
-      ).toThrowErrorMatchingSnapshot()
-    })
-    test('object with a bunch of stuff', () => {
+      ).toThrowErrorMatchingSnapshot();
+    });
+    test("object with a bunch of stuff", () => {
       const basic = `
       const cls2 = css({
         float: 'left',
@@ -269,13 +289,13 @@ describe('babel css', () => {
         flex: 1,
         alignItems: \`\${'center'}\`
       })
-    `
+    `;
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      })
-      expect(code).toMatchSnapshot()
-    })
-    test('array of objects', () => {
+      });
+      expect(code).toMatchSnapshot();
+    });
+    test("array of objects", () => {
       const basic = `
       const cls2 = css([{
         display: 'flex',
@@ -284,15 +304,15 @@ describe('babel css', () => {
       }, {
         justifyContent: 'flex-start'
       }])
-    `
+    `;
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      })
-      expect(code).toMatchSnapshot()
-    })
-  })
-  describe('extract', () => {
-    test('css basic', () => {
+      });
+      expect(code).toMatchSnapshot();
+    });
+  });
+  describe("extract", () => {
+    test("css basic", () => {
       const basic = `
         css\`
         margin: 12px 48px;
@@ -300,18 +320,18 @@ describe('babel css', () => {
         display: flex;
         flex: 1 0 auto;
         color: blue;
-      \``
+      \``;
       const { code } = babel.transform(basic, {
         plugins: [[plugin, { extractStatic: true }]],
         filename: __filename,
         babelrc: false
-      })
-      expect(code).toMatchSnapshot()
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(1)
-      expect(fs.writeFileSync.mock.calls[0][1]).toMatchSnapshot()
-    })
+      });
+      expect(code).toMatchSnapshot();
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+      expect(fs.writeFileSync.mock.calls[0][1]).toMatchSnapshot();
+    });
 
-    test('composes', () => {
+    test("composes", () => {
       const basic = `
         const cls1 = css\`
           display: flex;
@@ -321,17 +341,17 @@ describe('babel css', () => {
           justify-content: center;
           align-items: \${'center'}
         \`
-      `
+      `;
       const { code } = babel.transform(basic, {
         plugins: [[plugin, { extractStatic: true }]],
         filename: __filename,
         babelrc: false
-      })
-      expect(code).toMatchSnapshot()
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(2)
-      expect(fs.writeFileSync.mock.calls[1][1]).toMatchSnapshot()
-    })
-    test('composes no dynamic', () => {
+      });
+      expect(code).toMatchSnapshot();
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
+      expect(fs.writeFileSync.mock.calls[1][1]).toMatchSnapshot();
+    });
+    test("composes no dynamic", () => {
       const basic = `
         const cls1 = css\`
           display: flex;
@@ -341,34 +361,42 @@ describe('babel css', () => {
           justify-content: center;
           align-items: center
         \`
-      `
+      `;
       const { code } = babel.transform(basic, {
         plugins: [[plugin, { extractStatic: true }]],
         filename: __filename,
         babelrc: false
-      })
-      expect(code).toMatchSnapshot()
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(3)
-      expect(fs.writeFileSync.mock.calls[2][1]).toMatchSnapshot()
-    })
+      });
+      expect(code).toMatchSnapshot();
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(3);
+      expect(fs.writeFileSync.mock.calls[2][1]).toMatchSnapshot();
+    });
 
-    test('basic object support', () => {
-      const basic = `css({display: 'flex'})`
+    test("basic object support", () => {
+      const basic = `css({display: 'flex'})`;
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      })
-      expect(code).toMatchSnapshot()
-    })
+      });
+      expect(code).toMatchSnapshot();
+    });
 
-    test('renamed-import: basic object support', () => {
-      const basic = `cows({display: 'flex'})`
+    test("renamed-import: basic object support", () => {
+      const basic = `cows({display: 'flex'})`;
       const { code } = babel.transform(basic, {
-        plugins: [[plugin, { importedNames: { css: 'cows' } }]]
-      })
-      expect(code).toMatchSnapshot()
-    })
+        plugins: [[plugin, { importedNames: { css: "cows" } }]]
+      });
+      expect(code).toMatchSnapshot();
+    });
 
-    test('prefixed objects', () => {
+    test("dynamically renamed-import: basic object support", () => {
+      const basic = `import { css as cows } from 'emotion'; cows({display: 'flex'})`;
+      const { code } = babel.transform(basic, {
+        plugins: [[plugin]]
+      });
+      expect(code).toMatchSnapshot();
+    });
+
+    test("prefixed objects", () => {
       const basic = `
           css({
             borderRadius: '50%',
@@ -379,27 +407,27 @@ describe('babel css', () => {
                 transform: 'scale(1.2)'
             }
         })
-   `
+   `;
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      })
-      expect(code).toMatchSnapshot()
-    })
+      });
+      expect(code).toMatchSnapshot();
+    });
 
-    test('dynamic property objects', () => {
+    test("dynamic property objects", () => {
       const basic = `
         css({
           fontSize: 10,
           [\`w$\{'idth'}\`]: 20
         })
-       `
+       `;
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      })
-      expect(code).toMatchSnapshot()
-    })
+      });
+      expect(code).toMatchSnapshot();
+    });
 
-    test('prefixed array of objects', () => {
+    test("prefixed array of objects", () => {
       const basic = `
           css([{
             borderRadius: '50%',
@@ -411,14 +439,14 @@ describe('babel css', () => {
         }, {
           transition: 'transform 400ms ease-in-out',
         }])
-    `
+    `;
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
-      })
-      expect(code).toMatchSnapshot()
-    })
+      });
+      expect(code).toMatchSnapshot();
+    });
 
-    test('composes with objects', () => {
+    test("composes with objects", () => {
       const basic = `
         const cls1 = css({display: 'flex'})
         const cls2 = css\`
@@ -426,16 +454,16 @@ describe('babel css', () => {
           height: 20;
           justifyContent: center;
         \`
-      `
+      `;
       const { code } = babel.transform(basic, {
         plugins: [[plugin, { extractStatic: true }]],
         filename: __filename,
         babelrc: false
-      })
+      });
 
-      expect(code).toMatchSnapshot()
-      expect(fs.writeFileSync).toHaveBeenCalledTimes(3)
-      expect(fs.writeFileSync.mock.calls[2][1]).toMatchSnapshot()
-    })
-  })
-})
+      expect(code).toMatchSnapshot();
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(3);
+      expect(fs.writeFileSync.mock.calls[2][1]).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/babel-plugin-emotion/test/css.test.js
+++ b/packages/babel-plugin-emotion/test/css.test.js
@@ -27,6 +27,25 @@ describe('babel css', () => {
       expect(code).toMatchSnapshot()
     })
 
+    test('css basic', () => {
+      const basic = `
+        cows\`
+        margin: 12px 48px;
+        color: #ffffff;
+        display: flex;
+        flex: 1 0 auto;
+        color: blue;
+        @media(min-width: 420px) {
+          line-height: 40px;
+        }
+        width: \${widthVar};
+      \``
+      const { code } = babel.transform(basic, {
+        plugins: [[plugin, { importedNames: { css: 'cows' } }]]
+      })
+      expect(code).toMatchSnapshot()
+    })
+
     test('css with float property', () => {
       const basic = `
         css\`
@@ -47,7 +66,7 @@ describe('babel css', () => {
           line-height: 26px;
         }
         background: green;
-        \${{ backgroundColor: "hotpink" }};        
+        \${{ backgroundColor: "hotpink" }};
       \`
       `
       const { code } = babel.transform(basic, {
@@ -337,6 +356,14 @@ describe('babel css', () => {
       const basic = `css({display: 'flex'})`
       const { code } = babel.transform(basic, {
         plugins: [[plugin]]
+      })
+      expect(code).toMatchSnapshot()
+    })
+
+    test('renamed-import: basic object support', () => {
+      const basic = `cows({display: 'flex'})`
+      const { code } = babel.transform(basic, {
+        plugins: [[plugin, { importedNames: { css: 'cows' } }]]
       })
       expect(code).toMatchSnapshot()
     })

--- a/packages/babel-plugin-emotion/test/styled.test.js
+++ b/packages/babel-plugin-emotion/test/styled.test.js
@@ -370,7 +370,7 @@ describe('babel styled component', () => {
     test('config rename', () => {
       const basic = 'what.h1`color:blue;`'
       const { code } = babel.transform(basic, {
-        plugins: [[plugin, { importedNames: { default: 'what' } }]],
+        plugins: [[plugin, { importedNames: { styled: 'what' } }]],
         babelrc: false,
         filename: __filename
       })

--- a/packages/babel-plugin-emotion/test/styled.test.js
+++ b/packages/babel-plugin-emotion/test/styled.test.js
@@ -355,3 +355,17 @@ describe('babel styled component', () => {
     })
   })
 })
+
+describe('babel styled component', () => {
+  describe('renamed import: inline', () => {
+    test('variable import: no dynamic', () => {
+      const basic = "import what from 'emotion'; what.h1`color:blue;`"
+      const { code } = babel.transform(basic, {
+        plugins: [plugin],
+        babelrc: false,
+        filename: __filename
+      })
+      expect(code).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/babel-plugin-emotion/test/styled.test.js
+++ b/packages/babel-plugin-emotion/test/styled.test.js
@@ -367,5 +367,14 @@ describe('babel styled component', () => {
       })
       expect(code).toMatchSnapshot()
     })
+    test('config rename', () => {
+      const basic = 'what.h1`color:blue;`'
+      const { code } = babel.transform(basic, {
+        plugins: [[plugin, { importedNames: { default: 'what' } }]],
+        babelrc: false,
+        filename: __filename
+      })
+      expect(code).toMatchSnapshot()
+    })
   })
 })


### PR DESCRIPTION
~~Built on top of lint-fix changes (#289) -- [compare between these two branches](https://github.com/ChristopherBiscardi/emotion/compare/lint-fix...ChristopherBiscardi:configurable-imports?expand=1)~~

**What**:

Solves #267 by implementing a solution that will use the default import name instead of sticking only to `styled`.

in short, this works:

```js
import lol from 'emotion';

lol`color: blue`;
```

**Why**: See #267 

**How**: 

Modified the visitor to also visit ImportDeclarations. Then cache the values of any `import whatever from 'emotion'` in an object for later use when looking for `styled` calls.

**Checklist**:

These need work. This is just a POC. There definitely needs to be more tests.

- [x] Documentation
- [x] Tests
- [x] Code complete

