### PR TITLE
Add option for label formatting

### DIFF
--- a/packages/babel-plugin-emotion/README.md
+++ b/packages/babel-plugin-emotion/README.md
@@ -214,7 +214,7 @@ For example `labelFormat: "my-classname--[local]"`, where `[local]` will be repl
 with the name of the variable the result is assigned to.
 
 Allowed values:
-* `[local]` - the name of the variable the restul of the `css` or `styled` expression is assigned to.
+* `[local]` - the name of the variable the result of the `css` or `styled` expression is assigned to.
 * `[filename]` - name of the file (without extension) where `css` or `styled` expression is located.
 
 This format only affects the label property of the expression, meaning that `css` prefix and hash will

--- a/packages/babel-plugin-emotion/README.md
+++ b/packages/babel-plugin-emotion/README.md
@@ -207,7 +207,7 @@ const brownStyles = /*#__PURE__*/ css({ color: 'brown' }, 'label:brownStyles;')
 
 `string`, defaults to `null`.
 
-This option automatically adds the `label` property (same as `autoLabel`), but allows to
+This option automatically adds the `label` property (same as `autoLabel`), but allows you to
 define the format of the resulting `label`. The format is defined via string where
 variable parts are enclosed in square brackets `[]`.
 For example `labelFormat: "my-classname--[local]"`, where `[local]` will be replaced

--- a/packages/babel-plugin-emotion/README.md
+++ b/packages/babel-plugin-emotion/README.md
@@ -90,6 +90,7 @@ _Defaults Shown_
         "hoist": false,
         "sourceMap": false,
         "autoLabel": false,
