### PR TITLE
Typescript typings: Added emotion-theming typings and fixed react-emotion typings

### DIFF
--- a/packages/emotion-theming/package.json
+++ b/packages/emotion-theming/package.json
@@ -4,12 +4,15 @@
   "description": "A CSS-in-JS theming solution, inspired by styled-components",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
+  "types": "typings/emotion-theming.d.ts",
   "files": [
     "src",
     "dist"
   ],
   "scripts": {
     "build": "npm-run-all clean rollup rollup:umd",
+    "test:typescript": "tsc --noEmit -p typescript_tests/tsconfig.json",
+    "pretest:typescript": "npm run build",
     "clean": "rimraf dist",
     "rollup": "rollup -c ../../rollup.config.js",
     "watch": "rollup -c ../../rollup.config.js --watch",
@@ -34,10 +37,12 @@
   },
   "homepage": "https://github.com/emotion-js/emotion#readme",
   "devDependencies": {
+    "@types/react": "^16.0.14",
     "cross-env": "^5.0.1",
     "prop-types": "^15.5.8",
     "rimraf": "^2.6.1",
-    "rollup": "^0.43.0"
+    "rollup": "^0.43.0",
+    "typescript": "^2.5.3"
   },
   "dependencies": {
     "hoist-non-react-statics": "^2.3.1"

--- a/packages/emotion-theming/typescript_tests/tsconfig.json
+++ b/packages/emotion-theming/typescript_tests/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "es2015",
+    "declaration": true,
+    "strict": true,
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node",
+    "jsx": "react"
+  },
+  "include": [
+    "./*.ts",
+    "./*.tsx"
+  ]
+}

--- a/packages/emotion-theming/typescript_tests/typescript_tests.tsx
+++ b/packages/emotion-theming/typescript_tests/typescript_tests.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import * as emotionTheming from '../';
+import { ThemeProvider, withTheme, EmotionThemingModule } from '../';
+
+const theme = { primary: "green", secondary: "white" };
+const CompSFC = (props: { prop: boolean }) => <div />;
+declare class CompC extends React.Component<{ prop: boolean }> { }
+
+/**
+ * Theme Provider with no type
+ */
+<ThemeProvider theme={theme} />; 
+<ThemeProvider theme={() => theme} />;
+
+/**
+ * withTheme with no type
+ */
+const ThemedSFC = withTheme(CompSFC);
+<ThemedSFC theme={theme} prop />;
+<ThemedSFC prop />;
+
+const ThemedComp = withTheme(CompC);
+<ThemedComp theme={theme} prop />;
+<ThemedComp prop />
+
+const { ThemeProvider: TypedThemeProvider, withTheme: typedWithTheme } = emotionTheming as EmotionThemingModule<typeof theme>;
+
+<TypedThemeProvider theme={theme} />;
+<TypedThemeProvider theme={{ primary: "white" }} />;
+<TypedThemeProvider theme={theme => ({ primary: theme.primary, secondary: theme.secondary })} />;
+
+const TypedThemedSFC = typedWithTheme(ThemedSFC);
+<TypedThemedSFC prop />;
+<TypedThemedSFC theme={theme} prop/>
+
+const TypedCompSFC = typedWithTheme(CompSFC);
+<TypedCompSFC prop />;
+<TypedCompSFC theme={theme} prop />;

--- a/packages/emotion-theming/typings/emotion-theming.d.ts
+++ b/packages/emotion-theming/typings/emotion-theming.d.ts
@@ -1,0 +1,20 @@
+import { ComponentClass, SFC } from "react";
+
+export type OptionalThemeProps<Props, Theme> = Props & { theme?: Theme };
+
+export interface ThemeProviderProps<Theme> {
+    theme: Partial<Theme> | { (theme: Theme): Theme };
+}
+
+export type ThemeProviderComponent<Theme> = ComponentClass<ThemeProviderProps<Theme>>;
+export const ThemeProvider: ThemeProviderComponent<object>;
+
+/**
+ * Inject theme into component
+ */
+export function withTheme<Props, Theme = {}>(component: ComponentClass<Props> | SFC<Props>): ComponentClass<OptionalThemeProps<Props, Theme>>;
+
+export interface EmotionThemingModule<Theme> {
+    ThemeProvider: ThemeProviderComponent<Theme>;
+    withTheme<Props>(component: ComponentClass<Props> | SFC<Props>): ComponentClass<OptionalThemeProps<Props, Theme>>;
+}

--- a/packages/react-emotion/typings/react-emotion.d.ts
+++ b/packages/react-emotion/typings/react-emotion.d.ts
@@ -89,7 +89,7 @@ type ShorthandsFactories<Theme> = {
 export interface ThemedReactEmotionInterface<Theme> extends ShorthandsFactories<Theme> {
   // overload for dom tag
   <Props, Tag extends keyof JSX.IntrinsicElements>(
-    tag: Tag | Component<Props>,
+    tag: Tag,
     options?: Options,
   ): CreateStyled<Props, Theme, JSX.IntrinsicElements[Tag]>
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: First commit in PR fixes the problem with union type in TS typings, seconds commit adds TS typings for ```emotion-theming``` package

<!-- Why are these changes necessary? -->
**Why**:
* emotion-theming doesn't have TS typings
* There is a problem with union type ```Tag | Component<Props>``` in ```react-emotion``` typings: The second overload won't be taken into account when passing ```styled(MyComp)``` and thus ```MyComp``` will infer all Intrinsic properties from all tags. This is wrong and slows down the TS service. First commit in PR fixes this.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
