### PR TITLE
[babel-plugin-emotion][react-emotion] Adds Support for Components as Selectors Using the Object Syntax #501

### DIFF
--- a/docs/styled.md
+++ b/docs/styled.md
@@ -56,6 +56,18 @@ const Parent = styled.div`
     color: green;
   }
 `;
+
+```
+```jsx
+const Child = styled('div')({
+  color: 'red'
+});
+
+const Parent = styled('div')({
+  [Child]: {
+    color: 'green'
+  }
+});
 ```
 
 This will generate a class selector something like:

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     },
     {
       "path": "./packages/react-emotion/dist/emotion.umd.min.js",
-      "threshold": "9 Kb"
+      "threshold": "9.1 Kb"
     }
   ]
 }

--- a/packages/babel-plugin-emotion/src/index.js
+++ b/packages/babel-plugin-emotion/src/index.js
@@ -193,6 +193,7 @@ export function buildStyledCallExpression(identifier, tag, path, state, t) {
 }
 
 export function buildStyledObjectCallExpression(path, state, identifier, t) {
+  const targetProperty = buildTargetObjectProperty(path, state, t)
   const identifierName = getIdentifierName(path, t)
   const tag = t.isCallExpression(path.node.callee)
     ? path.node.callee.arguments[0]
@@ -203,23 +204,21 @@ export function buildStyledObjectCallExpression(path, state, identifier, t) {
     args.push(t.stringLiteral(addSourceMaps(path.node.loc.start, state)))
   }
 
+  const objectProperties = [targetProperty]
+
+  if (state.opts.autoLabel && identifierName) {
+    objectProperties.push(
+      t.objectProperty(
+        t.identifier('label'),
+        t.stringLiteral(identifierName.trim())
+      )
+    )
+  }
+
   path.addComment('leading', '#__PURE__')
 
   return t.callExpression(
-    t.callExpression(
-      identifier,
-      state.opts.autoLabel && identifierName
-        ? [
-            tag,
-            t.objectExpression([
-              t.objectProperty(
-                t.identifier('label'),
-                t.stringLiteral(identifierName.trim())
-              )
-            ])
-          ]
-        : [tag]
-    ),
+    t.callExpression(identifier, [tag, t.objectExpression(objectProperties)]),
     args
   )
 }

--- a/packages/babel-plugin-emotion/test/__snapshots__/macro.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/macro.test.js.snap
@@ -158,7 +158,9 @@ const someCls = /*#__PURE__*/_css('display:flex;');"
 exports[`styled macro babel 6 object function 1`] = `
 "import _styled from './styled';
 
