### PR TITLE
Clarify Babel plugin usage in install docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -18,12 +18,12 @@ npm install --save emotion react-emotion babel-plugin-emotion
 
 **Notes:**
 - Make sure `"emotion"` is the first plugin.
-- If you are using Babel's env option in your `.babelrc` file ensure that emotion is first in every environment's list of plugins.
+- If you are using Babel's env option in your `.babelrc` file, ensure that emotion is first in every environment's list of plugins.
   ```json
   {
     "env": {
       "production": {
-        "plugins": ["emotion", "transform-react-constant-elements"]
+        "plugins": ["emotion", "some-other-plugin"]
       }
     },
     "plugins": ["emotion"]


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Update install docs with regards to the Babel plugin to remove any confusion surrounding `transform-react-constant-elements` being related to emotion.

<!-- Why are these changes necessary? -->
**Why**:

People new to emotion and CSS-in-JS in general may not know if `transform-react-constant-elements` is related to emotion and whether or not it's required to use emotion's Babel plugin.

<!-- How were these changes implemented? -->
**How**:

Remove reference to `transform-react-constant-elements` by substituting a fictitious plugin to show it is only there to illustrate order.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A

<!-- feel free to add additional comments -->
