### PR TITLE
Change component selector error throwing

### DIFF
--- a/packages/create-emotion-styled/src/index.js
+++ b/packages/create-emotion-styled/src/index.js
@@ -142,9 +142,7 @@ function createEmotionStyled(emotion: Emotion, view: ReactType) {
             process.env.NODE_ENV !== 'production' &&
             stableClassName === undefined
           ) {
-            throw new Error(
-              'Component selectors can only be used in conjunction with babel-plugin-emotion.'
-            )
+            return 'NO_COMPONENT_SELECTOR'
           }
           return `.${stableClassName}`
         }

--- a/packages/create-emotion/src/index.js
+++ b/packages/create-emotion/src/index.js
@@ -132,7 +132,16 @@ function createEmotion(
         return ''
       case 'function':
         if (interpolation[STYLES_KEY] !== undefined) {
-          return interpolation.toString()
+          let selector = interpolation.toString()
+          if (
+            selector === 'NO_COMPONENT_SELECTOR' &&
+            process.env.NODE_ENV !== 'production'
+          ) {
+            throw new Error(
+              'Component selectors can only be used in conjunction with babel-plugin-emotion.'
+            )
+          }
+          return selector
         }
         return handleInterpolation.call(
           this,
@@ -179,6 +188,15 @@ function createEmotion(
             )};`
           }
         } else {
+          if (
+            key === 'NO_COMPONENT_SELECTOR' &&
+            process.env.NODE_ENV !== 'production'
+          ) {
+            throw new Error(
+              'Component selectors can only be used in conjunction with babel-plugin-emotion.'
+            )
+          }
+
           string += `${key}{${handleInterpolation.call(this, obj[key], false)}}`
         }
       }, this)

--- a/packages/emotion/test/no-babel/index.test.js
+++ b/packages/emotion/test/no-babel/index.test.js
@@ -210,6 +210,11 @@ describe('css', () => {
 
     expect(tree).toMatchSnapshot()
   })
+  test('styled does not throw on toString without target', () => {
+    expect(() => {
+      styled('div')().toString()
+    }).not.toThrow()
+  })
   test('styled throws a nice error when using the styled shorthand without babel-plugin-emotion', () => {
     expect(() => {
       styled.div``


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Change component selector error throwing so that it doesn't throw in `toString` if there is no target class name, instead it throws in style serialization.

<!-- Why are these changes necessary? -->
**Why**:

To avoid throwing errors when `toString` is called for some reason other than using component selectors 

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
