### PR TITLE
Fix typo in package description

### DIFF
--- a/packages/babel-plugin-emotion/package.json
+++ b/packages/babel-plugin-emotion/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-emotion",
   "version": "8.0.9",
-  "description": "A recommended babel preprocessing plugin for emotion, the The Next Generation of CSS-in-JS.",
+  "description": "A recommended babel preprocessing plugin for emotion, The Next Generation of CSS-in-JS.",
   "main": "lib/index.js",
   "files": [
     "src",


### PR DESCRIPTION
Delete duplicated word "the" in package description of babel-plugin-emotion.