### PR TITLE
Add eslint plugin

### DIFF
--- a/packages/eslint-plugin-emotion/README.md
+++ b/packages/eslint-plugin-emotion/README.md
@@ -1,0 +1,51 @@
+# eslint-plugin-emotion
+
+Apply eslint rules to emotion.sh css-in-js
+
+## Installation
+
+You'll first need to install [ESLint](http://eslint.org):
+
+```
+$ npm i eslint --save-dev
+```
+
+Next, install `eslint-plugin-emotion`:
+
+```
+$ npm install eslint-plugin-emotion --save-dev
+```
+
+**Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `eslint-plugin-emotion` globally.
+
+## Usage
+
+Add `emotion` to the plugins section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
+
+```json
+{
+    "plugins": [
+        "emotion"
+    ]
+}
+```
+
+
+Then configure the rules you want to use under the rules section.
+
+```json
+{
+    "rules": {
+        "emotion/syntax-preference": [2, "string"]
+    }
+}
+```
+
+## Supported Rules
+
+* [syntax-preference](docs/rules/syntax-preference.md)
+
+
+
+
+

--- a/packages/eslint-plugin-emotion/docs/rules/syntax-preference.md
+++ b/packages/eslint-plugin-emotion/docs/rules/syntax-preference.md
@@ -1,0 +1,40 @@
+# Choose between styles written as strings or objects (syntax-preference)
+
+[Styled](https://emotion.sh/#styled) accepts string styles or object styles.
+
+
+## Rule Details
+
+This rule aims to choose between syntaxes.
+
+Examples of **incorrect** code for this rule, when ```emotion/syntax-preference: [2, "string"]```:
+
+```js
+const H1 = styled.h1({
+  color: red
+})
+// --> Styles should be written using strings.
+
+const H1 = styled('h1')({
+  color: red
+})
+// --> Styles should be written using strings.
+```
+
+Examples of **incorrect** code for this rule, when ```emotion/syntax-preference: [2, "object"]```:
+
+```js
+const H1 = styled.h1`
+  color: red;
+`
+// --> Styles should be written using objects.
+
+const H1 = styled('h1')`
+  color: red;
+`
+// --> Styles should be written using objects.
+```
+
+## When Not To Use It
+
+If you don't want to limit styles to a unique syntax.

--- a/packages/eslint-plugin-emotion/package.json
+++ b/packages/eslint-plugin-emotion/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "eslint-plugin-emotion",
+  "version": "9.0.0",
+  "description": "Apply eslint rules to emotion.sh css-in-js",
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin",
+    "emotion"
+  ],
+  "author": "alex-pex <alexandre.paixao@stadline.com>",
+  "main": "src/index.js",
+  "scripts": {
+    "test": "mocha tests --recursive"
+  },
+  "dependencies": {
+    "requireindex": "^1.1.0"
+  },
+  "devDependencies": {
+    "mocha": "^3.1.2"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "license": "ISC"
+}

--- a/packages/eslint-plugin-emotion/package.json
+++ b/packages/eslint-plugin-emotion/package.json
@@ -10,14 +10,8 @@
   ],
   "author": "alex-pex <alexandre.paixao@stadline.com>",
   "main": "src/index.js",
