### PR TITLE
Allow components to be used outside of `ThemeProvider` context

### DIFF
--- a/packages/react-emotion/src/index.js
+++ b/packages/react-emotion/src/index.js
@@ -85,7 +85,7 @@ const createStyled = (tag, options: { e: string, label: string }) => {
       render() {
         const { props, state } = this
         this.mergedProps = omitAssign(testAlwaysTrue, {}, props, {
-          theme: (state !== null && state.theme) || props.theme || {}
+          theme: (state && state.theme) || props.theme || {}
         })
 
         let className = ''


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Fixes issue #467.

<!-- Why are these changes necessary? -->
**Why**:
Currently react-emotion throws an error if a component is used outside the context of a `ThemeProvider`.
<!-- How were these changes implemented? -->
**How**:
If `state` is `undefined` or `null`, then we do not read from `state.theme`.
<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Code complete

<!-- feel free to add additional comments -->
