### PR TITLE
Update rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react-dom": "^15.5.4",
     "react-test-renderer": "^15.6.1",
     "rimraf": "^2.6.1",
-    "rollup": "^0.43.0",
+    "rollup": "^0.51.3",
     "rollup-plugin-alias": "^1.3.1",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",

--- a/packages/emotion-theming/package.json
+++ b/packages/emotion-theming/package.json
@@ -42,7 +42,7 @@
     "dtslint": "^0.2.0",
     "prop-types": "^15.5.8",
     "rimraf": "^2.6.1",
-    "rollup": "^0.43.0"
+    "rollup": "^0.51.3"
   },
   "dependencies": {
     "hoist-non-react-statics": "^2.3.1"

--- a/packages/emotion-utils/package.json
+++ b/packages/emotion-utils/package.json
@@ -31,6 +31,6 @@
   "devDependencies": {
     "npm-run-all": "^4.0.2",
     "rimraf": "^2.6.1",
-    "rollup": "^0.47.2"
+    "rollup": "^0.51.3"
   }
 }

--- a/packages/emotion/package.json
+++ b/packages/emotion/package.json
@@ -36,7 +36,7 @@
     "dtslint": "^0.2.0",
     "npm-run-all": "^4.0.2",
     "rimraf": "^2.6.1",
-    "rollup": "^0.43.0"
+    "rollup": "^0.51.3"
   },
   "author": "Kye Hohenberger",
   "homepage": "https://emotion.sh",

--- a/packages/preact-emotion/package.json
+++ b/packages/preact-emotion/package.json
@@ -26,7 +26,7 @@
     "npm-run-all": "^4.0.2",
     "react-emotion": "^8.0.10",
     "rimraf": "^2.6.1",
-    "rollup": "^0.43.0"
+    "rollup": "^0.51.3"
   },
   "author": "Kye Hohenberger",
   "homepage": "https://github.com/tkh44/emotion#readme",

--- a/packages/react-emotion/package.json
+++ b/packages/react-emotion/package.json
@@ -33,7 +33,7 @@
     "emotion": "^8.0.10",
     "npm-run-all": "^4.0.2",
     "rimraf": "^2.6.1",
-    "rollup": "^0.43.0"
+    "rollup": "^0.51.3"
   },
   "author": "Kye Hohenberger",
   "homepage": "https://github.com/tkh44/emotion#readme",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,7 @@ import path from 'path'
 const pkg = require(path.resolve(process.cwd(), './package.json'))
 
 const config = {
-  entry: './src/index.js',
+  input: './src/index.js',
   external: [
     'react',
     'emotion',
@@ -19,7 +19,7 @@ const config = {
     'stylis-rule-sheet'
   ],
   exports: 'named',
-  sourceMap: true,
+  sourcemap: true,
   plugins: [
     resolve(),
     babel({
@@ -41,9 +41,9 @@ const config = {
     }),
     cjs()
   ],
-  targets: [
-    { dest: pkg.main, format: 'cjs' },
-    { dest: pkg.module, format: 'es' }
+  output: [
+    { file: pkg.main, format: 'cjs' },
+    { file: pkg.module, format: 'es' }
   ]
 }
 
@@ -63,17 +63,17 @@ if (process.env.UMD) {
     }),
     uglify()
   )
-  config.targets = [
+  config.output = [
     {
-      dest: './dist/emotion.umd.min.js',
+      file: './dist/emotion.umd.min.js',
       format: 'umd',
-      moduleName: pkg.name
+      name: pkg.name
     }
   ]
 }
 
 if (pkg.name === 'preact-emotion') {
-  config.entry = '../react-emotion/src/index.js'
+  config.input = '../react-emotion/src/index.js'
   config.external = ['preact', 'emotion-utils', 'emotion']
   config.plugins.unshift(alias({ react: 'preact' }))
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1391,10 +1391,6 @@ binary-extensions@^1.0.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.10.0.tgz#9aeb9a6c5e88638aad171e167f5900abe24835d0"
 
-bindings@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
-
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -5869,7 +5865,7 @@ mz@^2.6.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.0.5, nan@^2.3.0:
+nan@^2.3.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
 
@@ -7490,17 +7486,9 @@ rollup-watch@^4.3.1:
     require-relative "0.8.7"
     rollup-pluginutils "^2.0.1"
 
-rollup@^0.43.0:
-  version "0.43.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.43.1.tgz#a7770af9711bd21dda977e7cce3d0f63fdfdfa04"
-  dependencies:
-    source-map-support "^0.4.0"
-  optionalDependencies:
-    weak "^1.0.1"
-
-rollup@^0.47.2:
-  version "0.47.6"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.47.6.tgz#83b90a1890dd3321a3f8d0b2bd216e88483f33de"
+rollup@^0.51.3:
+  version "0.51.3"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.51.3.tgz#229e0004d6cf8f207f77a7a8dc76924155f4c1dd"
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -7784,7 +7772,7 @@ source-map-resolve@^0.3.0:
     source-map-url "~0.3.0"
     urix "~0.1.0"
 
-source-map-support@^0.4.0, source-map-support@^0.4.15:
+source-map-support@^0.4.15:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
   dependencies:
@@ -8637,13 +8625,6 @@ wcwidth@^1.0.0:
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
   dependencies:
     defaults "^1.0.3"
-
-weak@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/weak/-/weak-1.0.1.tgz#ab99aab30706959aa0200cb8cf545bb9cb33b99e"
-  dependencies:
-    bindings "^1.2.1"
-    nan "^2.0.5"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Update Rollup.

<!-- Why are these changes necessary? -->
**Why**:

Previously, in the esm bundle, rollup generated an import for emotion like this.
```jsx
import * as emotion from 'emotion'
```
This can't work with tree shaking since every export of emotion is used. (even though tree shaking won't do very much for the `emotion` package since most of the code is used by all the exports, this is mainly to make tree shaking work(hopefully) for #453 since tree-shaking will actually help that)
Now, rollup generates an import like this
```jsx
import { css, getRegisteredStyles } from 'emotion'
```
so it _should_ work better with tree shaking.
<!-- How were these changes implemented? -->
**How**:

`yarn upgrade-interactive --latest`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete

<!-- feel free to add additional comments -->
There is a small size increase to the UMD build but it's to the way the UMD is defined and checking for a default import, so it won't affect the way the majority of consumers will use it, with ESM.