### PR TITLE
Allow to set custom type for Element

### DIFF
--- a/packages/react-emotion/src/index.js
+++ b/packages/react-emotion/src/index.js
@@ -30,10 +30,6 @@ export default function(tag, cls, objs, vars = [], content) {
     tag.__emotion_spec !== undefined ? tag.__emotion_spec.concat(spec) : [spec]
   const localTag = newSpec[0].tag
 
-  const omitFn =
-    typeof localTag === 'string'
-      ? testOmitPropsOnStringTag
-      : testOmitPropsOnComponent
   function Styled(props, context) {
     const getValue = v => {
       if (v && typeof v === 'function') {
@@ -70,8 +66,13 @@ export default function(tag, cls, objs, vars = [], content) {
 
     const className = css(map(finalObjs, getValue))
 
+    const omitFn =
+      typeof localTag === 'string'
+        ? testOmitPropsOnStringTag
+        : testOmitPropsOnComponent
+
     return h(
-      localTag,
+      props.as || localTag,
       omit(
         assign({}, props, {
           ref: props.innerRef,

--- a/packages/react-emotion/test/__snapshots__/index.test.js.snap
+++ b/packages/react-emotion/test/__snapshots__/index.test.js.snap
@@ -293,6 +293,44 @@ exports[`styled composition 1`] = `
 </h1>
 `;
 
+exports[`styled custom component 1`] = `
+.glamor-2 {
+  color: green;
+}
+
+<span
+  className="glamor-0 glamor-1 glamor-2"
+  onClick={[Function]}
+>
+  emotion.sh
+</span>
+`;
+
+exports[`styled custom html tag 1`] = `
+.glamor-1 {
+  color: green;
+}
+
+<a
+  className="glamor-0 glamor-1"
+  href="https://emotion.sh"
+>
+  emotion.sh
+</a>
+`;
+
+exports[`styled fallback to localTag is as prop is falsy 1`] = `
+.glamor-1 {
+  color: green;
+}
+
+<button
+  className="glamor-0 glamor-1"
+>
+  emotion.sh
+</button>
+`;
+
 exports[`styled function in expression 1`] = `
 .glamor-2 {
   font-size: 40px;

--- a/packages/react-emotion/test/index.test.js
+++ b/packages/react-emotion/test/index.test.js
@@ -618,4 +618,41 @@ describe('styled', () => {
       () => styled(undefined)`display: flex;`
     ).toThrowErrorMatchingSnapshot()
   })
+
+  test('custom html tag', () => {
+    const Button = styled('button')`color: green;`
+
+    const tree = renderer
+      .create(
+        <Button as="a" href="https://emotion.sh">
+          emotion.sh
+        </Button>
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('custom component', () => {
+    const Button = styled('button')`color: green;`
+    const CustomComponent = styled('span')`color: red;`
+
+    const tree = renderer
+      .create(
+        <Button as={CustomComponent} onClick={() => {}}>
+          emotion.sh
+        </Button>
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('fallback to localTag is as prop is falsy', () => {
+    const Button = styled('button')`color: green;`
+
+    const tree = renderer.create(<Button as={null}>emotion.sh</Button>).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
**What**: feature

<!-- Why are these changes necessary? -->
**Why**: Right now there is no way to change tag / Component for styled component. For example with bootstrap you can use `btn` class for `button`, `a`, `span` etc. Lets say I have:

```js
const Text = styled('span')`/* styles */`;
```

Now in order to style `<p>` tag I have to move styles definition into separated variable and create new `styled('p')` or create completely new component. 

But lets talk about `flex-box` :) Some time ago I've created [just-box](https://github.com/RafalFilipek/just-box). You can find there `Box` component with `as` prop. This property allows you to render any element with magic flex-box styles. For example:

```js
<Box f1 column /> // <div>
<Box as="p" flexInline alignCenter /> // <p>
<Box as={Header} f2 /> // <Header />
<Box as="button" justifyEnd /> // <button>
```

<!-- How were these changes implemented? -->
**How**:  This PR simply adds `as` prop. if *falsy* value is provided `localTag` is used.

<!-- Have you done all of these things?  -->
**Checklist**:
- [ ] Documentation
- [x] Tests
- [x] Code complete

Thank you!
