### PR TITLE
Add module name mapping for emotion-utils to .flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -5,3 +5,4 @@
 [libs]
 
 [options]
+module.name_mapper='^\(emotion-utils\)$' -> '<PROJECT_ROOT>/packages/\1/src'


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

I received this error:

```
Error: packages/emotion/src/index.js:13
 13: } from 'emotion-utils'
            ^^^^^^^^^^^^^^^ emotion-utils. Required module not found
```

<!-- Why are these changes necessary? -->
**Why**:

Fix error.

<!-- How were these changes implemented? -->
**How**:

Add module name mapping

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
