### PR TITLE
Move emotion to peerDependencies

### DIFF
--- a/packages/babel-plugin-emotion/package.json
+++ b/packages/babel-plugin-emotion/package.json
@@ -14,13 +14,9 @@
     "clean": "rimraf lib"
   },
   "dependencies": {
-    "autoprefixer": "^7.1.2",
     "babel-macros": "^1.0.2",
     "babel-plugin-syntax-jsx": "^6.18.0",
     "emotion-utils": "^8.0.2-2",
-    "postcss": "^6.0.9",
-    "postcss-js": "^1.0.0",
-    "postcss-nested": "^2.1.1",
     "touch": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/emotion-server/package.json
+++ b/packages/emotion-server/package.json
@@ -14,8 +14,10 @@
     "clean": "rimraf lib"
   },
   "dependencies": {
-    "emotion": "^8.0.2-2",
     "emotion-utils": "^8.0.2-2"
+  },
+  "peerDependencies": {
+    "emotion": "^8.0.2-2"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/emotion-utils/package.json
+++ b/packages/emotion-utils/package.json
@@ -14,9 +14,6 @@
     "watch": "rollup -c ../../rollup.config.js --watch",
     "rollup": "rollup -c ../../rollup.config.js"
   },
-  "dependencies": {
-    "fbjs": "^0.8.12"
-  },
   "author": "Kye Hohenberger",
   "homepage": "https://github.com/tkh44/emotion#readme",
   "license": "MIT",

--- a/packages/emotion/babel.js
+++ b/packages/emotion/babel.js
@@ -1,1 +1,0 @@
-module.exports = require('babel-plugin-emotion')

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -20,10 +20,8 @@
     "rollup:umd": "UMD=true rollup -c ../../rollup.config.js"
   },
   "dependencies": {
+    "babel-plugin-emotion": "^8.0.2-2",
     "emotion-utils": "^8.0.2-2"
-  },
-  "peerDependencies": {
-    "babel-plugin-emotion": "^8.0.2-2"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -20,10 +20,10 @@
     "rollup:umd": "UMD=true rollup -c ../../rollup.config.js"
   },
   "dependencies": {
-    "babel-plugin-emotion": "^8.0.2-2",
-    "emotion-server": "^8.0.2-2",
-    "emotion-utils": "^8.0.2-2",
-    "react-emotion": "^8.0.2-2"
+    "emotion-utils": "^8.0.2-2"
+  },
+  "peerDependencies": {
+    "babel-plugin-emotion": "^8.0.2-2"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/packages/emotion/react/index.js
+++ b/packages/emotion/react/index.js
@@ -1,1 +1,0 @@
-module.exports = require('react-emotion')

--- a/packages/emotion/react/macro.js
+++ b/packages/emotion/react/macro.js
@@ -1,1 +1,0 @@
-module.exports = require('react-emotion/macro')

--- a/packages/emotion/server.js
+++ b/packages/emotion/server.js
@@ -1,1 +1,0 @@
-module.exports = require('emotion-server')

--- a/packages/preact-emotion/package.json
+++ b/packages/preact-emotion/package.json
@@ -15,10 +15,10 @@
     "rollup": "rollup -c ../../rollup.config.js"
   },
   "dependencies": {
+    "babel-plugin-emotion": "^8.0.2-2",    
     "emotion-utils": "^8.0.2-2"
   },
   "peerDependencies": {
-    "babel-plugin-emotion": "^8.0.2-2",
     "emotion": "^8.0.2-2"
   },
   "devDependencies": {

--- a/packages/preact-emotion/package.json
+++ b/packages/preact-emotion/package.json
@@ -15,9 +15,11 @@
     "rollup": "rollup -c ../../rollup.config.js"
   },
   "dependencies": {
-    "babel-plugin-emotion": "^8.0.2-2",
-    "emotion": "^8.0.2-2",
     "emotion-utils": "^8.0.2-2"
+  },
+  "peerDependencies": {
+    "babel-plugin-emotion": "^8.0.2-2",
+    "emotion": "^8.0.2-2"
   },
   "devDependencies": {
     "npm-run-all": "^4.0.2",

--- a/packages/react-emotion/package.json
+++ b/packages/react-emotion/package.json
@@ -17,9 +17,11 @@
     "rollup:umd": "UMD=true rollup -c ../../rollup.config.js"
   },
   "dependencies": {
-    "babel-plugin-emotion": "^8.0.2-2",
-    "emotion": "^8.0.2-2",
+    "babel-plugin-emotion": "^8.0.2-2",    
     "emotion-utils": "^8.0.2-2"
+  },
+  "peerDependencies": {
+    "emotion": "^8.0.2-2"
   },
   "devDependencies": {
     "npm-run-all": "^4.0.2",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Move `emotion` and `babel-plugin-emotion` to peerDependencies where they're used in other packages.

This also remove the aliases like `emotion/react`. `emotion/macro` and `react-emotion/macro` are still the entry points for the macros though.

`emotion-utils` is still a direct dependency.

<!-- Why are these changes necessary? -->
**Why**:
it should solve #295.

Right now, `emotion` is a dependency of `emotion-server` and others so depending on the way package managers and bundlers do things `emotion-server` may import `emotion` from it's own node_modules so it won't have the styles in it's version of emotion.

The same is also true for composition, for example using `styled` from `react-emotion` and `css` from `emotion` and `react-emotion` will use `emotion` from it's node_modules so the styles won't be in the caches.

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete

<!-- feel free to add additional comments -->
