### PR TITLE
Fix flowtype errors in babel-plugin-emotion

### DIFF
--- a/packages/babel-plugin-emotion/src/index.js
+++ b/packages/babel-plugin-emotion/src/index.js
@@ -113,12 +113,12 @@ const getFileHash = state => {
     moduleRoot && relative(moduleRoot, filename).replace(pathSep, '/')
   let moduleName = ''
   if (moduleRoot) {
-    const packageJsonString = fs.readFileSync(
+    const packageJsonContent = fs.readFileSync(
       pathJoin(moduleRoot, 'package.json')
     )
-    if (packageJsonString) {
+    if (packageJsonContent) {
       try {
-        moduleName = JSON.parse(packageJsonString).name
+        moduleName = JSON.parse(packageJsonContent.toString()).name
       } catch (e) {}
     }
   }

--- a/packages/babel-plugin-emotion/src/parser.js
+++ b/packages/babel-plugin-emotion/src/parser.js
@@ -94,7 +94,7 @@ export function expandCSSFallbacks(style: { [string]: any }) {
 }
 
 // Parser
-export function parse(css, opts) {
+export function parse(css: string, opts: Object) {
   let input = new Input(css, opts)
 
   let parser = new EmotionParser(input)


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

I received this errors using Flow version 0.54.0:

```
Error: packages/babel-plugin-emotion/src/index.js:121
121:         moduleName = JSON.parse(packageJsonContent).name
                                     ^^^^^^^^^^^^^^^^^^ Buffer. This type is incompatible with the expected param type of
485:     static parse(text: string, reviver?: (key: any, value: any) => any): any;
                            ^^^^^^ string. See lib: /tmp/flow/flowlib_2d62ca57/core.js:485

Error: packages/babel-plugin-emotion/src/parser.js:97
 97: export function parse(css, opts) {
                           ^^^ parameter `css`. Missing annotation

Error: packages/babel-plugin-emotion/src/parser.js:97
 97: export function parse(css, opts) {
                                ^^^^ parameter `opts`. Missing annotation
```

**Why**:

If we use Flow, we must not ignore this error reports.

**How**:

The type of the variable is explicitly converted to string. Function parse in parser.js is annotated.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Code complete

<!-- feel free to add additional comments -->