-const SomeComponent = /*#__PURE__*/_styled('div')({
+const SomeComponent = /*#__PURE__*/_styled('div', {
+  target: 'css-o9rakq0'
+})({
   display: 'flex'
 });"
 `;
@@ -166,7 +168,9 @@ const SomeComponent = /*#__PURE__*/_styled('div')({
 exports[`styled macro babel 6 object member 1`] = `
 "import _styled from './styled';
 
-const SomeComponent = /*#__PURE__*/_styled('div')({
+const SomeComponent = /*#__PURE__*/_styled('div', {
+  target: 'css-o9rakq0'
+})({
   display: 'flex'
 });"
 `;
@@ -206,7 +210,9 @@ exports[`styled macro babel 7 object function 1`] = `
 
 const SomeComponent =
 /*#__PURE__*/
-_styled('div')({
+_styled('div', {
+  target: \\"css-o9rakq0\\"
+})({
   display: 'flex'
 });"
 `;
@@ -216,7 +222,9 @@ exports[`styled macro babel 7 object member 1`] = `
 
 const SomeComponent =
 /*#__PURE__*/
-_styled(\\"div\\")({
+_styled(\\"div\\", {
+  target: \\"css-o9rakq0\\"
+})({
   display: 'flex'
 });"
 `;

--- a/packages/babel-plugin-emotion/test/__snapshots__/source-map.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/source-map.test.js.snap
@@ -38,7 +38,9 @@ fontFace(\\"font-family:MyHelvetica;src:local(\\\\\\"Helvetica Neue Bold\\\\\\")
 
 exports[`source map babel 6 styled object styles source map 1`] = `
 "
-/*#__PURE__*/styled('div')({
+/*#__PURE__*/styled('div', {
+  target: 'css-5gcmo60'
+})({
   color: 'blue',
   '&:hover': {
     '& .name': {
@@ -103,7 +105,9 @@ exports[`source map babel 7 fontFace source map 1`] = `"fontFace(\\"font-family:
 
 exports[`source map babel 7 styled object styles source map 1`] = `
 "/*#__PURE__*/
-styled('div')({
+styled('div', {
+  target: \\"css-5gcmo60\\"
+})({
   color: 'blue',
   '&:hover': {
     '& .name': {

--- a/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
@@ -4,6 +4,7 @@ exports[`styled extract babel 6 autoLabel object styles 1`] = `
 "
 const Profile = () => {
   const H1 = /*#__PURE__*/styled('h1', {
+    target: 'css-8nbyc50',
     label: 'H1'
   })({
     borderRadius: '50%',
@@ -127,7 +128,9 @@ exports[`styled extract babel 6 hoisting 1`] = `
 var _ref2 = [{ color: 'blue' }];
 
 const Profile = () => {
-  const H1 = /*#__PURE__*/styled('h1')(_ref, props => ({
+  const H1 = /*#__PURE__*/styled('h1', {
+    target: 'css-8nbyc50'
+  })(_ref, props => ({
     display: props.display
   }), _ref2);
 };"
@@ -193,21 +196,27 @@ emotion.emotion.css
 
 exports[`styled extract babel 6 objects based on props 1`] = `
 "
-const H1 = /*#__PURE__*/styled('h1')({ padding: 10 }, props => ({
+const H1 = /*#__PURE__*/styled('h1', {
+  target: 'css-8nbyc50'
+})({ padding: 10 }, props => ({
   display: props.display
 }));"
 `;
 
 exports[`styled extract babel 6 objects fn call 1`] = `
 "
-const H1 = /*#__PURE__*/styled('h1')({
+const H1 = /*#__PURE__*/styled('h1', {
+  target: 'css-8nbyc50'
+})({
   display: 'flex'
 });"
 `;
 
 exports[`styled extract babel 6 objects prefixed 1`] = `
 "
-const H1 = /*#__PURE__*/styled('h1')({
+const H1 = /*#__PURE__*/styled('h1', {
+    target: 'css-8nbyc50'
+})({
     borderRadius: '50%',
     transition: 'transform 400ms ease-in-out',
     boxSizing: 'border-box',
@@ -234,11 +243,17 @@ emotion.emotion.css
 .css-143zpy6{font-size:32px;}"
 `;
 
-exports[`styled extract babel 6 shorthand property 1`] = `"const H1 = /*#__PURE__*/styled(\\"h1\\")({ fontSize });"`;
+exports[`styled extract babel 6 shorthand property 1`] = `
+"const H1 = /*#__PURE__*/styled(\\"h1\\", {
+  target: \\"css-8nbyc50\\"
+})({ fontSize });"
+`;
 
 exports[`styled extract babel 6 styled objects prefixed 1`] = `
 "
-const H1 = /*#__PURE__*/styled('h1')({
+const H1 = /*#__PURE__*/styled('h1', {
+  target: 'css-8nbyc50'
+})({
   borderRadius: '50%',
   transition: 'transform 400ms ease-in-out',
   boxSizing: 'border-box',
@@ -253,7 +268,9 @@ const H1 = /*#__PURE__*/styled('h1')({
 
 exports[`styled extract babel 6 styled. objects 1`] = `
 "
-const H1 = /*#__PURE__*/styled(\\"h1\\")({ padding: 10 }, props => ({
+const H1 = /*#__PURE__*/styled(\\"h1\\", {
+  target: \\"css-8nbyc50\\"
+})({ padding: 10 }, props => ({
   display: props.display
 }));"
 `;
@@ -261,7 +278,9 @@ const H1 = /*#__PURE__*/styled(\\"h1\\")({ padding: 10 }, props => ({
 exports[`styled extract babel 6 styled. objects with a multiple spread properties 1`] = `
 "
 const defaultText = { fontSize: 20 };
-const Figure = /*#__PURE__*/styled(\\"figure\\")({
+const Figure = /*#__PURE__*/styled(\\"figure\\", {
+  target: \\"css-8nbyc50\\"
+})({
   ...defaultText,
   ...defaultFigure
 });"
@@ -270,7 +289,9 @@ const Figure = /*#__PURE__*/styled(\\"figure\\")({
 exports[`styled extract babel 6 styled. objects with a multiple spread properties and other keys 1`] = `
 "
 const defaultText = { fontSize: 20 };
-const Figure = /*#__PURE__*/styled('figure')({
+const Figure = /*#__PURE__*/styled('figure', {
+  target: 'css-8nbyc50'
+})({
   ...defaultText,
   fontSize: '20px',
   ...defaultFigure,
@@ -281,7 +302,9 @@ const Figure = /*#__PURE__*/styled('figure')({
 exports[`styled extract babel 6 styled. objects with a single spread property 1`] = `
 "
 const defaultText = { fontSize: 20 };
-const Figure = /*#__PURE__*/styled(\\"figure\\")({
+const Figure = /*#__PURE__*/styled(\\"figure\\", {
+  target: \\"css-8nbyc50\\"
+})({
   ...defaultText
 });"
 `;
@@ -303,6 +326,7 @@ exports[`styled extract babel 7 autoLabel object styles 1`] = `
   const H1 =
   /*#__PURE__*/
   styled(\\"h1\\", {
+    target: \\"css-8nbyc50\\",
     label: \\"H1\\"
   })({
     borderRadius: '50%',
@@ -436,7 +460,9 @@ var _ref2 = [{
 const Profile = () => {
   const H1 =
   /*#__PURE__*/
-  styled(\\"h1\\")(_ref, props => ({
+  styled(\\"h1\\", {
+    target: \\"css-8nbyc50\\"
+  })(_ref, props => ({
     display: props.display
   }), _ref2);
 };"
@@ -508,7 +534,9 @@ emotion.emotion.css
 exports[`styled extract babel 7 objects based on props 1`] = `
 "const H1 =
 /*#__PURE__*/
-styled('h1')({
+styled('h1', {
+  target: \\"css-8nbyc50\\"
+})({
   padding: 10
 }, props => ({
   display: props.display
@@ -518,7 +546,9 @@ styled('h1')({
 exports[`styled extract babel 7 objects fn call 1`] = `
 "const H1 =
 /*#__PURE__*/
-styled('h1')({
+styled('h1', {
+  target: \\"css-8nbyc50\\"
+})({
   display: 'flex'
 });"
 `;
@@ -526,7 +556,9 @@ styled('h1')({
 exports[`styled extract babel 7 objects prefixed 1`] = `
 "const H1 =
 /*#__PURE__*/
-styled('h1')({
+styled('h1', {
+  target: \\"css-8nbyc50\\"
+})({
   borderRadius: '50%',
   transition: 'transform 400ms ease-in-out',
   boxSizing: 'border-box',
@@ -560,7 +592,9 @@ emotion.emotion.css
 exports[`styled extract babel 7 shorthand property 1`] = `
 "const H1 =
 /*#__PURE__*/
-styled(\\"h1\\")({
+styled(\\"h1\\", {
+  target: \\"css-8nbyc50\\"
+})({
   fontSize
 });"
 `;
@@ -568,7 +602,9 @@ styled(\\"h1\\")({
 exports[`styled extract babel 7 styled objects prefixed 1`] = `
 "const H1 =
 /*#__PURE__*/
-styled(\\"h1\\")({
+styled(\\"h1\\", {
+  target: \\"css-8nbyc50\\"
+})({
   borderRadius: '50%',
   transition: 'transform 400ms ease-in-out',
   boxSizing: 'border-box',
@@ -584,7 +620,9 @@ styled(\\"h1\\")({
 exports[`styled extract babel 7 styled. objects 1`] = `
 "const H1 =
 /*#__PURE__*/
-styled(\\"h1\\")({
+styled(\\"h1\\", {
+  target: \\"css-8nbyc50\\"
+})({
   padding: 10
 }, props => ({
   display: props.display
@@ -597,7 +635,9 @@ exports[`styled extract babel 7 styled. objects with a multiple spread propertie
 };
 const Figure =
 /*#__PURE__*/
-styled(\\"figure\\")({ ...defaultText,
+styled(\\"figure\\", {
+  target: \\"css-8nbyc50\\"
+})({ ...defaultText,
   ...defaultFigure
 });"
 `;
@@ -608,7 +648,9 @@ exports[`styled extract babel 7 styled. objects with a multiple spread propertie
 };
 const Figure =
 /*#__PURE__*/
-styled(\\"figure\\")({ ...defaultText,
+styled(\\"figure\\", {
+  target: \\"css-8nbyc50\\"
+})({ ...defaultText,
   fontSize: '20px',
   ...defaultFigure,
   ...defaultText2
@@ -621,7 +663,9 @@ exports[`styled extract babel 7 styled. objects with a single spread property 1`
 };
 const Figure =
 /*#__PURE__*/
-styled(\\"figure\\")({ ...defaultText
+styled(\\"figure\\", {
+  target: \\"css-8nbyc50\\"
+})({ ...defaultText
 });"
 `;
 
@@ -642,6 +686,7 @@ exports[`styled inline babel 6 autoLabel object styles 1`] = `
 "
 const Profile = () => {
   const H1 = /*#__PURE__*/styled('h1', {
+    target: 'css-8nbyc50',
     label: 'H1'
   })({
     borderRadius: '50%',
@@ -734,7 +779,9 @@ exports[`styled inline babel 6 hoisting 1`] = `
 var _ref2 = [{ color: 'blue' }];
 
 const Profile = () => {
-  const H1 = /*#__PURE__*/styled('h1')(_ref, props => ({
+  const H1 = /*#__PURE__*/styled('h1', {
+    target: 'css-8nbyc50'
+  })(_ref, props => ({
     display: props.display
   }), _ref2);
 };"
@@ -779,21 +826,27 @@ exports[`styled inline babel 6 no use 1`] = `
 
 exports[`styled inline babel 6 objects based on props 1`] = `
 "
-const H1 = /*#__PURE__*/styled('h1')({ padding: 10 }, props => ({
+const H1 = /*#__PURE__*/styled('h1', {
+  target: 'css-8nbyc50'
+})({ padding: 10 }, props => ({
   display: props.display
 }));"
 `;
 
 exports[`styled inline babel 6 objects fn call 1`] = `
 "
-const H1 = /*#__PURE__*/styled('h1')({
+const H1 = /*#__PURE__*/styled('h1', {
+  target: 'css-8nbyc50'
+})({
   display: 'flex'
 });"
 `;
 
 exports[`styled inline babel 6 objects prefixed 1`] = `
 "
-const H1 = /*#__PURE__*/styled('h1')({
+const H1 = /*#__PURE__*/styled('h1', {
+    target: 'css-8nbyc50'
+})({
     borderRadius: '50%',
     transition: 'transform 400ms ease-in-out',
     boxSizing: 'border-box',
@@ -814,11 +867,17 @@ const a = () => /*#__PURE__*/css(\\"font-size:1rem\\");
 })(\\"margin:12px 48px;\\", /*#__PURE__*/css(\\"font-size:32px\\"), \\";color:#ffffff;& .profile{\\", props => props.prop && a(), \\"}\\", { backgroundColor: \\"hotpink\\" }, \\";\\");"
 `;
 
-exports[`styled inline babel 6 shorthand property 1`] = `"const H1 = /*#__PURE__*/styled(\\"h1\\")({ fontSize });"`;
+exports[`styled inline babel 6 shorthand property 1`] = `
+"const H1 = /*#__PURE__*/styled(\\"h1\\", {
+  target: \\"css-8nbyc50\\"
+})({ fontSize });"
+`;
 
 exports[`styled inline babel 6 styled objects prefixed 1`] = `
 "
-const H1 = /*#__PURE__*/styled('h1')({
+const H1 = /*#__PURE__*/styled('h1', {
+  target: 'css-8nbyc50'
+})({
   borderRadius: '50%',
   transition: 'transform 400ms ease-in-out',
   boxSizing: 'border-box',
@@ -833,7 +892,9 @@ const H1 = /*#__PURE__*/styled('h1')({
 
 exports[`styled inline babel 6 styled. objects 1`] = `
 "
-const H1 = /*#__PURE__*/styled(\\"h1\\")({ padding: 10 }, props => ({
+const H1 = /*#__PURE__*/styled(\\"h1\\", {
+  target: \\"css-8nbyc50\\"
+})({ padding: 10 }, props => ({
   display: props.display
 }));"
 `;
@@ -841,7 +902,9 @@ const H1 = /*#__PURE__*/styled(\\"h1\\")({ padding: 10 }, props => ({
 exports[`styled inline babel 6 styled. objects with a multiple spread properties 1`] = `
 "
 const defaultText = { fontSize: 20 };
-const Figure = /*#__PURE__*/styled(\\"figure\\")({
+const Figure = /*#__PURE__*/styled(\\"figure\\", {
+  target: \\"css-8nbyc50\\"
+})({
   ...defaultText,
   ...defaultFigure
 });"
@@ -850,7 +913,9 @@ const Figure = /*#__PURE__*/styled(\\"figure\\")({
 exports[`styled inline babel 6 styled. objects with a multiple spread properties and other keys 1`] = `
 "
 const defaultText = { fontSize: 20 };
-const Figure = /*#__PURE__*/styled('figure')({
+const Figure = /*#__PURE__*/styled('figure', {
+  target: 'css-8nbyc50'
+})({
   ...defaultText,
   fontSize: '20px',
   ...defaultFigure,
@@ -861,7 +926,9 @@ const Figure = /*#__PURE__*/styled('figure')({
 exports[`styled inline babel 6 styled. objects with a single spread property 1`] = `
 "
 const defaultText = { fontSize: 20 };
-const Figure = /*#__PURE__*/styled(\\"figure\\")({
+const Figure = /*#__PURE__*/styled(\\"figure\\", {
+  target: \\"css-8nbyc50\\"
+})({
   ...defaultText
 });"
 `;
@@ -877,6 +944,7 @@ exports[`styled inline babel 7 autoLabel object styles 1`] = `
   const H1 =
   /*#__PURE__*/
   styled(\\"h1\\", {
+    target: \\"css-8nbyc50\\",
     label: \\"H1\\"
   })({
     borderRadius: '50%',
@@ -985,7 +1053,9 @@ var _ref2 = [{
 const Profile = () => {
   const H1 =
   /*#__PURE__*/
-  styled(\\"h1\\")(_ref, props => ({
+  styled(\\"h1\\", {
+    target: \\"css-8nbyc50\\"
+  })(_ref, props => ({
     display: props.display
   }), _ref2);
 };"
@@ -1040,7 +1110,9 @@ styled(\\"h1\\", {
 exports[`styled inline babel 7 objects based on props 1`] = `
 "const H1 =
 /*#__PURE__*/
-styled('h1')({
+styled('h1', {
+  target: \\"css-8nbyc50\\"
+})({
   padding: 10
 }, props => ({
   display: props.display
@@ -1050,7 +1122,9 @@ styled('h1')({
 exports[`styled inline babel 7 objects fn call 1`] = `
 "const H1 =
 /*#__PURE__*/
-styled('h1')({
+styled('h1', {
+  target: \\"css-8nbyc50\\"
+})({
   display: 'flex'
 });"
 `;
@@ -1058,7 +1132,9 @@ styled('h1')({
 exports[`styled inline babel 7 objects prefixed 1`] = `
 "const H1 =
 /*#__PURE__*/
-styled('h1')({
+styled('h1', {
+  target: \\"css-8nbyc50\\"
+})({
   borderRadius: '50%',
   transition: 'transform 400ms ease-in-out',
   boxSizing: 'border-box',
@@ -1089,7 +1165,9 @@ css(\\"font-size:32px\\"), \\";color:#ffffff;& .profile{\\", props => props.prop
 exports[`styled inline babel 7 shorthand property 1`] = `
 "const H1 =
 /*#__PURE__*/
-styled(\\"h1\\")({
+styled(\\"h1\\", {
+  target: \\"css-8nbyc50\\"
+})({
   fontSize
 });"
 `;
@@ -1097,7 +1175,9 @@ styled(\\"h1\\")({
 exports[`styled inline babel 7 styled objects prefixed 1`] = `
 "const H1 =
 /*#__PURE__*/
-styled(\\"h1\\")({
+styled(\\"h1\\", {
+  target: \\"css-8nbyc50\\"
+})({
   borderRadius: '50%',
   transition: 'transform 400ms ease-in-out',
   boxSizing: 'border-box',
@@ -1113,7 +1193,9 @@ styled(\\"h1\\")({
 exports[`styled inline babel 7 styled. objects 1`] = `
 "const H1 =
 /*#__PURE__*/
-styled(\\"h1\\")({
+styled(\\"h1\\", {
+  target: \\"css-8nbyc50\\"
+})({
   padding: 10
 }, props => ({
   display: props.display
@@ -1126,7 +1208,9 @@ exports[`styled inline babel 7 styled. objects with a multiple spread properties
 };
 const Figure =
 /*#__PURE__*/
-styled(\\"figure\\")({ ...defaultText,
+styled(\\"figure\\", {
+  target: \\"css-8nbyc50\\"
+})({ ...defaultText,
   ...defaultFigure
 });"
 `;
@@ -1137,7 +1221,9 @@ exports[`styled inline babel 7 styled. objects with a multiple spread properties
 };
 const Figure =
 /*#__PURE__*/
-styled(\\"figure\\")({ ...defaultText,
+styled(\\"figure\\", {
+  target: \\"css-8nbyc50\\"
+})({ ...defaultText,
   fontSize: '20px',
   ...defaultFigure,
   ...defaultText2
@@ -1150,7 +1236,9 @@ exports[`styled inline babel 7 styled. objects with a single spread property 1`]
 };
 const Figure =
 /*#__PURE__*/
-styled(\\"figure\\")({ ...defaultText
+styled(\\"figure\\", {
+  target: \\"css-8nbyc50\\"
+})({ ...defaultText
 });"
 `;
 

--- a/packages/babel-plugin-emotion/test/macro/__snapshots__/react.test.js.snap
+++ b/packages/babel-plugin-emotion/test/macro/__snapshots__/react.test.js.snap
@@ -25,7 +25,7 @@ exports[`styled basic render with object as style 1`] = `
 }
 
 <h1
-  className="glamor-0"
+  className="glamor-0 glamor-1"
 >
   hello world
 </h1>
@@ -226,7 +226,7 @@ exports[`styled composition of nested pseudo selectors 1`] = `
 }
 
 <button
-  className="glamor-0"
+  className="glamor-0 glamor-1"
 >
   Should be purple
 </button>
@@ -294,7 +294,7 @@ exports[`styled glamorous style api & composition 1`] = `
 }
 
 <h1
-  className="glamor-0"
+  className="glamor-0 glamor-1"
   fontSize={20}
 >
   hello world
@@ -405,7 +405,7 @@ exports[`styled input placeholder object 1`] = `
 }
 
 <input
-  className="glamor-0"
+  className="glamor-0 glamor-1"
 >
   hello world
 </input>
@@ -507,7 +507,7 @@ exports[`styled object as style 1`] = `
 }
 
 <h1
-  className="glamor-0"
+  className="glamor-0 glamor-1"
   fontSize={20}
 >
   hello world
@@ -548,7 +548,7 @@ exports[`styled objects 1`] = `
 }
 
 <h1
-  className="glamor-0"
+  className="glamor-0 glamor-1"
   display="flex"
 >
   hello world
@@ -561,7 +561,7 @@ exports[`styled objects with spread properties 1`] = `
 }
 
 <figure
-  className="glamor-0"
+  className="glamor-0 glamor-1"
 >
   hello world
 </figure>

--- a/packages/emotion/test/no-babel/__snapshots__/index.test.js.snap
+++ b/packages/emotion/test/no-babel/__snapshots__/index.test.js.snap
@@ -12,6 +12,8 @@ exports[`css @supports 1`] = `
 />
 `;
 
+exports[`css component as selectors (object syntax) 1`] = `"Component selectors can only be used in conjunction with babel-plugin-emotion."`;
+
 exports[`css composition 1`] = `
 .glamor-0 {
   display: -webkit-box;

--- a/packages/emotion/test/no-babel/index.test.js
+++ b/packages/emotion/test/no-babel/index.test.js
@@ -127,6 +127,24 @@ describe('css', () => {
 
     expect(tree).toMatchSnapshot()
   })
+  test('component as selectors (object syntax)', () => {
+    expect(() => {
+      const fontSize = '20px'
+      const H1 = styled('h1')({ fontSize })
+
+      const Thing = styled('div')({
+        display: 'flex',
+        [H1]: {
+          color: 'green'
+        }
+      })
+      renderer.create(
+        <Thing>
+          hello <H1>This will be green</H1> world
+        </Thing>
+      )
+    }).toThrowErrorMatchingSnapshot()
+  })
   test('glamorous style api & composition', () => {
     const H1 = styled('h1')(props => ({ fontSize: props.fontSize }))
     const H2 = styled(H1)(props => ({ flex: props.flex }), { display: 'flex' })

--- a/packages/react-emotion/src/index.js
+++ b/packages/react-emotion/src/index.js
@@ -147,7 +147,9 @@ const createStyled = (
           process.env.NODE_ENV !== 'production' &&
           stableClassName === undefined
         ) {
-          throw new Error('')
+          throw new Error(
+            'Component selectors can only be used in conjunction with babel-plugin-emotion.'
+          )
         }
         return `.${stableClassName}`
       }

--- a/packages/react-emotion/src/index.js
+++ b/packages/react-emotion/src/index.js
@@ -140,6 +140,19 @@ const createStyled = (
     Styled.__emotion_real = Styled
     Styled[TARGET_KEY] = stableClassName
 
+    Object.defineProperty(Styled, 'toString', {
+      enumerable: false,
+      value() {
+        if (
+          process.env.NODE_ENV !== 'production' &&
+          stableClassName === undefined
+        ) {
+          throw new Error('')
+        }
+        return `.${stableClassName}`
+      }
+    })
+
     Styled.withComponent = (nextTag, nextOptions: { target: string }) => {
       return createStyled(
         nextTag,

--- a/packages/react-emotion/test/__snapshots__/index.test.js.snap
+++ b/packages/react-emotion/test/__snapshots__/index.test.js.snap
@@ -25,7 +25,7 @@ exports[`styled basic render with object as style 1`] = `
 }
 
 <h1
-  className="glamor-0"
+  className="glamor-0 glamor-1"
 >
   hello world
 </h1>
@@ -226,7 +226,7 @@ exports[`styled composition of nested pseudo selectors 1`] = `
 }
 
 <button
-  className="glamor-0"
+  className="glamor-0 glamor-1"
 >
   Should be purple
 </button>
@@ -294,7 +294,7 @@ exports[`styled glamorous style api & composition 1`] = `
 }
 
 <h1
-  className="glamor-0"
+  className="glamor-0 glamor-1"
   fontSize={20}
 >
   hello world
@@ -405,7 +405,7 @@ exports[`styled input placeholder object 1`] = `
 }
 
 <input
-  className="glamor-0"
+  className="glamor-0 glamor-1"
 >
   hello world
 </input>
@@ -529,7 +529,7 @@ exports[`styled object as style 1`] = `
 }
 
 <h1
-  className="glamor-0"
+  className="glamor-0 glamor-1"
   fontSize={20}
 >
   hello world
@@ -570,7 +570,7 @@ exports[`styled objects 1`] = `
 }
 
 <h1
-  className="glamor-0"
+  className="glamor-0 glamor-1"
   display="flex"
 >
   hello world
@@ -583,7 +583,7 @@ exports[`styled objects with spread properties 1`] = `
 }
 
 <figure
-  className="glamor-0"
+  className="glamor-0 glamor-1"
 >
   hello world
 </figure>
@@ -709,7 +709,7 @@ exports[`styled theming 1`] = `
   >
     <Styled(div)>
       <div
-        className="css-olgnlr css-ldhy9931"
+        className="css-olgnlr css-ldhy9939"
       >
         this will be green then pink
       </div>
@@ -736,7 +736,7 @@ exports[`styled theming 2`] = `
   >
     <Styled(div)>
       <div
-        className="css-olgnlr css-ldhy9931"
+        className="css-olgnlr css-ldhy9939"
       >
         this will be green then pink
       </div>
@@ -784,11 +784,11 @@ exports[`styled with higher order component that hoists statics 1`] = `
 />
 `;
 
-exports[`styled withComponent creates a new, unique stable class per invocation 1`] = `"css-ldhy9946"`;
+exports[`styled withComponent creates a new, unique stable class per invocation 1`] = `"css-ldhy9954"`;
 
-exports[`styled withComponent creates a new, unique stable class per invocation 2`] = `"css-ldhy9947"`;
+exports[`styled withComponent creates a new, unique stable class per invocation 2`] = `"css-ldhy9955"`;
 
-exports[`styled withComponent creates a new, unique stable class per invocation 3`] = `"css-ldhy9948"`;
+exports[`styled withComponent creates a new, unique stable class per invocation 3`] = `"css-ldhy9956"`;
 
 exports[`styled withComponent will replace tags but keep styling classes 1`] = `
 .glamor-0 {

--- a/packages/react-emotion/test/component-selectors/__snapshots__/component-selector.test.js.snap
+++ b/packages/react-emotion/test/component-selectors/__snapshots__/component-selector.test.js.snap
@@ -1,5 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`component as selector (object syntax) 1`] = `
+.glamor-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.glamor-2 .glamor-1 {
+  color: green;
+}
+
+.glamor-0 {
+  font-size: 20px;
+}
+
+<div
+  className="glamor-2 glamor-3"
+>
+  hello 
+  <h1
+    className="glamor-0 glamor-1"
+  >
+    This will be green
+  </h1>
+   world
+</div>
+`;
+
+exports[`component as selector (object syntax) 2`] = `
+".css-bpijsz {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.css-bpijsz .css-qeli5r4 {
+  color: green;
+}
+
+.css-bk9fzy {
+  font-size: 20px;
+}"
+`;
+
 exports[`component as selector 1`] = `
 .glamor-2 {
   display: -webkit-box;
@@ -38,6 +84,54 @@ exports[`component as selector 2`] = `
 }
 
 .css-1n9lalg .css-qeli5r0 {
+  color: green;
+}
+
+.css-bk9fzy {
+  font-size: 20px;
+}"
+`;
+
+exports[`component as selector function interpolation (object syntax) 1`] = `
+.glamor-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.glamor-2 .glamor-1 {
+  color: green;
+}
+
+.glamor-0 {
+  font-size: 20px;
+}
+
+<div
+  className="glamor-2 glamor-3"
+  fontSize={10}
+>
+  hello 
+  <h1
+    className="glamor-0 glamor-1"
+    fontSize={20}
+  >
+    This will be green
+  </h1>
+   world
+</div>
+`;
+
+exports[`component as selector function interpolation (object syntax) 2`] = `
+".css-hm85j0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.css-hm85j0 .css-qeli5r6 {
   color: green;
 }
 

--- a/packages/react-emotion/test/component-selectors/component-selector.test.js
+++ b/packages/react-emotion/test/component-selectors/component-selector.test.js
@@ -52,3 +52,50 @@ test('component as selector function interpolation', () => {
   expect(tree).toMatchSnapshot()
   expect(sheet).toMatchSnapshot()
 })
+
+test('component as selector (object syntax)', () => {
+  const fontSize = '20px'
+  const H1 = styled('h1')({ fontSize })
+
+  const Thing = styled('div')({
+    display: 'flex',
+    [H1]: {
+      color: 'green'
+    }
+  })
+
+  const tree = renderer
+    .create(
+      <Thing>
+        hello <H1>This will be green</H1> world
+      </Thing>
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
+  expect(sheet).toMatchSnapshot()
+})
+
+test('component as selector function interpolation (object syntax)', () => {
+  const H1 = styled('h1')({}, props => ({
+    fontSize: `${props.fontSize}px`
+  }))
+
+  const Thing = styled('div')({
+    display: 'flex',
+    [H1]: {
+      color: 'green'
+    }
+  })
+
+  const tree = renderer
+    .create(
+      <Thing fontSize={10}>
+        hello <H1 fontSize={20}>This will be green</H1> world
+      </Thing>
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
+  expect(sheet).toMatchSnapshot()
+})


### PR DESCRIPTION
Issue #501 

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Adding the ability to use components as selectors when object syntax is being used.

<!-- Why are these changes necessary? -->
**Why**: To achieve api parity regardless of the syntax being used.

<!-- How were these changes implemented? -->
**How**: Under direction of @mitchellhamilton via comments on issue #501.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
