### PR TITLE
Document CSS prop incompatibility with babel-plugin-transform-react-inline-elements

### DIFF
--- a/docs/css-prop.md
+++ b/docs/css-prop.md
@@ -24,3 +24,7 @@ function SomeComponent (props) {
 }
 
 ```
+
+**Notes:**
+- This feature requires the `"emotion"` babel plugin.
+- CSS props are not compatible with babel's `"transform-react-inline-elements"` plugin. If you include it in your `.babelrc`, no transformation will take place and your styles will silently fail.


### PR DESCRIPTION
**What**:
transform-react-inline-elements breaks CSS prop.

> The plugin order is complicated because babel plugins don’t run one after the other, they run at the same time, so you have a JSXElement (babel-plugin-transform-react-inline-elements does it’s stuff here) and a JSXOpeningElement (where the css prop stuff runs), the JSXElement will be visited and the plugins that visit that node will run in the order they’re specified in the babel config and if the JSXElement is replaced there the JSXOpeningElement never gets visited.

**Why**:
This behavior should be documented. `babel-plugin-transform-react-inline-elements` is usually only included in production, therefore it's highly likely that someone might use CSS prop in development thinking it is working fine. But as soon as they compile the project for production styles will silently fail.

**Checklist**:
- [x] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A