+        "labelFormat": null,
         "extractStatic": false,
         "importedNames": {
           "styled": "styled",
@@ -197,10 +198,45 @@ const brownStyles = css({ color: 'brown' })
 **Out**
 
 ```javascript
-const brownStyles = /*#__PURE__*/ css({ color: 'blue' }, 'label:brownStyles;')
+const brownStyles = /*#__PURE__*/ css({ color: 'brown' }, 'label:brownStyles;')
 ```
 
 `brownStyles`'s value would be `css-1q8eu9e-brownStyles`
+
+### `labelFormat`
+
+`string`, defaults to `null`.
+
+This option automatically adds the `label` property (same as `autoLabel`), but allows to
+define the format of the resulting `label`. The format is defined via string where
+variable parts are enclosed in square brackets `[]`.
+For example `labelFormat: "my-classname--[local]"`, where `[local]` will be replaced
+with the name of the variable the result is assigned to.
+
+Allowed values:
+* `[local]` - the name of the variable the restul of the `css` or `styled` expression is assigned to.
+* `[filename]` - name of the file (without extension) where `css` or `styled` expression is located.
+
+This format only affects the label property of the expression, meaning that `css` prefix and hash will
+be prepended automatically.
+
+#### css
+
+**In**
+
+```javascript
+// BrownView.js
+// labelFormat: [filename]--[local]
+const brownStyles = css({ color: 'brown' })
+```
+
+**Out**
+
+```javascript
+const brownStyles = /*#__PURE__*/ css({ color: 'brown' }, 'label:BrownView--brownStyles;')
+```
+
+`BrownView--brownStyles`'s value would be `css-1q8eu9e-BrownView--brownStyles`
 
 #### styled
 

--- a/packages/babel-plugin-emotion/README.md
+++ b/packages/babel-plugin-emotion/README.md
@@ -90,7 +90,7 @@ _Defaults Shown_
         "hoist": false,
         "sourceMap": false,
         "autoLabel": false,
-        "labelFormat": null,
+        "labelFormat": "[local]",
         "extractStatic": false,
         "importedNames": {
           "styled": "styled",
@@ -205,9 +205,9 @@ const brownStyles = /*#__PURE__*/ css({ color: 'brown' }, 'label:brownStyles;')
 
 ### `labelFormat`
 
-`string`, defaults to `null`.
+`string`, defaults to `"[local]"`.
 
-This option automatically adds the `label` property (same as `autoLabel`), but allows you to
+This option only works when `autoLabel` is set to `true`. It allows you to
 define the format of the resulting `label`. The format is defined via string where
 variable parts are enclosed in square brackets `[]`.
 For example `labelFormat: "my-classname--[local]"`, where `[local]` will be replaced
@@ -226,6 +226,7 @@ be prepended automatically.
 
 ```javascript
 // BrownView.js
+// autoLabel: true
 // labelFormat: [filename]--[local]
 const brownStyles = css({ color: 'brown' })
 ```

--- a/packages/babel-plugin-emotion/src/babel-utils.js
+++ b/packages/babel-plugin-emotion/src/babel-utils.js
@@ -107,9 +107,8 @@ export function getLabel(
   labelFormat?: string,
   filename: string
 ) {
-  if (!identifierName) return null
-  if (autoLabel) return identifierName.trim()
-  if (!labelFormat) return null
+  if (!identifierName || !autoLabel) return null
+  if (!labelFormat) return identifierName.trim()
 
   const parsedPath = nodePath.parse(filename)
   const normalizedFilename = parsedPath.name.replace('.', '-')

--- a/packages/babel-plugin-emotion/src/babel-utils.js
+++ b/packages/babel-plugin-emotion/src/babel-utils.js
@@ -1,4 +1,5 @@
 // @flow
+import nodePath from 'path'
 import { hashArray } from './index'
 import type { BabelPath, EmotionBabelPluginPass } from './index'
 import type { Types, Identifier } from 'babel-flow-types'
@@ -98,6 +99,23 @@ export function getName(identifierName?: string, prefix: string) {
     parts.push(identifierName)
   }
   return parts.join('-')
+}
+
+export function getLabel(
+  identifierName?: string,
+  autoLabel: boolean,
+  labelFormat?: string,
+  filename: string
+) {
+  if (!identifierName) return null
+  if (autoLabel) return identifierName.trim()
+  if (!labelFormat) return null
+
+  const parsedPath = nodePath.parse(filename)
+  const normalizedFilename = parsedPath.name.replace('.', '-')
+  return labelFormat
+    .replace(/\[local\]/gi, identifierName.trim())
+    .replace(/\[filename\]/gi, normalizedFilename)
 }
 
 export function createRawStringFromTemplateLiteral(quasi: {

--- a/packages/babel-plugin-emotion/test/__snapshots__/css.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/css.test.js.snap
@@ -162,6 +162,42 @@ exports[`babel css inline babel 6 interpolation in selector 1`] = `
 const cls2 = /*#__PURE__*/css(\\"margin:12px 48px;color:#ffffff;\\", className, \\"{display:none;}\\");"
 `;
 
+exports[`babel css inline babel 6 label format with filename and local 1`] = `
+"
+function test() {
+  const cls1 = /*#__PURE__*/css(\\"font-size:20px;@media(min-width:420px){color:blue;\\", /*#__PURE__*/css(\\"width:96px;height:96px;\\", \\"label:my-css-emotion-cls1;\\"), \\";line-height:26px;}background:green;\\", { backgroundColor: \\"hotpink\\" }, \\";\\", \\"label:my-css-emotion-cls1;\\");
+
+  const cls2 = /*#__PURE__*/css({ color: 'blue' }, \\"label:my-css-emotion-cls2;\\");
+  const cls4 = /*#__PURE__*/css({ color: \\"hotpink\\" }, \\"label:my-css-emotion-cls4;\\");
+
+  const cls3 = /*#__PURE__*/css(\\"display:flex;&:hover{color:hotpink;}\\", \\"label:my-css-emotion-cls3;\\");
+  function inner() {
+    const styles = { color: \\"darkorchid\\" };
+    const color = 'aquamarine';
+
+    const cls4 = /*#__PURE__*/css(cls3, \\";\\", cls1, \\";\\", () => ({ color: \\"darkorchid\\" }), \\";\\", () => ({ color }), \\";\\", /*#__PURE__*/css(\\"height:420px;width:\\", styles, \\"label:my-css-emotion-cls4;\\"), \\";\\", \\"label:my-css-emotion-cls4;\\");
+  }
+}"
+`;
+
+exports[`babel css inline babel 6 labelFormat 1`] = `
+"
+function test() {
+  const cls1 = /*#__PURE__*/css(\\"font-size:20px;@media(min-width:420px){color:blue;\\", /*#__PURE__*/css(\\"width:96px;height:96px;\\", \\"label:my-css-cls1;\\"), \\";line-height:26px;}background:green;\\", { backgroundColor: \\"hotpink\\" }, \\";\\", \\"label:my-css-cls1;\\");
+
+  const cls2 = /*#__PURE__*/css({ color: 'blue' }, \\"label:my-css-cls2;\\");
+  const cls4 = /*#__PURE__*/css({ color: \\"hotpink\\" }, \\"label:my-css-cls4;\\");
+
+  const cls3 = /*#__PURE__*/css(\\"display:flex;&:hover{color:hotpink;}\\", \\"label:my-css-cls3;\\");
+  function inner() {
+    const styles = { color: \\"darkorchid\\" };
+    const color = 'aquamarine';
+
+    const cls4 = /*#__PURE__*/css(cls3, \\";\\", cls1, \\";\\", () => ({ color: \\"darkorchid\\" }), \\";\\", () => ({ color }), \\";\\", /*#__PURE__*/css(\\"height:420px;width:\\", styles, \\"label:my-css-cls4;\\"), \\";\\", \\"label:my-css-cls4;\\");
+  }
+}"
+`;
+
 exports[`babel css inline babel 6 nested expanded properties 1`] = `
 "
 /*#__PURE__*/css(\\"margin:12px 48px;& .div{display:flex;}\\");"
@@ -417,6 +453,88 @@ exports[`babel css inline babel 7 interpolation in selector 1`] = `
 "const cls2 =
 /*#__PURE__*/
 css(\\"margin:12px 48px;color:#ffffff;\\", className, \\"{display:none;}\\");"
+`;
+
+exports[`babel css inline babel 7 label format with filename and local 1`] = `
+"function test() {
+  const cls1 =
+  /*#__PURE__*/
+  css(\\"font-size:20px;@media(min-width:420px){color:blue;\\",
+  /*#__PURE__*/
+  css(\\"width:96px;height:96px;\\", \\"label:my-css-emotion-cls1;\\"), \\";line-height:26px;}background:green;\\", {
+    backgroundColor: \\"hotpink\\"
+  }, \\";\\", \\"label:my-css-emotion-cls1;\\");
+  const cls2 =
+  /*#__PURE__*/
+  css({
+    color: 'blue'
+  }, \\"label:my-css-emotion-cls2;\\");
+  const cls4 =
+  /*#__PURE__*/
+  css({
+    color: \\"hotpink\\"
+  }, \\"label:my-css-emotion-cls4;\\");
+  const cls3 =
+  /*#__PURE__*/
+  css(\\"display:flex;&:hover{color:hotpink;}\\", \\"label:my-css-emotion-cls3;\\");
+
+  function inner() {
+    const styles = {
+      color: \\"darkorchid\\"
+    };
+    const color = 'aquamarine';
+    const cls4 =
+    /*#__PURE__*/
+    css(cls3, \\";\\", cls1, \\";\\", () => ({
+      color: \\"darkorchid\\"
+    }), \\";\\", () => ({
+      color
+    }), \\";\\",
+    /*#__PURE__*/
+    css(\\"height:420px;width:\\", styles, \\"label:my-css-emotion-cls4;\\"), \\";\\", \\"label:my-css-emotion-cls4;\\");
+  }
+}"
+`;
+
+exports[`babel css inline babel 7 labelFormat 1`] = `
+"function test() {
+  const cls1 =
+  /*#__PURE__*/
+  css(\\"font-size:20px;@media(min-width:420px){color:blue;\\",
+  /*#__PURE__*/
+  css(\\"width:96px;height:96px;\\", \\"label:my-css-cls1;\\"), \\";line-height:26px;}background:green;\\", {
+    backgroundColor: \\"hotpink\\"
+  }, \\";\\", \\"label:my-css-cls1;\\");
+  const cls2 =
+  /*#__PURE__*/
+  css({
+    color: 'blue'
+  }, \\"label:my-css-cls2;\\");
+  const cls4 =
+  /*#__PURE__*/
+  css({
+    color: \\"hotpink\\"
+  }, \\"label:my-css-cls4;\\");
+  const cls3 =
+  /*#__PURE__*/
+  css(\\"display:flex;&:hover{color:hotpink;}\\", \\"label:my-css-cls3;\\");
+
+  function inner() {
+    const styles = {
+      color: \\"darkorchid\\"
+    };
+    const color = 'aquamarine';
+    const cls4 =
+    /*#__PURE__*/
+    css(cls3, \\";\\", cls1, \\";\\", () => ({
+      color: \\"darkorchid\\"
+    }), \\";\\", () => ({
+      color
+    }), \\";\\",
+    /*#__PURE__*/
+    css(\\"height:420px;width:\\", styles, \\"label:my-css-cls4;\\"), \\";\\", \\"label:my-css-cls4;\\");
+  }
+}"
 `;
 
 exports[`babel css inline babel 7 nested expanded properties 1`] = `

--- a/packages/babel-plugin-emotion/test/css.test.js
+++ b/packages/babel-plugin-emotion/test/css.test.js
@@ -284,7 +284,10 @@ function test () {
   }
 }
 `,
-    opts: { labelFormat: 'my-css-[local]' }
+    opts: {
+      labelFormat: 'my-css-[local]',
+      autoLabel: true
+    }
   },
 
   'label format with filename and local': {
@@ -326,6 +329,7 @@ function test () {
     `,
     opts: {
       labelFormat: 'my-css-[filename]-[local]',
+      autoLabel: true,
       filename: __filename
     }
   },

