### PR TITLE
Fix multiple nested selectors in media queries

### DIFF
--- a/packages/emotion/src/index.js
+++ b/packages/emotion/src/index.js
@@ -20,48 +20,42 @@ export function flush() {
   sheet.inject()
 }
 
-let rule = ''
-let isRootSelector = false
 let queue = []
 
 const insertRule = sheet.insert.bind(sheet)
 
-function insertionPlugin(context, content, selectors, parent) {
+function insertionPlugin(
+  context,
+  content,
+  selectors,
+  parent,
+  line,
+  column,
+  length,
+  id
+) {
   switch (context) {
     case -2: {
-      if (rule !== '') {
-        if (isRootSelector === true) {
-          queue.push(rule)
-        } else {
-          queue.unshift(rule)
-        }
-        rule = ''
-      }
-
       queue.forEach(insertRule)
       queue = []
       break
     }
 
     case 2: {
-      if (rule !== '') {
-        if (isRootSelector === true) {
+      const joinedSelectors = selectors.join(',')
+      const rule = `${joinedSelectors}{${content}}`
+      if (id === 0) {
+        if (parent.join(',') === joinedSelectors || parent[0] === '') {
           queue.push(rule)
         } else {
           queue.unshift(rule)
         }
       }
-
-      const joinedSelectors = selectors.join(',')
-
-      isRootSelector = parent.join(',') === joinedSelectors || parent[0] === ''
-      rule = `${joinedSelectors}{${content}}`
       break
     }
     // after an at rule block
-    case 3: // eslint-disable-line no-fallthrough
+    case 3:
       queue.push(`${selectors.join(',')}{${content}}`)
-      rule = ''
   }
 }
 

--- a/packages/emotion/src/index.js
+++ b/packages/emotion/src/index.js
@@ -42,9 +42,9 @@ function insertionPlugin(
     }
 
     case 2: {
-      const joinedSelectors = selectors.join(',')
-      const rule = `${joinedSelectors}{${content}}`
       if (id === 0) {
+        const joinedSelectors = selectors.join(',')
+        const rule = `${joinedSelectors}{${content}}`
         if (parent.join(',') === joinedSelectors || parent[0] === '') {
           queue.push(rule)
         } else {

--- a/packages/emotion/test/__snapshots__/css.test.js.snap
+++ b/packages/emotion/test/__snapshots__/css.test.js.snap
@@ -239,17 +239,17 @@ exports[`css handles objects 1`] = `
 `;
 
 exports[`css media query specificity 1`] = `
-"@media (min-width:420px) {
+".css-mfslnr {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+}
+
+@media (min-width:420px) {
   .css-mfslnr {
     width: 96px;
     height: 96px;
   }
-}
-
-.css-mfslnr {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
 }"
 `;
 

--- a/packages/emotion/test/__snapshots__/selectivity.test.js.snap
+++ b/packages/emotion/test/__snapshots__/selectivity.test.js.snap
@@ -1,94 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`css complex nested media queries 1`] = `
-@media (max-width:600px) {
-  .glamor-0 h1 {
+"@media (max-width:600px) {
+  .css-acogag h1 {
     font-size: 1.4rem;
   }
 }
 
 @media (max-width:400px),(max-height:420px) {
-  .glamor-0 h1 {
+  .css-acogag h1 {
     font-size: 1.1rem;
   }
-}
-
-<div
-  className="glamor-0"
-/>
+}"
 `;
 
 exports[`css complex nested styles 1`] = `
-.glamor-0 {
-  color: blue;
-}
-
-.glamor-0:hover {
-  color: green;
-}
-
-.glamor-0:hover .name {
-  color: amethyst;
-}
-
-.glamor-0:hover .name:focus {
-  color: burlywood;
-}
-
-@media (min-width:420px) {
-  .glamor-0:hover .name:focus {
-    color: rebeccapurple;
-  }
-}
-
-<div
-  className="glamor-0"
-/>
-`;
-
-exports[`css handles media query merges 1`] = `
-.glamor-0 {
-  color: darkslateblue;
-  color: red;
-  color: purple;
-}
-
-@media (min-width:420px) {
-  .glamor-0 {
-    color: amethyst;
-  }
-}
-
-@media (min-width:640px) {
-  .glamor-0 {
-    color: rebeccapurple;
-  }
-}
-
-@media (min-width:960px) {
-  .glamor-0 {
-    color: burlywood;
-  }
-}
-
-@media (min-width:640px) {
-  .glamor-0 {
-    color: blue;
-  }
-}
-
-@media (min-width:640px) {
-  .glamor-0 {
-    color: aquamarine;
-  }
-}
-
-<div
-  className="glamor-0"
-/>
-`;
-
-exports[`css selectivity sheet 1`] = `
 ".css-s7aswl {
   color: blue;
 }
@@ -109,21 +35,11 @@ exports[`css selectivity sheet 1`] = `
   .css-s7aswl:hover .name:focus {
     color: rebeccapurple;
   }
-}
+}"
+`;
 
-@media (max-width:600px) {
-  .css-acogag h1 {
-    font-size: 1.4rem;
-  }
-}
-
-@media (max-width:400px),(max-height:420px) {
-  .css-acogag h1 {
-    font-size: 1.1rem;
-  }
-}
-
-.css-yno01n {
+exports[`css handles media query merges 1`] = `
+".css-yno01n {
   color: darkslateblue;
   color: red;
   color: purple;
@@ -156,6 +72,86 @@ exports[`css selectivity sheet 1`] = `
 @media (min-width:640px) {
   .css-yno01n {
     color: aquamarine;
+  }
+}"
+`;
+
+exports[`css media queries with multiple nested selectors 1`] = `
+".css-17riori {
+  color: blue;
+}
+
+@media (max-width:400px) {
+  .css-17riori {
+    color: green;
+  }
+
+  .css-17riori h1 {
+    color: red;
+  }
+
+  .css-17riori span {
+    color: red;
+  }
+}"
+`;
+
+exports[`css media queries with nested selectors 1`] = `
+".css-17riori {
+  color: blue;
+}
+
+@media (max-width:400px) {
+  .css-17riori {
+    color: green;
+  }
+
+  .css-17riori h1 {
+    color: red;
+  }
+
+  .css-17riori span {
+    color: red;
+  }
+}"
+`;
+
+exports[`css media query with nested selector with nested selector on root 1`] = `
+".css-1ssiu3j span {
+  color: blue;
+}
+
+@media (max-width:400px) {
+  .css-1ssiu3j {
+    color: green;
+  }
+
+  .css-1ssiu3j span {
+    color: red;
+  }
+}"
+`;
+
+exports[`css media query with nested selector without declarations on root 1`] = `
+"@media (max-width:400px) {
+  .css-18muius {
+    color: green;
+  }
+
+  .css-18muius span {
+    color: red;
+  }
+}"
+`;
+
+exports[`css nested media query without declarations on root 1`] = `
+"@media (max-width:400px) {
+  .css-18muius {
+    color: green;
+  }
+
+  .css-18muius span {
+    color: red;
   }
 }"
 `;

--- a/packages/emotion/test/__snapshots__/selectivity.test.js.snap
+++ b/packages/emotion/test/__snapshots__/selectivity.test.js.snap
@@ -96,26 +96,6 @@ exports[`css media queries with multiple nested selectors 1`] = `
 }"
 `;
 
-exports[`css media queries with nested selectors 1`] = `
-".css-17riori {
-  color: blue;
-}
-
-@media (max-width:400px) {
-  .css-17riori {
-    color: green;
-  }
-
-  .css-17riori h1 {
-    color: red;
-  }
-
-  .css-17riori span {
-    color: red;
-  }
-}"
-`;
-
 exports[`css media query with nested selector with nested selector on root 1`] = `
 ".css-1ssiu3j span {
   color: blue;
@@ -133,18 +113,6 @@ exports[`css media query with nested selector with nested selector on root 1`] =
 `;
 
 exports[`css media query with nested selector without declarations on root 1`] = `
-"@media (max-width:400px) {
-  .css-18muius {
-    color: green;
-  }
-
-  .css-18muius span {
-    color: red;
-  }
-}"
-`;
-
-exports[`css nested media query without declarations on root 1`] = `
 "@media (max-width:400px) {
   .css-18muius {
     color: green;

--- a/packages/emotion/test/css.test.js
+++ b/packages/emotion/test/css.test.js
@@ -263,7 +263,7 @@ describe('css', () => {
     const tree2 = renderer.create(<div className={cls1} />).toJSON()
     expect(tree2).toMatchSnapshot()
   })
-  test.skip('media query specificity', () => {
+  test('media query specificity', () => {
     flush()
     const cls = css`
       width: 32px;

--- a/packages/emotion/test/selectivity.test.js
+++ b/packages/emotion/test/selectivity.test.js
@@ -1,8 +1,7 @@
-import React from 'react'
-import renderer from 'react-test-renderer'
-import { css, sheet } from 'emotion'
+import { css, sheet, flush } from 'emotion'
 
 describe('css', () => {
+  afterEach(() => flush())
   test('complex nested styles', () => {
     const mq = [
       '@media(min-width: 420px)',
@@ -10,7 +9,7 @@ describe('css', () => {
       '@media(min-width: 960px)'
     ]
 
-    const cls1 = css({
+    css({
       color: 'blue',
       '&:hover': {
         '& .name': {
@@ -25,12 +24,11 @@ describe('css', () => {
         color: 'green'
       }
     })
-    const tree = renderer.create(<div className={cls1} />).toJSON()
-    expect(tree).toMatchSnapshot()
+    expect(sheet).toMatchSnapshot()
   })
 
   test('complex nested media queries', () => {
-    const cls1 = css`
+    css`
       @media (max-width: 600px) {
         h1 {
           font-size: 1.4rem;
@@ -44,8 +42,7 @@ describe('css', () => {
       }
     `
 
-    const tree = renderer.create(<div className={cls1} />).toJSON()
-    expect(tree).toMatchSnapshot()
+    expect(sheet).toMatchSnapshot()
   })
 
   test('handles media query merges', () => {
@@ -68,8 +65,7 @@ describe('css', () => {
         }
       }
     ]
-
-    const cls1 = css([
+    css([
       {
         color: 'darkslateblue',
         [mq[0]]: {
@@ -84,11 +80,48 @@ describe('css', () => {
       },
       buttonCSS
     ])
-    const tree = renderer.create(<div className={cls1} />).toJSON()
-    expect(tree).toMatchSnapshot()
+    expect(sheet).toMatchSnapshot()
   })
+  test('media queries with multiple nested selectors', () => {
+    css`
+      color: blue;
 
-  test('selectivity sheet', () => {
+      @media (max-width: 400px) {
+        color: green;
+        h1 {
+          color: red;
+        }
+        span {
+          color: red;
+        }
+      }
+    `
+
+    expect(sheet).toMatchSnapshot()
+  })
+  test('media query with nested selector without declarations on root', () => {
+    css`
+      @media (max-width: 400px) {
+        color: green;
+        span {
+          color: red;
+        }
+      }
+    `
+    expect(sheet).toMatchSnapshot()
+  })
+  test('media query with nested selector with nested selector on root', () => {
+    css`
+      span {
+        color: blue;
+      }
+      @media (max-width: 400px) {
+        color: green;
+        span {
+          color: red;
+        }
+      }
+    `
     expect(sheet).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Fix multiple nested selectors in media queries

<!-- Why are these changes necessary? -->
**Why**:

Closes #323 

<!-- How were these changes implemented? -->
**How**:

The last argument to stylis plugins is an id which is 0 in context 2 if the style is not in a media query.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->

@apostolos I checked this with your test cases(Thanks so much!!!) and it works for all of them except `ExampleP1` where the whole thing is black. From what I can see this is correct since there is no `color: blue` in `ExampleP1`. If you disagree please reopen the issue.
