### PR TITLE
Fix component type in TS typings

### DIFF
--- a/packages/react-emotion/typescript_tests/typescript_tests.tsx
+++ b/packages/react-emotion/typescript_tests/typescript_tests.tsx
@@ -66,6 +66,8 @@ const SFCComponent: React.StatelessComponent<SFCComponentProps> = props => (
   <div className={props.className}>{props.children} {props.foo}</div>
 );
 
+declare class MyClassC extends React.Component<CustomProps2> { };
+
 // infer SFCComponentProps
 Component = styled(SFCComponent)({ color: 'red' });
 mount = <Component foo="bar" />;
@@ -73,6 +75,9 @@ mount = <Component foo="bar" />;
 // infer SFCComponentProps
 Component = styled(SFCComponent)`color: red`;
 mount = <Component foo="bar" />;
+
+Component = styled(MyClassC) ``;
+mount = <Component customProp="abc" />;
 
 // do not infer SFCComponentProps with pass CustomProps, need to pass both
 Component = styled<CustomProps2 & SFCComponentProps>(SFCComponent)({ 

--- a/packages/react-emotion/typings/react-emotion.d.ts
+++ b/packages/react-emotion/typings/react-emotion.d.ts
@@ -1,4 +1,4 @@
-import { StatelessComponent, Component as ClassComponent, CSSProperties } from 'react'
+import { StatelessComponent, ComponentClass, CSSProperties } from 'react'
 import { Interpolation as EmotionInterpolation } from 'emotion'
 
 export * from 'emotion'
@@ -21,7 +21,7 @@ export interface Options {
 }
 
 type Component<Props> =
-  | ClassComponent<Props>
+  | ComponentClass<Props>
   | StatelessComponent<Props>
 
 export type ThemedProps<Props, Theme> = Props & {
@@ -30,7 +30,7 @@ export type ThemedProps<Props, Theme> = Props & {
 
 export interface StyledComponent<Props, Theme, IntrinsicProps>
   extends
-    ClassComponent<Props & IntrinsicProps>,
+    ComponentClass<Props & IntrinsicProps>,
     StatelessComponent<Props & IntrinsicProps>
 {
   withComponent<Tag extends keyof JSX.IntrinsicElements>(tag: Tag):


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: TS typings update

<!-- Why are these changes necessary? -->
**Why**:
Prior the fix, this gives an error:
```tsx
declare class C extends React.Component<Props> {}
const Styled = styled(C);
``` 

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
