### PR TITLE
Make the theme prop always exist

### DIFF
--- a/packages/react-emotion/src/index.js
+++ b/packages/react-emotion/src/index.js
@@ -78,12 +78,9 @@ const createStyled = (tag, options: { e: string }) => {
     class Styled extends Component {
       render() {
         const { props, state } = this
-        this.mergedProps = props
-        if (state !== null && state.theme) {
-          this.mergedProps = omitAssign(testAlwaysTrue, {}, props, {
-            theme: state.theme || {}
-          })
-        }
+        this.mergedProps = omitAssign(testAlwaysTrue, {}, props, {
+          theme: (state !== null && state.theme) || props.theme || {}
+        })
 
         let className = ''
         let classInterpolations = []

--- a/packages/react-emotion/test/__snapshots__/index.test.js.snap
+++ b/packages/react-emotion/test/__snapshots__/index.test.js.snap
@@ -647,6 +647,28 @@ exports[`styled random object expression 1`] = `
 </h1>
 `;
 
+exports[`styled theme prop exists without ThemeProvider 1`] = `
+.glamor-0 {
+  color: green;
+  background-color: yellow;
+}
+
+<div
+  className="glamor-0"
+/>
+`;
+
+exports[`styled theme prop exists without ThemeProvider with a theme prop on the component 1`] = `
+.glamor-0 {
+  color: hotpink;
+  background-color: yellow;
+}
+
+<div
+  className="glamor-0"
+/>
+`;
+
 exports[`styled themes 1`] = `
 .glamor-0 {
   background-color: #ffd43b;

--- a/packages/react-emotion/test/index.test.js
+++ b/packages/react-emotion/test/index.test.js
@@ -682,4 +682,22 @@ describe('styled', () => {
     const tree = renderer.create(<SomeComponent color="hotpink" />).toJSON()
     expect(tree).toMatchSnapshot()
   })
+  test('theme prop exists without ThemeProvider', () => {
+    const SomeComponent = styled.div`
+      color: ${props => props.theme.color || 'green'};
+      background-color: yellow;
+    `
+    const tree = renderer.create(<SomeComponent />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+  test('theme prop exists without ThemeProvider with a theme prop on the component', () => {
+    const SomeComponent = styled.div`
+      color: ${props => props.theme.color || 'green'};
+      background-color: yellow;
+    `
+    const tree = renderer
+      .create(<SomeComponent theme={{ color: 'hotpink' }} />)
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Make the theme prop always exist

<!-- Why are these changes necessary? -->
**Why**:

Because otherwise when people are trying to use props.theme.something and there isn't a ThemeProvider they'll get cannot read property of undefined.

<!-- How were these changes implemented? -->
**How**:

Always do an assign for the theme prop.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
