### PR TITLE
Docs: use a more decent alternative to 'cows'

### DIFF
--- a/docs/configurable-imports.md
+++ b/docs/configurable-imports.md
@@ -7,9 +7,9 @@ import renaming.
 ## Dynamic
 
 ```js
-import something, { css as ecss } from 'react-emotion';
+import something, { css as emotion } from 'react-emotion';
 
-const classes = ecss`
+const classes = emotion`
   color: red;
 `
 
@@ -27,14 +27,14 @@ a prop other than `css` for processing.
 ```js
 {
   "plugins": [
-    ["emotion", { "importedNames": { "css": "ecss" }}]
+    ["emotion", { "importedNames": { "css": "emotion" }}]
   ]
 }
 ```
 
 Beware that if you use the babel configuration, you must import as the
 same name. In the previous example, we would have to `import { css as
-ecss } from 'emotion';` then use `ecss` to construct the template
+emotion } from 'emotion';` then use `emotion` to construct the template
 literals. 
 
 # Use Case
@@ -86,17 +86,17 @@ By adding the babel opt config rename as such.
 {
   "plugins": [
     "styled-jsx/babel",
-    ["emotion", { "importedNames": { "css": "ecss" }}]
+    ["emotion", { "importedNames": { "css": "emotion" }}]
   ]
 }
 ```
 
-We can avoid re-compiling the `css` props and instead use `ecss` for
+We can avoid re-compiling the `css` props and instead use `emotion` for
 our template literals, etc.
 
 ```js
 import _JSXStyle from "styled-jsx/style";
-import styled, { css as ecss } from "react-emotion";
+import styled, { css as emotion } from "react-emotion";
 
 export default (() => <div data-jsx={2648947580}>
     <p data-jsx={2648947580}>only this paragraph will get the style :)</p>

--- a/docs/configurable-imports.md
+++ b/docs/configurable-imports.md
@@ -7,9 +7,9 @@ import renaming.
 ## Dynamic
 
 ```js
-import something, { css as cows } from 'react-emotion';
+import something, { css as ecss } from 'react-emotion';
 
-const classes = cows`
+const classes = ecss`
   color: red;
 `
 
@@ -27,14 +27,14 @@ a prop other than `css` for processing.
 ```js
 {
   "plugins": [
-    ["emotion", { "importedNames": { "css": 'cows' }}]
+    ["emotion", { "importedNames": { "css": "ecss" }}]
   ]
 }
 ```
 
 Beware that if you use the babel configuration, you must import as the
 same name. In the previous example, we would have to `import { css as
-cows } from 'emotion';` then use `cows` to construct the template
+ecss } from 'emotion';` then use `ecss` to construct the template
 literals. 
 
 # Use Case
@@ -86,17 +86,17 @@ By adding the babel opt config rename as such.
 {
   "plugins": [
     "styled-jsx/babel",
-    ["emotion", { "importedNames": { "css": 'cows' }}]
+    ["emotion", { "importedNames": { "css": "ecss" }}]
   ]
 }
 ```
 
-We can avoid re-compiling the `css` props and instead use `cows` for
+We can avoid re-compiling the `css` props and instead use `ecss` for
 our template literals, etc.
 
 ```js
 import _JSXStyle from "styled-jsx/style";
-import styled, { css as cows } from "react-emotion";
+import styled, { css as ecss } from "react-emotion";
 
 export default (() => <div data-jsx={2648947580}>
     <p data-jsx={2648947580}>only this paragraph will get the style :)</p>


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

- This changes the example `cows` to a more-likely-to-be-used `ecss`.

<!-- Why are these changes necessary? -->
**Why**:

- The alias `cows` is arbitrary, but people are likely to copy-paste this code from documentation. This gives them a less silly name to start with.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests - N/A
- [x] Code complete - N/A

<!-- feel free to add additional comments -->
