### PR TITLE
Fix incorrect usage of css variable in docs

### DIFF
--- a/docs/extract-static.md
+++ b/docs/extract-static.md
@@ -12,7 +12,7 @@ While there are some beneficial use cases for `extractStatic`, emotion's inheren
 
 ```javascript
 const Button = styled('button')`
-  background-color: --bg;
+  background-color: var(--bg);
   padding: 10px;
 `
 <Button style={{ '--bg': props.success ? '#8BC34A' : '#2395f3' }}/>


### PR DESCRIPTION
The way the css variables is being used in that example is incorrect, it is missing a `var()`.
https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables

**What**: Quick typo fix in the extract static docs.

**Why**: Adds clarification and stops misinformation on css variables to other devs.

**Checklist**:
- [x] Documentation
- [x] Tests N/A
- [x] Code complete N/A