-  "scripts": {
-    "test": "mocha tests --recursive"
-  },
   "dependencies": {
     "requireindex": "^1.1.0"
-  },
-  "devDependencies": {
-    "mocha": "^3.1.2"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/packages/eslint-plugin-emotion/src/index.js
+++ b/packages/eslint-plugin-emotion/src/index.js
@@ -1,0 +1,17 @@
+/**
+ * @fileoverview Apply eslint rules to emotion.sh css-in-js
+ * @author alex-pex
+ */
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const requireIndex = require('requireindex')
+
+// ------------------------------------------------------------------------------
+// Plugin Definition
+// ------------------------------------------------------------------------------
+
+// import all rules in src/rules
+module.exports.rules = requireIndex(`${__dirname}/rules`)

--- a/packages/eslint-plugin-emotion/src/rules/syntax-preference.js
+++ b/packages/eslint-plugin-emotion/src/rules/syntax-preference.js
@@ -4,53 +4,52 @@
  */
 
 function isStringStyle(node) {
-  if (node.type !== 'TaggedTemplateExpression') {
-    return false
-  }
+  if (node.type === 'TaggedTemplateExpression') {
+    // shorthand notation
+    // eg: styled.h1` color: red; `
+    if (
+      node.tag.type === 'MemberExpression' &&
+      node.tag.object.name === 'styled'
+    ) {
+      // string syntax used
+      return true
+    }
 
-  // shorthand notation
-  // eg: styled.h1` color: red; `
-  if (
-    node.tag.type === 'MemberExpression' &&
-    node.tag.object.name === 'styled'
-  ) {
-    // string syntax used
-    return true
-  }
-
-  // full notation
-  // eg: styled('h1')` color: red; `
-  if (node.tag.type === 'CallExpression' && node.tag.callee.name === 'styled') {
-    // string syntax used
-    return true
+    // full notation
+    // eg: styled('h1')` color: red; `
+    if (
+      node.tag.type === 'CallExpression' &&
+      node.tag.callee.name === 'styled'
+    ) {
+      // string syntax used
+      return true
+    }
   }
 
   return false
 }
 
 function isObjectStyle(node) {
-  if (node.type !== 'CallExpression') {
-    return false
-  }
+  if (node.type === 'CallExpression') {
+    // shorthand notation
+    // eg: styled.h1({ color: 'red' })
+    if (
+      node.callee.type === 'MemberExpression' &&
+      node.callee.object.name === 'styled'
+    ) {
+      // object syntax used
+      return true
+    }
 
-  // shorthand notation
-  // eg: styled.h1({ color: 'red' })
-  if (
-    node.callee.type === 'MemberExpression' &&
-    node.callee.object.name === 'styled'
-  ) {
-    // object syntax used
-    return true
-  }
-
-  // full notation
-  // eg: styled('h1')({ color: 'red' })
-  if (
-    node.callee.type === 'CallExpression' &&
-    node.callee.callee.name === 'styled'
-  ) {
-    // object syntax used
-    return true
+    // full notation
+    // eg: styled('h1')({ color: 'red' })
+    if (
+      node.callee.type === 'CallExpression' &&
+      node.callee.callee.name === 'styled'
+    ) {
+      // object syntax used
+      return true
+    }
   }
 
   return false

--- a/packages/eslint-plugin-emotion/src/rules/syntax-preference.js
+++ b/packages/eslint-plugin-emotion/src/rules/syntax-preference.js
@@ -1,0 +1,106 @@
+/**
+ * @fileoverview Choose between string or object syntax
+ * @author alex-pex
+ */
+
+function isStringStyle(node) {
+  if (node.type !== 'TaggedTemplateExpression') {
+    return false
+  }
+
+  // shorthand notation
+  // eg: styled.h1` color: red; `
+  if (
+    node.tag.type === 'MemberExpression' &&
+    node.tag.object.name === 'styled'
+  ) {
+    // string syntax used
+    return true
+  }
+
+  // full notation
+  // eg: styled('h1')` color: red; `
+  if (node.tag.type === 'CallExpression' && node.tag.callee.name === 'styled') {
+    // string syntax used
+    return true
+  }
+
+  return false
+}
+
+function isObjectStyle(node) {
+  if (node.type !== 'CallExpression') {
+    return false
+  }
+
+  // shorthand notation
+  // eg: styled.h1({ color: 'red' })
+  if (
+    node.callee.type === 'MemberExpression' &&
+    node.callee.object.name === 'styled'
+  ) {
+    // object syntax used
+    return true
+  }
+
+  // full notation
+  // eg: styled('h1')({ color: 'red' })
+  if (
+    node.callee.type === 'CallExpression' &&
+    node.callee.callee.name === 'styled'
+  ) {
+    // object syntax used
+    return true
+  }
+
+  return false
+}
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+const MSG_PREFER_STRING_STYLE = 'Styles should be written using strings.'
+const MSG_PREFER_OBJECT_STYLE = 'Styles should be written using objects.'
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Choose between string or object styles',
+      category: 'Stylistic Issues',
+      recommended: false
+    },
+    fixable: null, // or "code" or "whitespace"
+    schema: [
+      {
+        enum: ['string', 'object']
+      }
+    ]
+  },
+
+  create(context) {
+    return {
+      TaggedTemplateExpression(node) {
+        const preferedSyntax = context.options[0]
+
+        if (isStringStyle(node) && preferedSyntax === 'object') {
+          context.report({
+            node,
+            message: MSG_PREFER_OBJECT_STYLE
+          })
+        }
+      },
+
+      CallExpression(node) {
+        const preferedSyntax = context.options[0]
+
+        if (isObjectStyle(node) && preferedSyntax === 'string') {
+          context.report({
+            node,
+            message: MSG_PREFER_STRING_STYLE
+          })
+        }
+      }
+    }
+  }
+}

--- a/packages/eslint-plugin-emotion/test/rules/syntax-preference.test.js
+++ b/packages/eslint-plugin-emotion/test/rules/syntax-preference.test.js
@@ -33,6 +33,10 @@ ruleTester.run('syntax-preference (string)', rule, {
     {
       code: "const H1 = styled('h1')` color: red; `",
       options: ['string']
+    },
+    {
+      code: 'const query = gql` { user(id: 5) { firstName, lastName } }`',
+      options: ['string']
     }
   ],
 
@@ -69,6 +73,10 @@ ruleTester.run('syntax-preference (object)', rule, {
     },
     {
       code: "const H1 = styled('h1')({ color: 'red' })",
+      options: ['object']
+    },
+    {
+      code: 'const query = gql` { user(id: 5) { firstName, lastName } }`',
       options: ['object']
     }
   ],
@@ -111,6 +119,9 @@ ruleTester.run('syntax-preference (undefined)', rule, {
     },
     {
       code: "const H1 = styled('h1')({ color: 'red' })"
+    },
+    {
+      code: 'const query = gql` { user(id: 5) { firstName, lastName } }`'
     }
   ],
 

--- a/packages/eslint-plugin-emotion/test/rules/syntax-preference.test.js
+++ b/packages/eslint-plugin-emotion/test/rules/syntax-preference.test.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Choose between string or object syntax
  * @author alex-pex
+ * @jest-environment node
  */
 
 // ------------------------------------------------------------------------------
@@ -8,7 +9,7 @@
 // ------------------------------------------------------------------------------
 
 const { RuleTester } = require('eslint')
-const rule = require('../../../src/rules/syntax-preference')
+const rule = require('../../src/rules/syntax-preference')
 
 RuleTester.setDefaultConfig({
   parserOptions: {

--- a/packages/eslint-plugin-emotion/test/src/rules/syntax-preference.js
+++ b/packages/eslint-plugin-emotion/test/src/rules/syntax-preference.js
@@ -1,0 +1,117 @@
+/**
+ * @fileoverview Choose between string or object syntax
+ * @author alex-pex
+ */
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const { RuleTester } = require('eslint')
+const rule = require('../../../src/rules/syntax-preference')
+
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 6
+  }
+})
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('syntax-preference (string)', rule, {
+  valid: [
+    // give me some code that won't trigger a warning
+    {
+      code: 'const H1 = styled.h1` color: red; `',
+      options: ['string']
+    },
+    {
+      code: "const H1 = styled('h1')` color: red; `",
+      options: ['string']
+    }
+  ],
+
+  invalid: [
+    {
+      code: "const H1 = styled.h1({ color: 'red' })",
+      options: ['string'],
+      errors: [
+        {
+          message: 'Styles should be written using strings.',
+          type: 'CallExpression'
+        }
+      ]
+    },
+    {
+      code: "const H1 = styled('h1')({ color: 'red' })",
+      options: ['string'],
+      errors: [
+        {
+          message: 'Styles should be written using strings.',
+          type: 'CallExpression'
+        }
+      ]
+    }
+  ]
+})
+
+ruleTester.run('syntax-preference (object)', rule, {
+  valid: [
+    // give me some code that won't trigger a warning
+    {
+      code: "const H1 = styled.h1({ color: 'red' })",
+      options: ['object']
+    },
+    {
+      code: "const H1 = styled('h1')({ color: 'red' })",
+      options: ['object']
+    }
+  ],
+
+  invalid: [
+    {
+      code: 'const H1 = styled.h1` color: red; `',
+      options: ['object'],
+      errors: [
+        {
+          message: 'Styles should be written using objects.',
+          type: 'TaggedTemplateExpression'
+        }
+      ]
+    },
+    {
+      code: "const H1 = styled('h1')` color: red; `",
+      options: ['object'],
+      errors: [
+        {
+          message: 'Styles should be written using objects.',
+          type: 'TaggedTemplateExpression'
+        }
+      ]
+    }
+  ]
+})
+
+ruleTester.run('syntax-preference (undefined)', rule, {
+  valid: [
+    // give me some code that won't trigger a warning
+    {
+      code: 'const H1 = styled.h1` color: red; `'
+    },
+    {
+      code: "const H1 = styled('h1')` color: red; `"
+    },
+    {
+      code: "const H1 = styled.h1({ color: 'red' })"
+    },
+    {
+      code: "const H1 = styled('h1')({ color: 'red' })"
+    }
+  ],
+
+  invalid: []
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2425,10 +2425,6 @@ browser-resolve@^1.11.0, browser-resolve@^1.11.2:
   dependencies:
     resolve "1.1.7"
 
-browser-stdout@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
-
 browserify-aes@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-0.4.0.tgz#067149b668df31c4b58533e02d01e806d8608e2c"
@@ -3834,12 +3830,6 @@ debug@2.2.0:
   dependencies:
     ms "0.7.1"
 
-debug@2.6.8:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
-  dependencies:
-    ms "2.0.0"
-
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.4.1, debug@^2.6.0, debug@^2.6.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9, debug@~2.6.4, debug@~2.6.6, debug@~2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -4073,10 +4063,6 @@ detect-port@1.2.1, detect-port@^1.2.1:
   dependencies:
     address "^1.0.1"
     debug "^2.6.0"
-
-diff@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
 diff@^3.2.0:
   version "3.3.1"
@@ -6040,17 +6026,6 @@ glob@5.0.x, glob@^5.0.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@^6.0.1:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
@@ -6261,10 +6236,6 @@ grid-emotion@^2.1.0:
     prop-types "^15.6.0"
     styled-system "^1.0.2"
     tag-hoc "^1.0.0"
-
-growl@1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -6583,7 +6554,7 @@ hawk@~6.0.2:
     hoek "4.x.x"
     sntp "2.x.x"
 
-he@1.1.1, he@1.1.x:
+he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
@@ -8163,7 +8134,7 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
-json3@3.3.2, json3@^3.3.2:
+json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
 
@@ -8484,20 +8455,9 @@ lodash-id@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/lodash-id/-/lodash-id-0.14.0.tgz#baf48934e543a1b5d6346f8c84698b1a8c803896"
 
-lodash._baseassign@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
-  dependencies:
-    lodash._basecopy "^3.0.0"
-    lodash.keys "^3.0.0"
-
 lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
-
-lodash._basecreate@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
 
 lodash._basetostring@^3.0.0:
   version "3.0.1"
@@ -8550,14 +8510,6 @@ lodash.camelcase@^4.3.0:
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
-
-lodash.create@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
-  dependencies:
-    lodash._baseassign "^3.0.0"
-    lodash._basecreate "^3.0.0"
-    lodash._isiterateecall "^3.0.0"
 
 lodash.defaults@^4.0.1:
   version "4.2.0"
@@ -9202,23 +9154,6 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdir
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
-
-mocha@^3.1.2:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
-  dependencies:
-    browser-stdout "1.3.0"
-    commander "2.9.0"
-    debug "2.6.8"
-    diff "3.2.0"
-    escape-string-regexp "1.0.5"
-    glob "7.1.1"
-    growl "1.9.2"
-    he "1.1.1"
-    json3 "3.3.2"
-    lodash.create "3.1.1"
-    mkdirp "0.5.1"
-    supports-color "3.1.2"
 
 modify-values@^1.0.0:
   version "1.0.0"
@@ -11843,8 +11778,8 @@ require-uncached@^1.0.3:
     resolve-from "^1.0.0"
 
 requireindex@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
 
 requires-port@1.0.x, requires-port@1.x.x:
   version "1.0.0"
@@ -13041,12 +12976,6 @@ sum-up@^1.0.1:
   resolved "https://registry.yarnpkg.com/sum-up/-/sum-up-1.0.3.tgz#1c661f667057f63bcb7875aa1438bc162525156e"
   dependencies:
     chalk "^1.0.0"
-
-supports-color@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
-  dependencies:
-    has-flag "^1.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2425,6 +2425,10 @@ browser-resolve@^1.11.0, browser-resolve@^1.11.2:
   dependencies:
     resolve "1.1.7"
 
+browser-stdout@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
+
 browserify-aes@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-0.4.0.tgz#067149b668df31c4b58533e02d01e806d8608e2c"
@@ -3830,6 +3834,12 @@ debug@2.2.0:
   dependencies:
     ms "0.7.1"
 
+debug@2.6.8:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+  dependencies:
+    ms "2.0.0"
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.4.1, debug@^2.6.0, debug@^2.6.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9, debug@~2.6.4, debug@~2.6.6, debug@~2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -4063,6 +4073,10 @@ detect-port@1.2.1, detect-port@^1.2.1:
   dependencies:
     address "^1.0.1"
     debug "^2.6.0"
+
+diff@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
 diff@^3.2.0:
   version "3.3.1"
@@ -6026,6 +6040,17 @@ glob@5.0.x, glob@^5.0.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^6.0.1:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
@@ -6236,6 +6261,10 @@ grid-emotion@^2.1.0:
     prop-types "^15.6.0"
     styled-system "^1.0.2"
     tag-hoc "^1.0.0"
+
+growl@1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -6554,7 +6583,7 @@ hawk@~6.0.2:
     hoek "4.x.x"
     sntp "2.x.x"
 
-he@1.1.x:
+he@1.1.1, he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
@@ -8134,7 +8163,7 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
-json3@^3.3.2:
+json3@3.3.2, json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
 
@@ -8455,9 +8484,20 @@ lodash-id@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/lodash-id/-/lodash-id-0.14.0.tgz#baf48934e543a1b5d6346f8c84698b1a8c803896"
 
+lodash._baseassign@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
+  dependencies:
+    lodash._basecopy "^3.0.0"
+    lodash.keys "^3.0.0"
+
 lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
+
+lodash._basecreate@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
 
 lodash._basetostring@^3.0.0:
   version "3.0.1"
@@ -8510,6 +8550,14 @@ lodash.camelcase@^4.3.0:
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
+
+lodash.create@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
+  dependencies:
+    lodash._baseassign "^3.0.0"
+    lodash._basecreate "^3.0.0"
+    lodash._isiterateecall "^3.0.0"
 
 lodash.defaults@^4.0.1:
   version "4.2.0"
@@ -9154,6 +9202,23 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdir
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+mocha@^3.1.2:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
+  dependencies:
+    browser-stdout "1.3.0"
+    commander "2.9.0"
+    debug "2.6.8"
+    diff "3.2.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.1"
+    growl "1.9.2"
+    he "1.1.1"
+    json3 "3.3.2"
+    lodash.create "3.1.1"
+    mkdirp "0.5.1"
+    supports-color "3.1.2"
 
 modify-values@^1.0.0:
   version "1.0.0"
@@ -11777,6 +11842,10 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
+requireindex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+
 requires-port@1.0.x, requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -12972,6 +13041,12 @@ sum-up@^1.0.1:
   resolved "https://registry.yarnpkg.com/sum-up/-/sum-up-1.0.3.tgz#1c661f667057f63bcb7875aa1438bc162525156e"
   dependencies:
     chalk "^1.0.0"
+
+supports-color@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
+  dependencies:
+    has-flag "^1.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: An Eslint plugin, to enforce coding style. You can choose between strings or objects.

<!-- Why are these changes necessary? -->
**Why**: Emotion allow developers to write styles the way they want, without enforcing a specific coding style. In a large project, it can be useful to have an opiniated way of writing styles.

<!-- How were these changes implemented? -->
**How**: They were implemented on my big project (which was using lerna), and migrated to the fork. I used the CLI (yeoman I think) to generate the template of the eslint plugin, then TDD with code samples. It works perfectly for my project, I hope it will match your expectations ;)

<!-- Have you done all of these things?  -->
**Checklist**:
- [x] Documentation
- [x] Tests
- [x] Code complete

https://github.com/alex-pex/emotion/blob/7db2475846bd752d142630ceee6d26152869708e/packages/eslint-plugin-emotion/README.md