### PR TITLE
Switched to using dtslint from just running tsc --noEmit for typescript tests

### DIFF
--- a/packages/emotion-theming/package.json
+++ b/packages/emotion-theming/package.json
@@ -4,15 +4,14 @@
   "description": "A CSS-in-JS theming solution, inspired by styled-components",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
-  "types": "typings/emotion-theming.d.ts",
+  "types": "types/index.d.ts",
   "files": [
     "src",
     "dist"
   ],
   "scripts": {
     "build": "npm-run-all clean rollup rollup:umd",
-    "test:typescript": "tsc --noEmit -p typescript_tests/tsconfig.json",
-    "pretest:typescript": "npm run build",
+    "test:typescript": "dtslint types",
     "clean": "rimraf dist",
     "rollup": "rollup -c ../../rollup.config.js",
     "watch": "rollup -c ../../rollup.config.js --watch",
@@ -39,10 +38,10 @@
   "devDependencies": {
     "@types/react": "16.0.16",
     "cross-env": "^5.0.1",
+    "dtslint": "^0.2.0",
     "prop-types": "^15.5.8",
     "rimraf": "^2.6.1",
-    "rollup": "^0.43.0",
-    "typescript": "^2.5.3"
+    "rollup": "^0.43.0"
   },
   "dependencies": {
     "hoist-non-react-statics": "^2.3.1"

--- a/packages/emotion-theming/types/index.d.ts
+++ b/packages/emotion-theming/types/index.d.ts
@@ -1,9 +1,10 @@
+// TypeScript Version: 2.3
 import { ComponentClass, SFC } from "react";
 
 export type OptionalThemeProps<Props, Theme> = Props & { theme?: Theme };
 
 export interface ThemeProviderProps<Theme> {
-    theme: Partial<Theme> | { (theme: Theme): Theme };
+    theme: Partial<Theme> | ((theme: Theme) => Theme);
 }
 
 export type ThemeProviderComponent<Theme> = ComponentClass<ThemeProviderProps<Theme>>;
@@ -12,6 +13,7 @@ export const ThemeProvider: ThemeProviderComponent<object>;
 /**
  * Inject theme into component
  */
+// tslint:disable-next-line:no-unnecessary-generics
 export function withTheme<Props, Theme = {}>(component: ComponentClass<Props> | SFC<Props>): ComponentClass<OptionalThemeProps<Props, Theme>>;
 
 export interface EmotionThemingModule<Theme> {

--- a/packages/emotion-theming/types/tests.tsx
+++ b/packages/emotion-theming/types/tests.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import * as emotionTheming from '../';
+// tslint:disable-next-line:no-duplicate-imports
 import { ThemeProvider, withTheme, EmotionThemingModule } from '../';
 
 const theme = { primary: "green", secondary: "white" };
@@ -9,7 +10,7 @@ declare class CompC extends React.Component<{ prop: boolean }> { }
 /**
  * Theme Provider with no type
  */
-<ThemeProvider theme={theme} />; 
+<ThemeProvider theme={theme} />;
 <ThemeProvider theme={() => theme} />;
 
 /**
@@ -21,7 +22,7 @@ const ThemedSFC = withTheme(CompSFC);
 
 const ThemedComp = withTheme(CompC);
 <ThemedComp theme={theme} prop />;
-<ThemedComp prop />
+<ThemedComp prop />;
 
 const { ThemeProvider: TypedThemeProvider, withTheme: typedWithTheme } = emotionTheming as EmotionThemingModule<typeof theme>;
 
@@ -31,7 +32,7 @@ const { ThemeProvider: TypedThemeProvider, withTheme: typedWithTheme } = emotion
 
 const TypedThemedSFC = typedWithTheme(ThemedSFC);
 <TypedThemedSFC prop />;
-<TypedThemedSFC theme={theme} prop/>
+<TypedThemedSFC theme={theme} prop/>;
 
 const TypedCompSFC = typedWithTheme(CompSFC);
 <TypedCompSFC prop />;

--- a/packages/emotion-theming/types/tsconfig.json
+++ b/packages/emotion-theming/types/tsconfig.json
@@ -6,7 +6,12 @@
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
-    "jsx": "react"
+    "jsx": "react",
+    "lib": ["es6"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true
   },
   "include": [
     "./*.ts",

--- a/packages/emotion-theming/types/tslint.json
+++ b/packages/emotion-theming/types/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dtslint.json",
+    "rules": {
+        "no-relative-import-in-test": false
+    }
+}

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -4,7 +4,7 @@
   "description": "The Next Generation of CSS-in-JS.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
-  "types": "typings/emotion.d.ts",
+  "types": "types/index.d.ts",
   "files": [
     "src",
     "dist",
@@ -16,8 +16,7 @@
   ],
   "scripts": {
     "build": "npm-run-all clean rollup rollup:umd",
-    "test:typescript": "tsc --noEmit -p typescript_tests/tsconfig.json",
-    "pretest:typescript": "npm run build",
+    "test:typescript": "dtslint types",
     "clean": "rimraf dist",
     "rollup": "rollup -c ../../rollup.config.js",
     "watch": "rollup -c ../../rollup.config.js --watch",
@@ -34,10 +33,10 @@
     "babel-cli": "^6.24.1",
     "babel-plugin-transform-define": "^1.3.0",
     "cross-env": "^5.0.5",
+    "dtslint": "^0.2.0",
     "npm-run-all": "^4.0.2",
     "rimraf": "^2.6.1",
-    "rollup": "^0.43.0",
-    "typescript": "^2.0.0"
+    "rollup": "^0.43.0"
   },
   "author": "Kye Hohenberger",
   "homepage": "https://emotion.sh",

--- a/packages/emotion/types/index.d.ts
+++ b/packages/emotion/types/index.d.ts
@@ -1,19 +1,16 @@
-export type Interpolation = string | number | boolean | null | undefined | _Interpolation1 | _Interpolation2 | _Interpolation3;
+// TypeScript Version: 2.2
+export type Interpolation = string | number | boolean | null | undefined | _Interpolation1 | _Interpolation2 | (() => Interpolation);
 
 // HACK: See https://github.com/Microsoft/TypeScript/issues/3496#issuecomment-128553540
-interface _Interpolation1 extends Record<string, Interpolation> {}
-interface _Interpolation2 extends Array<Interpolation> {}
-interface _Interpolation3 {
-  (): Interpolation;
-}
+export interface _Interpolation1 extends Record<string, Interpolation> {}
+export interface _Interpolation2 extends Array<Interpolation> {}
 
 export type CreateStyles<TRet> = ((...values: Interpolation[]) => TRet)
   & ((strings: TemplateStringsArray, ...vars: Interpolation[]) => TRet);
 
-export interface StylisUse {
-  // TODO: Make this more precise than just Function
-  (plugin: Function | Function[] | null): StylisUse;
-}
+// TODO: Make this more precise than just Function
+// tslint:disable-next-line:ban-types
+export type StylisUse = (plugin: Function | Function[] | null) => StylisUse;
 
 export interface StyleSheet {
   inject(): void;

--- a/packages/emotion/types/tests.tsx
+++ b/packages/emotion/types/tests.tsx
@@ -8,6 +8,7 @@ import {
   hydrate,
   cx
 } from '../';
+// tslint:disable-next-line:no-implicit-dependencies
 import React from 'react';
 
 sheet.speedy(true);
@@ -50,7 +51,7 @@ css([
     { position: false },
     { width: 100 }
   ]
-])
+]);
 
 css(
   { display: 'none' },

--- a/packages/emotion/types/tsconfig.json
+++ b/packages/emotion/types/tsconfig.json
@@ -5,7 +5,12 @@
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
-    "jsx": "react"
+    "jsx": "react",
+    "lib": ["es6"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true
   },
   "include": [
     "./*.ts",

--- a/packages/emotion/types/tslint.json
+++ b/packages/emotion/types/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dtslint.json",
+    "rules": {
+        "no-relative-import-in-test": false
+    }
+}

--- a/packages/react-emotion/package.json
+++ b/packages/react-emotion/package.json
@@ -4,7 +4,7 @@
   "description": "The Next Generation of CSS-in-JS, for React projects.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
-  "types": "typings/react-emotion.d.ts",
+  "types": "types/index.d.ts",
   "files": [
     "src",
     "dist",
@@ -13,8 +13,7 @@
   ],
   "scripts": {
     "build": "npm-run-all clean rollup rollup:umd",
-    "test:typescript": "tsc --noEmit -p typescript_tests/tsconfig.json",
-    "pretest:typescript": "npm run build",
+    "test:typescript": "dtslint types",
     "clean": "rimraf dist",
     "rollup": "rollup -c ../../rollup.config.js",
     "watch": "rollup -c ../../rollup.config.js --watch",
@@ -30,11 +29,11 @@
   "devDependencies": {
     "@types/react": "16.0.16",
     "cross-env": "^5.0.5",
+    "dtslint": "^0.2.0",
     "emotion": "^8.0.9",
     "npm-run-all": "^4.0.2",
     "rimraf": "^2.6.1",
-    "rollup": "^0.43.0",
-    "typescript": "^2.0.0"
+    "rollup": "^0.43.0"
   },
   "author": "Kye Hohenberger",
   "homepage": "https://github.com/tkh44/emotion#readme",

--- a/packages/react-emotion/types/index.d.ts
+++ b/packages/react-emotion/types/index.d.ts
@@ -1,73 +1,74 @@
-import { StatelessComponent, ComponentClass, CSSProperties } from 'react'
-import { Interpolation as EmotionInterpolation } from 'emotion'
+// TypeScript Version: 2.3
+// tslint:disable-next-line:no-implicit-dependencies
+import { StatelessComponent, ComponentClass, CSSProperties } from 'react';
+import { Interpolation as EmotionInterpolation } from 'emotion';
 
-export * from 'emotion'
+export * from 'emotion';
 
 export type InterpolationFn<Props = {}> =
   (props: Props) =>
     | EmotionInterpolation
-    | InterpolationFn<Props>
+    | InterpolationFn<Props>;
 
 export type InterpolationTypes<Props = {}> =
   | InterpolationFn<Props>
-  | EmotionInterpolation
+  | EmotionInterpolation;
 
 export type Interpolation<Props = {}> =
   | InterpolationTypes<Props>
-  | InterpolationTypes<Props>[]
+  | Array<InterpolationTypes<Props>>;
 
 export interface Options {
-  string?: string,
+  string?: string;
 }
 
 type Component<Props> =
   | ComponentClass<Props>
-  | StatelessComponent<Props>
+  | StatelessComponent<Props>;
 
 export type ThemedProps<Props, Theme> = Props & {
   theme: Theme,
-}
+};
 
 type ElementProps<Tag extends keyof JSX.IntrinsicElements> =
   & JSX.IntrinsicElements[Tag]
-  & { innerRef?: JSX.IntrinsicElements[Tag]['ref'] }
+  & { innerRef?: JSX.IntrinsicElements[Tag]['ref'] };
 
 export interface StyledComponent<Props, Theme, IntrinsicProps>
   extends
     ComponentClass<Props & IntrinsicProps>,
-    StatelessComponent<Props & IntrinsicProps>
-{
+    StatelessComponent<Props & IntrinsicProps> {
   withComponent<Tag extends keyof JSX.IntrinsicElements>(tag: Tag):
-    StyledComponent<Props, Theme, ElementProps<Tag>>
+    StyledComponent<Props, Theme, ElementProps<Tag>>;
 
   withComponent(component: Component<Props>):
-    StyledComponent<Props, Theme, {}>
+    StyledComponent<Props, Theme, {}>;
 
-  displayName: string
+  displayName: string;
 
-  __emotion_styles: string[]
-  __emotion_base: string | Component<Props & IntrinsicProps>
-  __emotion_real: ThemedReactEmotionInterface<Theme>
+  __emotion_styles: string[];
+  __emotion_base: string | Component<Props & IntrinsicProps>;
+  __emotion_real: ThemedReactEmotionInterface<Theme>;
 }
 
 export type ObjectStyleAttributes =
   | CSSProperties
-  | { [key: string]: ObjectStyleAttributes }
+  | { [key: string]: ObjectStyleAttributes };
 
 export interface CreateStyled<Props, Theme, IntrinsicProps> {
   // overload for template string as styles
   (
     strings: TemplateStringsArray,
-    ...vars: Interpolation<ThemedProps<Props & IntrinsicProps, Theme>>[],
-  ): StyledComponent<Props, Theme, IntrinsicProps>
+    ...vars: Array<Interpolation<ThemedProps<Props & IntrinsicProps, Theme>>>,
+  ): StyledComponent<Props, Theme, IntrinsicProps>;
 
   // overload for object as styles
   (
-    ...styles: (
+    ...styles: Array<
       | ObjectStyleAttributes
       | ((props: ThemedProps<Props & IntrinsicProps, Theme>) => ObjectStyleAttributes)
-    )[]
-  ): StyledComponent<Props, Theme, IntrinsicProps>
+    >
+  ): StyledComponent<Props, Theme, IntrinsicProps>;
 }
 
 // TODO: find a way to reuse CreateStyled here
@@ -77,15 +78,15 @@ type ShorthandsFactories<Theme> = {
     // overload for template string as styles
     <Props = {}>(
       strings: TemplateStringsArray,
-      ...vars: Interpolation<ThemedProps<Props & JSX.IntrinsicElements[Tag], Theme>>[],
+      ...vars: Array<Interpolation<ThemedProps<Props & JSX.IntrinsicElements[Tag], Theme>>>,
     ): StyledComponent<Props, Theme, ElementProps<Tag>>
-  
+
     // overload for object as styles
     <Props = {}>(
-      ...styles: (
+      ...styles: Array<
         | ObjectStyleAttributes
         | ((props: ThemedProps<Props & JSX.IntrinsicElements[Tag], Theme>) => ObjectStyleAttributes)
-      )[]
+      >
     ): StyledComponent<Props, Theme, ElementProps<Tag>>
   };
 };
@@ -95,20 +96,19 @@ export interface ThemedReactEmotionInterface<Theme> extends ShorthandsFactories<
   <Props, Tag extends keyof JSX.IntrinsicElements>(
     tag: Tag,
     options?: Options,
-  ): CreateStyled<Props, Theme, ElementProps<Tag>>
+    // tslint:disable-next-line:no-unnecessary-generics
+  ): CreateStyled<Props, Theme, ElementProps<Tag>>;
 
   // overload for component
   <Props>(
     component: Component<Props>,
     options?: Options,
-  ): CreateStyled<Props, Theme, {}>
+  ): CreateStyled<Props, Theme, {}>;
 }
 
 export interface ThemedReactEmotionModule<Theme> {
-  default: ThemedReactEmotionInterface<Theme>
+  default: ThemedReactEmotionInterface<Theme>;
 }
 
-declare const styled: ThemedReactEmotionInterface<any>
-export default styled
-
-
+declare const styled: ThemedReactEmotionInterface<any>;
+export default styled;

--- a/packages/react-emotion/types/index.d.ts
+++ b/packages/react-emotion/types/index.d.ts
@@ -100,10 +100,11 @@ export interface ThemedReactEmotionInterface<Theme> extends ShorthandsFactories<
   ): CreateStyled<Props, Theme, ElementProps<Tag>>;
 
   // overload for component
-  <Props>(
+  <Props, CustomProps>(
     component: Component<Props>,
     options?: Options,
-  ): CreateStyled<Props, Theme, {}>;
+    // tslint:disable-next-line:no-unnecessary-generics
+  ): CreateStyled<Props & CustomProps, Theme, {}>;
 }
 
 export interface ThemedReactEmotionModule<Theme> {

--- a/packages/react-emotion/types/tests.tsx
+++ b/packages/react-emotion/types/tests.tsx
@@ -81,7 +81,7 @@ Component = styled(MyClassC) ``;
 mount = <Component customProp="abc" />;
 
 // do not infer SFCComponentProps with pass CustomProps, need to pass both
-Component = styled<CustomProps2 & SFCComponentProps>(SFCComponent)({
+Component = styled<SFCComponentProps, CustomProps2>(SFCComponent)({
   color: 'red',
 }, props => ({
   background: props.customProp,
@@ -89,7 +89,7 @@ Component = styled<CustomProps2 & SFCComponentProps>(SFCComponent)({
 mount = <Component customProp="red" foo="bar" />;
 
 // do not infer SFCComponentProps with pass CustomProps, need to pass both
-Component = styled<CustomProps2 & SFCComponentProps>(SFCComponent)`
+Component = styled<SFCComponentProps, CustomProps2>(SFCComponent)`
   color: red;
   background: ${props => props.customProp};
 `;

--- a/packages/react-emotion/types/tests.tsx
+++ b/packages/react-emotion/types/tests.tsx
@@ -1,3 +1,4 @@
+// tslint:disable-next-line:no-implicit-dependencies
 import React from 'react';
 import styled, { flush, ThemedReactEmotionInterface } from '../';
 
@@ -28,7 +29,7 @@ mount = <Component href="#" />;
 /*
  * Passing custom props
  */
-type CustomProps = { lookColor: string };
+interface CustomProps { lookColor: string; }
 
 Component = styled.div<CustomProps>(
   { color: 'blue' },
@@ -53,20 +54,20 @@ const anotherColor = 'blue';
 Component = styled<CustomProps, 'div'>('div')`
   background: ${props => props.lookColor};
   color: ${anotherColor};
-`
+`;
 mount = <Component lookColor="red" />;
 
 /*
  * With other components
  */
-type CustomProps2 = { customProp: string };
-type SFCComponentProps = { className?: string, foo: string };
+interface CustomProps2 { customProp: string; }
+interface SFCComponentProps { className?: string; foo: string; }
 
 const SFCComponent: React.StatelessComponent<SFCComponentProps> = props => (
   <div className={props.className}>{props.children} {props.foo}</div>
 );
 
-declare class MyClassC extends React.Component<CustomProps2> { };
+declare class MyClassC extends React.Component<CustomProps2> { }
 
 // infer SFCComponentProps
 Component = styled(SFCComponent)({ color: 'red' });
@@ -80,7 +81,7 @@ Component = styled(MyClassC) ``;
 mount = <Component customProp="abc" />;
 
 // do not infer SFCComponentProps with pass CustomProps, need to pass both
-Component = styled<CustomProps2 & SFCComponentProps>(SFCComponent)({ 
+Component = styled<CustomProps2 & SFCComponentProps>(SFCComponent)({
   color: 'red',
 }, props => ({
   background: props.customProp,
@@ -94,17 +95,16 @@ Component = styled<CustomProps2 & SFCComponentProps>(SFCComponent)`
 `;
 mount = <Component customProp="red" foo="bar" />;
 
-
 /*
  * With explicit theme
  */
 
-type Theme = {
+interface Theme {
   color: {
-    primary: string,
-    secondary: string,
-  }
-};
+    primary: string;
+    secondary: string;
+  };
+}
 
 const _styled = styled as ThemedReactEmotionInterface<Theme>;
 
@@ -117,18 +117,18 @@ mount = <Component onClick={event => event} />;
  * withComponent
  */
 
-type CustomProps3 = {
-  bgColor: string,
-};
+interface CustomProps3 {
+  bgColor: string;
+}
 
 Component = styled.div<CustomProps3>(props => ({
   bgColor: props.bgColor,
 }));
 
-let Link = Component.withComponent('a');
+const Link = Component.withComponent('a');
 mount = <Link href="#" bgColor="red" />;
 
-let Button = Component.withComponent('button');
+const Button = Component.withComponent('button');
 mount = <Button type="submit" bgColor="red" />;
 
 /*

--- a/packages/react-emotion/types/tsconfig.json
+++ b/packages/react-emotion/types/tsconfig.json
@@ -6,7 +6,12 @@
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
-    "jsx": "react"
+    "jsx": "react",
+    "lib": ["es6"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true
   },
   "include": [
     "./*.ts",

--- a/packages/react-emotion/types/tslint.json
+++ b/packages/react-emotion/types/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dtslint.json",
+    "rules": {
+        "no-relative-import-in-test": false
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@types/parsimmon@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/parsimmon/-/parsimmon-1.3.0.tgz#0509b11d85e7d10f83141e5d4490ba8ad5e5cbec"
+
 "@types/react@16.0.16":
   version "16.0.16"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.16.tgz#f0652a5a3acc1706ec729c8fba3976acbf45b827"
@@ -147,6 +151,10 @@ ansi-styles@^3.0.0, ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
     color-convert "^1.9.0"
+
+any-promise@^1.0.0, any-promise@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
 
 anymatch@^1.3.0:
   version "1.3.2"
@@ -2497,6 +2505,13 @@ defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
 
+definitelytyped-header-parser@Microsoft/definitelytyped-header-parser#production:
+  version "0.0.0"
+  resolved "https://codeload.github.com/Microsoft/definitelytyped-header-parser/tar.gz/54643e95abcac5421ea8b8c590775ec6f1ff2d71"
+  dependencies:
+    "@types/parsimmon" "^1.3.0"
+    parsimmon "^1.2.0"
+
 del@^2.0.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
@@ -2679,6 +2694,16 @@ dot-prop@^4.1.0:
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
   dependencies:
     is-obj "^1.0.0"
+
+dtslint@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/dtslint/-/dtslint-0.2.0.tgz#7723be0d974ad133ff1e5cdb84728669ca66c51e"
+  dependencies:
+    definitelytyped-header-parser Microsoft/definitelytyped-header-parser#production
+    fs-promise "^2.0.0"
+    strip-json-comments "^2.0.1"
+    tslint "^5.4.2"
+    typescript next
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -3493,6 +3518,22 @@ fs-extra@4.0.2, fs-extra@^4.0.1:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
+
+fs-extra@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.1.2.tgz#046c70163cef9aad46b0e4a7fa467fb22d71de35"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+
+fs-promise@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/fs-promise/-/fs-promise-2.0.3.tgz#f64e4f854bcf689aa8bddcba268916db3db46854"
+  dependencies:
+    any-promise "^1.3.0"
+    fs-extra "^2.0.0"
+    mz "^2.6.0"
+    thenify-all "^1.6.0"
 
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
@@ -4859,6 +4900,12 @@ json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
+jsonfile@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -5466,6 +5513,14 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
+mz@^2.6.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
+
 nan@^2.0.5, nan@^2.3.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
@@ -5928,6 +5983,10 @@ parse5@^1.5.1:
 parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
+
+parsimmon@^1.2.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/parsimmon/-/parsimmon-1.6.2.tgz#28fbe6b8caa38ab89f52b77f8c7743563c7d9aff"
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -7574,7 +7633,7 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -7749,6 +7808,18 @@ text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
+thenify-all@^1.0.0, thenify-all@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
+  dependencies:
+    any-promise "^1.0.0"
+
 throat@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-3.2.0.tgz#50cb0670edbc40237b9e347d7e1f88e4620af836"
@@ -7840,6 +7911,32 @@ tryit@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
 
+tslib@^1.7.1:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.0.tgz#dc604ebad64bcbf696d613da6c954aa0e7ea1eb6"
+
+tslint@^5.4.2:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.8.0.tgz#1f49ad5b2e77c76c3af4ddcae552ae4e3612eb13"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.1.0"
+    commander "^2.9.0"
+    diff "^3.2.0"
+    glob "^7.1.1"
+    minimatch "^3.0.4"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.7.1"
+    tsutils "^2.12.1"
+
+tsutils@^2.12.1:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.12.1.tgz#f4d95ce3391c8971e46e54c4cf0edb0a21dd5b24"
+  dependencies:
+    tslib "^1.7.1"
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -7882,9 +7979,13 @@ typescript-eslint-parser@^7.0.0:
     lodash.unescape "4.0.1"
     semver "5.3.0"
 
-typescript@^2.0.0, typescript@^2.4.2, typescript@^2.5.3:
+typescript@^2.4.2:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
+
+typescript@next:
+  version "2.7.0-dev.20171024"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.0-dev.20171024.tgz#8bd83bafae5955bd2fb683bc4acb499adb92bcf3"
 
 ua-parser-js@^0.7.9:
   version "0.7.14"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Changed the TypeScript tests to using dtslint.

<!-- Why are these changes necessary? -->
**Why**:
* Most importantly it lets you use `$ExpectError` to assert that a certain statement *does* type error, which the previous type tests did not.
* It also tests against multiple TypeScript versions.

<!-- How were these changes implemented? -->
**How**:
By changing from running `tsc --noEmit` to running `dtslint` for running the TypeScript tests.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->

I'm having trouble running the dtslint tests for the react-emotion package - some of the features used in the dts files require a new version of TypeScript but I keep getting an error (https://github.com/Microsoft/dtslint/issues/78) when trying to use new versions of TypeScript.

This PR is just to make sure you agree with this direction before I pursue it even more and to collaborate if anyone else is working on it.

A few related changes, some as a side-effect of moving to dtslint:
* Made some changes to the dts files to satisfy the default dtslint rules.
* Renamed typings directory to types because this seems to be more standard.
* Renamed emotion.d.ts, etc to index.d.ts because dtslint seems to require this.
* Stopped "build" running before "test:typescript" as this is not actually necessary.