### PR TITLE
Fixed nested themes not being republished on outer theme changes

### DIFF
--- a/packages/emotion-theming/src/theme-provider.js
+++ b/packages/emotion-theming/src/theme-provider.js
@@ -20,8 +20,13 @@ class ThemeProvider extends Component {
     if (this.context[channel] !== undefined) {
       this.unsubscribeToOuterId = this.context[channel].subscribe(theme => {
         this.outerTheme = theme
+
+        if (this.broadcast !== undefined) {
+          this.publish(this.props.theme)
+        }
       })
     }
+
     this.broadcast = createBroadcast(this.getTheme(this.props.theme))
   }
 
@@ -36,7 +41,7 @@ class ThemeProvider extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.theme !== nextProps.theme) {
-      this.broadcast.publish(this.getTheme(nextProps.theme))
+      this.publish(nextProps.theme)
     }
   }
 
@@ -69,6 +74,10 @@ class ThemeProvider extends Component {
     }
 
     return { ...this.outerTheme, ...theme }
+  }
+
+  publish(theme) {
+    this.broadcast.publish(this.getTheme(theme))
   }
 
   render() {

--- a/packages/emotion-theming/test/theme-provider.test.js
+++ b/packages/emotion-theming/test/theme-provider.test.js
@@ -177,6 +177,27 @@ test(`ThemeProvider propagates theme updates`, () => {
   expect(actual()).toEqual(expected)
 })
 
+test(`ThemeProvider propagates theme updates through nested ThemeProviders`, () => {
+  const theme = { themed: true }
+  const augment = outerTheme =>
+    Object.assign({}, outerTheme, { augmented: true })
+  const update = { updated: true }
+  const actual = getInterceptor()
+  const expected = { themed: true, augmented: true, updated: true }
+
+  const wrapper = mount(
+    <ThemeProvider theme={theme}>
+      <ThemeProvider theme={augment}>
+        <Trap.Context intercept={actual} />
+      </ThemeProvider>
+    </ThemeProvider>
+  )
+
+  wrapper.setProps({ theme: Object.assign({}, theme, update) })
+
+  expect(actual()).toEqual(expected)
+})
+
 test('ThemeProvider propagates theme updates even through PureComponent', () => {
   const theme = { themed: true }
   const update = { updated: true }


### PR DESCRIPTION
**What**:

This fixes a bug when having nested `ThemeProvider`s and updating outer theme the change is not reaching the `StyledComponent`
```jsx
<ThemeProvider theme={{}}>
	<ThemeProvider theme={{}}>
		<StyledComponent>
	</ThemeProvider>
</ThemeProvider>
```

**Why**:

This is a bug fix.

**How**:
Using publish in the nested `ThemeProvider`s subscriptions.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation - N/A
- [x] Tests 
- [x] Code complete

