### PR TITLE
Pass converted arguments as array directly to the underlaying classnames helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
   "bundlesize": [
     {
       "path": "./packages/emotion/dist/emotion.umd.min.js",
-      "threshold": "6.35 Kb"
+      "threshold": "6.36 Kb"
     },
     {
       "path": "./packages/react-emotion/dist/emotion.umd.min.js",

--- a/packages/emotion/src/index.js
+++ b/packages/emotion/src/index.js
@@ -258,12 +258,12 @@ export function merge(className, sourceMap) {
   return rawClassName + css(registeredStyles, sourceMap)
 }
 
-function classnames() {
-  let len = arguments.length
+function classnames(args) {
+  let len = args.length
   let i = 0
   let cls = ''
   for (; i < len; i++) {
-    let arg = arguments[i]
+    let arg = args[i]
 
     if (arg == null) continue
     let next = (cls && cls + ' ') || cls
@@ -272,11 +272,11 @@ function classnames() {
       case 'boolean':
         break
       case 'function':
-        cls = next + classnames(arg())
+        cls = next + classnames([arg()])
         break
       case 'object': {
         if (Array.isArray(arg)) {
-          cls = next + classnames.apply(null, arg)
+          cls = next + classnames(arg)
         } else {
           for (const k in arg) {
             if (arg[k]) {
@@ -296,7 +296,7 @@ function classnames() {
 }
 
 export function cx(...classNames) {
-  return merge(classnames(...classNames))
+  return merge(classnames(classNames))
 }
 
 export function hydrate(ids) {


### PR DESCRIPTION
**What**:

Passing already casted to an array arguments to next function helper.

**Why**:
This avoids `arguments` access in the underlaying function which is known to be deopt in many engines.

**Checklist**:
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete

This added literally few bytes to the gzipped size of the bundle, so it requires bumping up bundlesize's limits.
