### PR TITLE
Use babel-plugin-codegen to generate props regex

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,7 +11,7 @@
     "react",
     "flow"
   ],
-  "plugins": ["babel-plugin-preval"],
+  "plugins": ["codegen"],
   "env": {
     "test": {
       "presets": [
@@ -26,7 +26,7 @@
         "react",
         "stage-2"
       ],
-      "plugins": ["./babel-plugin-emotion-test", "preval"]    
+      "plugins": ["./babel-plugin-emotion-test", "codegen"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-eslint": "^7.2.3",
     "babel-jest": "^20.0.3",
     "babel-macros": "^1.0.2",
-    "babel-plugin-preval": "^1.4.2",
+    "babel-plugin-codegen": "^1.2.0",
     "babel-preset-env": "^1.5.1",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",

--- a/packages/babel-plugin-emotion/test/macro/.babelrc
+++ b/packages/babel-plugin-emotion/test/macro/.babelrc
@@ -11,5 +11,5 @@
     "react",
     "flow"
   ],
-  "plugins": ["preval", "./babel-macros-register"]
+  "plugins": ["codegen", "./babel-macros-register"]
 }

--- a/packages/emotion/test/extract/.babelrc
+++ b/packages/emotion/test/extract/.babelrc
@@ -4,5 +4,5 @@
     "env",
     "react"
   ],
-  "plugins": [["../../../../babel-plugin-emotion-test", {"extractStatic": true}], "babel-plugin-preval"]
+  "plugins": [["../../../../babel-plugin-emotion-test", {"extractStatic": true}], "codegen"]
 }

--- a/packages/react-emotion/src/index.js
+++ b/packages/react-emotion/src/index.js
@@ -1,3 +1,4 @@
+/* global codegen */
 import { createElement as h } from 'react'
 import { css } from 'emotion'
 import { map, reduce, assign, omit } from 'emotion-utils'

--- a/packages/react-emotion/src/index.js
+++ b/packages/react-emotion/src/index.js
@@ -1,13 +1,12 @@
 import { createElement as h } from 'react'
 import { css } from 'emotion'
 import { map, reduce, assign, omit } from 'emotion-utils'
-import propsRegexString from /* preval */ './props'
 
 export * from 'emotion'
 
 const push = (obj, items) => Array.prototype.push.apply(obj, items)
 
-const reactPropsRegex = new RegExp(propsRegexString)
+const reactPropsRegex = codegen.require('./props')
 const testOmitPropsOnStringTag = key => reactPropsRegex.test(key)
 const testOmitPropsOnComponent = key => key !== 'theme' && key !== 'innerRef'
 

--- a/packages/react-emotion/src/props.js
+++ b/packages/react-emotion/src/props.js
@@ -194,6 +194,6 @@ const props = {
   unselectable: true
 }
 
-module.exports = `^((${Object.keys(props).join(
+module.exports = `/^((${Object.keys(props).join(
   '|'
-)})|(on[A-Z].*)|((data|aria)-.*))$`
+)})|(on[A-Z].*)|((data|aria)-.*))$/`

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,7 +28,7 @@ const config = {
         'react',
         'flow'
       ],
-      plugins: ['babel-plugin-preval'],
+      plugins: ['codegen'],
       babelrc: false
     })
   ],


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Use `babel-plugin-codegen` to generate the props filter regex instead of `babel-plugin-preval`.

<!-- Why are these changes necessary? -->
**Why**:

So that a regex literal is used instead of a string and then `new RegExp()`

<!-- How were these changes implemented? -->
**How**:

Use `codegen.require` and change preval to codegen in all the babel configs

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete

<!-- feel free to add additional comments -->
