### PR TITLE
Fix create-emotion-styled proxy with react-hot-loader and add appearance: none to search input

### DIFF
--- a/packages/create-emotion-styled/src/index.js
+++ b/packages/create-emotion-styled/src/index.js
@@ -169,10 +169,21 @@ function createEmotionStyled(emotion: Emotion, view: ReactType) {
   if (process.env.NODE_ENV !== 'production' && typeof Proxy !== 'undefined') {
     createStyled = new Proxy(createStyled, {
       get(target, property) {
-        throw new Error(
-          `You're trying to use the styled shorthand without babel-plugin-emotion.` +
-            `\nPlease install and setup babel-plugin-emotion or use the function call syntax(\`styled('${property}')\` instead of \`styled.${property}\`)`
-        )
+        switch (property) {
+          // react-hot-loader tries to access this stuff
+          case '__proto__':
+          case 'name':
+          case 'prototype':
+          case 'displayName': {
+            return target[property]
+          }
+          default: {
+            throw new Error(
+              `You're trying to use the styled shorthand without babel-plugin-emotion.` +
+                `\nPlease install and setup babel-plugin-emotion or use the function call syntax(\`styled('${property}')\` instead of \`styled.${property}\`)`
+            )
+          }
+        }
       }
     })
   }

--- a/packages/emotion/test/no-babel/index.test.js
+++ b/packages/emotion/test/no-babel/index.test.js
@@ -215,4 +215,13 @@ describe('css', () => {
       styled.div``
     }).toThrowErrorMatchingSnapshot()
   })
+  test('styled does not throw an error when certain properties are accessed', () => {
+    expect(() => {
+      // eslint-disable-next-line no-proto
+      styled.__proto__``
+      styled.prototype``
+      styled.name``
+      styled.displayName``
+    }).not.toThrow()
+  })
 })

--- a/packages/emotion/test/no-babel/index.test.js
+++ b/packages/emotion/test/no-babel/index.test.js
@@ -217,11 +217,13 @@ describe('css', () => {
   })
   test('styled does not throw an error when certain properties are accessed', () => {
     expect(() => {
+      /* eslint-disable no-unused-expressions */
       // eslint-disable-next-line no-proto
-      styled.__proto__``
-      styled.prototype``
-      styled.name``
-      styled.displayName``
+      styled.__proto__
+      styled.prototype
+      styled.name
+      styled.displayName
+      /* eslint-enable no-unused-expressions */
     }).not.toThrow()
   })
 })

--- a/packages/site/src/components/Search.js
+++ b/packages/site/src/components/Search.js
@@ -91,6 +91,7 @@ class Search extends React.Component<Props, State> {
             outline: 0,
             width: 16,
             margin: 8,
+            appearance: 'none',
             transition:
               'width 200ms ease,padding 200ms ease, background-color 100ms ease',
             '@media (max-width: 600px)': {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Fix create-emotion-styled proxy with react-hot-loader and add appearance: none to search input
<!-- Why are these changes necessary? -->
**Why**:
react-hot-loader tries to access some properties on styled and because of the proxy it throws.
<!-- How were these changes implemented? -->
**How**:
Return the actual values when it's those properties
<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