--- a/packages/babel-plugin-emotion/test/css.test.js
+++ b/packages/babel-plugin-emotion/test/css.test.js
@@ -247,6 +247,89 @@ function test () {
     opts: { autoLabel: true }
   },
 
+  labelFormat: {
+    code: `
+function test () {
+  const cls1 = css\`
+    font-size: 20px;
+    @media(min-width: 420px) {
+      color: blue;
+      \${css\`width: 96px; height: 96px;\`};
+      line-height: 26px;
+    }
+    background: green;
+    \${{ backgroundColor: "hotpink" }};
+  \`
+
+  const cls2 = css\`\${{color: 'blue'}}\`
+  const cls4 = css({color: "hotpink"})
+
+  const cls3 = css\`
+    display: flex;
+    &:hover {
+      color: hotpink;
+    }
+  \`
+  function inner () {
+    const styles = { color: "darkorchid" };
+    const color = 'aquamarine';
+
+    const cls4 = css\`
+      \${cls3};
+      \${cls1};
+      \${() => ({ color: "darkorchid" })};
+      \${() => ({ color })};
+      \${css\`height: 420px;width: \${styles}\`};
+    \`
+  }
+}
+`,
+    opts: { labelFormat: 'my-css-[local]' }
+  },
+
+  'label format with filename and local': {
+    code: `
+    function test () {
+      const cls1 = css\`
+        font-size: 20px;
+        @media(min-width: 420px) {
+          color: blue;
+          \${css\`width: 96px; height: 96px;\`};
+          line-height: 26px;
+        }
+        background: green;
+        \${{ backgroundColor: "hotpink" }};
+      \`
+
+      const cls2 = css\`\${{color: 'blue'}}\`
+      const cls4 = css({color: "hotpink"})
+
+      const cls3 = css\`
+        display: flex;
+        &:hover {
+          color: hotpink;
+        }
+      \`
+      function inner () {
+        const styles = { color: "darkorchid" };
+        const color = 'aquamarine';
+
+        const cls4 = css\`
+          \${cls3};
+          \${cls1};
+          \${() => ({ color: "darkorchid" })};
+          \${() => ({ color })};
+          \${css\`height: 420px;width: \${styles}\`};
+        \`
+      }
+    }
+    `,
+    opts: {
+      labelFormat: 'my-css-[filename]-[local]',
+      filename: __filename
+    }
+  },
+
   'basic object support': {
     code: `css({display: 'flex'})`
   },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
New option for `babel-plugin-emotion` that allows to configure label format in generated class names. Implements https://github.com/emotion-js/emotion/issues/563

<!-- Why are these changes necessary? -->
**Why**:
Details are in https://github.com/emotion-js/emotion/issues/563, but in general when debugging it is nice to have the file name in the class names (especially, for composed styles). The potential of the format is quite big. The feature and solution itself are inspired by `localIdentName` option in [webpack's css-loader](https://github.com/webpack-contrib/css-loader).

<!-- How were these changes implemented? -->
**How**:
New function that handles label generation for all cases (autoLabel, labelFormat, nothing).

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Code complete
