### PR TITLE
Line clamp property needs webkit vendor prefix

### DIFF
--- a/packages/emotion-utils/src/index.js
+++ b/packages/emotion-utils/src/index.js
@@ -35,7 +35,6 @@ export const unitless: { [string]: 1 } = {
   gridColumnSpan: 1,
   gridColumnStart: 1,
   fontWeight: 1,
-  lineClamp: 1,
   lineHeight: 1,
   opacity: 1,
   order: 1,
@@ -44,6 +43,7 @@ export const unitless: { [string]: 1 } = {
   widows: 1,
   zIndex: 1,
   zoom: 1,
+  WebkitLineClamp: 1,
 
   // SVG-related properties
   fillOpacity: 1,


### PR DESCRIPTION
**What**:
The lineClamp property needs to be vendor prefixed to WebkitLineClamp. Resolves https://github.com/emotion-js/emotion/issues/561.

**Why**:
The lineClamp property doesn't work without the prefix and WebkitLineClamp is not in the unitless exceptions list so 'px' is added to the final rule.

**How**:
Replace lineClamp with WebkitLineClamp in the unitless exceptions.

**Checklist**:
- [x] Documentation N/A
- [ ] Tests 
- [x] Code complete N/A

Wasn't sure what kind of test you are looking for, would you mind pointing me in the right direction here? Sorry if I've missed them but I don't currently see any existing tests for this area of the code.

