### PR TITLE
Move babel-plugin-emotion to devDependencies

### DIFF
--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -20,11 +20,11 @@
     "rollup:umd": "UMD=true rollup -c ../../rollup.config.js"
   },
   "dependencies": {
-    "babel-plugin-emotion": "^8.0.2-6",
     "emotion-utils": "^8.0.2-3"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
+    "babel-plugin-emotion": "^8.0.2-6",
     "npm-run-all": "^4.0.2",
     "rimraf": "^2.6.1",
     "rollup": "^0.43.0"


### PR DESCRIPTION
**What**:

Dependencies

**Why**:

`babel-plugin-emotion` is opt-in. Shouldnt be downloaded by each `emotion` consumer.

**How**:

Made a `package.json` tweak.

**Checklist**:
- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Code complete N/A

