### PR TITLE
Fix a typo in docs on composition

### DIFF
--- a/docs/composition.md
+++ b/docs/composition.md
@@ -36,11 +36,11 @@ const ColumnCenteredComponent = styled.div`
 `
 
 // Composition can be very powerful. For example, styles are expanded where you interpolate,
-// so the following class has flex-direction: column because ${flexCenter} is interpolated
+// so the following class has flex-direction: column because ${flexCenterClass} is interpolated
 // after flex-direction: row
 const stillColumn = css`
   flex-direction: row;
-  ${flexCenter}
+  ${flexCenterClass}
 `
 
 // Nested composing is supported


### PR DESCRIPTION
The actual `flex-direction: column;` property is declared in `flexCenterClass` const and not in `flexCenter`.

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

<!-- Why are these changes necessary? -->
**Why**:
Fix typo in docs.

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Code complete

<!-- feel free to add additional comments -->
