### PR TITLE
Do not add px to css custom-properties

### DIFF
--- a/packages/emotion/src/index.js
+++ b/packages/emotion/src/index.js
@@ -96,7 +96,12 @@ const processStyleValue = (key, value) => {
   if (value === undefined || value === null || typeof value === 'boolean')
     return ''
 
-  if (unitless[key] !== 1 && !isNaN(value) && value !== 0) {
+  if (
+    unitless[key] !== 1 &&
+    key.indexOf('--') !== 0 &&
+    !isNaN(value) &&
+    value !== 0
+  ) {
     return value + 'px'
   }
   return value

--- a/packages/emotion/src/index.js
+++ b/packages/emotion/src/index.js
@@ -98,7 +98,7 @@ const processStyleValue = (key, value) => {
 
   if (
     unitless[key] !== 1 &&
-    key.indexOf('--') !== 0 &&
+    key.charCodeAt(1) !== 45 && // custom properties
     !isNaN(value) &&
     value !== 0
   ) {

--- a/packages/emotion/test/__snapshots__/css.test.js.snap
+++ b/packages/emotion/test/__snapshots__/css.test.js.snap
@@ -48,6 +48,7 @@ exports[`css auto px 1`] = `
   -ms-flex: 1;
   flex: 1;
   font-size: 10px;
+  --custom: 5;
 }
 
 <div

--- a/packages/emotion/test/css.test.js
+++ b/packages/emotion/test/css.test.js
@@ -49,7 +49,7 @@ describe('css', () => {
     expect(tree).toMatchSnapshot()
   })
   test('auto px', () => {
-    const cls1 = css({ display: 'flex', flex: 1, fontSize: 10 })
+    const cls1 = css({ display: 'flex', flex: 1, fontSize: 10, '--custom': 5 })
     const tree = renderer.create(<div className={cls1} />).toJSON()
     expect(tree).toMatchSnapshot()
   })


### PR DESCRIPTION
Ref #479 

**What**:

Bug

**Why**:

To support css custom properties which can be used to simplify cascade

**How**:

Just added special case with checking keys started with `--`

**Checklist**:
- [ ] Documentation
- [x] Tests
- [x] Code complete
