### PR TITLE
Preserve existing options passed to styled calls

### DIFF
--- a/packages/babel-plugin-emotion/src/macro-styled.js
+++ b/packages/babel-plugin-emotion/src/macro-styled.js
@@ -27,7 +27,7 @@ function macro(options) {
           path.replaceWith(
             buildStyledCallExpression(
               runtimeNode,
-              t.stringLiteral(path.node.tag.property.name),
+              [t.stringLiteral(path.node.tag.property.name)],
               path,
               state,
               t
@@ -37,7 +37,7 @@ function macro(options) {
           path.replaceWith(
             buildStyledCallExpression(
               runtimeNode,
-              path.node.tag.arguments[0],
+              path.node.tag.arguments,
               path,
               state,
               t

--- a/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
@@ -96,6 +96,19 @@ exports[`styled extract babel 6 dynamic fns 1`] = `
 })('width:96px;height:96px;border-radius:', props => props.theme.borderRadius, ';border:1px solid ', props => props.theme.borderColor, ';');"
 `;
 
+exports[`styled extract babel 6 existing options 1`] = `
+"require('./emotion.emotion.css');
+
+const Button = styled('button', {
+  e: 'css-1aj1g6z',
+  target: 'e8nbyc50'
+})();
+
+
+emotion.emotion.css
+.css-1aj1g6z{color:blue;}"
+`;
+
 exports[`styled extract babel 6 function call 1`] = `
 "/*#__PURE__*/styled(MyComponent, {
   target: 'e8nbyc50'
@@ -421,6 +434,19 @@ exports[`styled extract babel 7 dynamic fns 1`] = `
 styled('img', {
   target: \\"e8nbyc50\\"
 })(\\"width:96px;height:96px;border-radius:\\", props => props.theme.borderRadius, \\";border:1px solid \\", props => props.theme.borderColor, \\";\\");"
+`;
+
+exports[`styled extract babel 7 existing options 1`] = `
+"require(\\"./emotion.emotion.css\\");
+
+const Button = styled('button', {
+  e: \\"css-1aj1g6z\\",
+  target: \\"e8nbyc50\\"
+})();
+
+
+emotion.emotion.css
+.css-1aj1g6z{color:blue;}"
 `;
 
 exports[`styled extract babel 7 function call 1`] = `
@@ -754,6 +780,15 @@ exports[`styled inline babel 6 dynamic fns 1`] = `
 })('width:96px;height:96px;border-radius:', props => props.theme.borderRadius, ';border:1px solid ', props => props.theme.borderColor, ';');"
 `;
 
+exports[`styled inline babel 6 existing options 1`] = `
+"
+const Button = /*#__PURE__*/styled('button', {
+  existing: true,
+  label: 'Button',
+  target: 'e8nbyc50'
+})('color:blue;');"
+`;
+
 exports[`styled inline babel 6 function call 1`] = `
 "/*#__PURE__*/styled(MyComponent, {
   target: 'e8nbyc50'
@@ -1020,6 +1055,16 @@ exports[`styled inline babel 7 dynamic fns 1`] = `
 styled('img', {
   target: \\"e8nbyc50\\"
 })(\\"width:96px;height:96px;border-radius:\\", props => props.theme.borderRadius, \\";border:1px solid \\", props => props.theme.borderColor, \\";\\");"
+`;
+
+exports[`styled inline babel 7 existing options 1`] = `
+"const Button =
+/*#__PURE__*/
+styled('button', {
+  existing: true,
+  label: \\"Button\\",
+  target: \\"e8nbyc50\\"
+})(\\"color:blue;\\");"
 `;
 
 exports[`styled inline babel 7 function call 1`] = `

--- a/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
@@ -103,7 +103,7 @@ const Button = styled('button', {
   existing: true,
   e: 'css-1aj1g6z',
   target: 'e8nbyc50'
-})();
+}, otherArg, 'test', { anotherArg: 1 })();
 
 
 emotion.emotion.css
@@ -116,7 +116,7 @@ const Button = /*#__PURE__*/styled('button', {
   existing: true,
   target: 'e8nbyc50',
   label: 'Button'
-})({
+}, otherArg, 'test', { anotherArg: 1 })({
   color: 'blue'
 });"
 `;
@@ -455,6 +455,8 @@ const Button = styled('button', {
   existing: true,
   e: \\"css-1aj1g6z\\",
   target: \\"e8nbyc50\\"
+}, otherArg, 'test', {
+  anotherArg: 1
 })();
 
 
@@ -469,6 +471,8 @@ styled('button', {
   existing: true,
   target: \\"e8nbyc50\\",
   label: \\"Button\\"
+}, otherArg, 'test', {
+  anotherArg: 1
 })({
   color: 'blue'
 });"
@@ -811,7 +815,7 @@ const Button = /*#__PURE__*/styled('button', {
   existing: true,
   label: 'Button',
   target: 'e8nbyc50'
-})('color:blue;');"
+}, otherArg, 'test', { anotherArg: 1 })('color:blue;');"
 `;
 
 exports[`styled inline babel 6 existing options object 1`] = `
@@ -820,7 +824,7 @@ const Button = /*#__PURE__*/styled('button', {
   existing: true,
   target: 'e8nbyc50',
   label: 'Button'
-})({
+}, otherArg, 'test', { anotherArg: 1 })({
   color: 'blue'
 });"
 `;
@@ -1100,6 +1104,8 @@ styled('button', {
   existing: true,
   label: \\"Button\\",
   target: \\"e8nbyc50\\"
+}, otherArg, 'test', {
+  anotherArg: 1
 })(\\"color:blue;\\");"
 `;
 
@@ -1110,6 +1116,8 @@ styled('button', {
   existing: true,
   target: \\"e8nbyc50\\",
   label: \\"Button\\"
+}, otherArg, 'test', {
+  anotherArg: 1
 })({
   color: 'blue'
 });"

--- a/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
@@ -110,6 +110,17 @@ emotion.emotion.css
 .css-1aj1g6z{color:blue;}"
 `;
 
+exports[`styled extract babel 6 existing options object 1`] = `
+"
+const Button = /*#__PURE__*/styled('button', {
+  existing: true,
+  target: 'e8nbyc50',
+  label: 'Button'
+})({
+  color: 'blue'
+});"
+`;
+
 exports[`styled extract babel 6 function call 1`] = `
 "/*#__PURE__*/styled(MyComponent, {
   target: 'e8nbyc50'
@@ -449,6 +460,18 @@ const Button = styled('button', {
 
 emotion.emotion.css
 .css-1aj1g6z{color:blue;}"
+`;
+
+exports[`styled extract babel 7 existing options object 1`] = `
+"const Button =
+/*#__PURE__*/
+styled('button', {
+  existing: true,
+  target: \\"e8nbyc50\\",
+  label: \\"Button\\"
+})({
+  color: 'blue'
+});"
 `;
 
 exports[`styled extract babel 7 function call 1`] = `
@@ -791,6 +814,17 @@ const Button = /*#__PURE__*/styled('button', {
 })('color:blue;');"
 `;
 
+exports[`styled inline babel 6 existing options object 1`] = `
+"
+const Button = /*#__PURE__*/styled('button', {
+  existing: true,
+  target: 'e8nbyc50',
+  label: 'Button'
+})({
+  color: 'blue'
+});"
+`;
+
 exports[`styled inline babel 6 function call 1`] = `
 "/*#__PURE__*/styled(MyComponent, {
   target: 'e8nbyc50'
@@ -1067,6 +1101,18 @@ styled('button', {
   label: \\"Button\\",
   target: \\"e8nbyc50\\"
 })(\\"color:blue;\\");"
+`;
+
+exports[`styled inline babel 7 existing options object 1`] = `
+"const Button =
+/*#__PURE__*/
+styled('button', {
+  existing: true,
+  target: \\"e8nbyc50\\",
+  label: \\"Button\\"
+})({
+  color: 'blue'
+});"
 `;
 
 exports[`styled inline babel 7 function call 1`] = `

--- a/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
@@ -100,6 +100,7 @@ exports[`styled extract babel 6 existing options 1`] = `
 "require('./emotion.emotion.css');
 
 const Button = styled('button', {
+  existing: true,
   e: 'css-1aj1g6z',
   target: 'e8nbyc50'
 })();
@@ -440,6 +441,7 @@ exports[`styled extract babel 7 existing options 1`] = `
 "require(\\"./emotion.emotion.css\\");
 
 const Button = styled('button', {
+  existing: true,
   e: \\"css-1aj1g6z\\",
   target: \\"e8nbyc50\\"
 })();

--- a/packages/babel-plugin-emotion/test/styled.test.js
+++ b/packages/babel-plugin-emotion/test/styled.test.js
@@ -301,6 +301,17 @@ const cases = {
   'hash generation no file system': {
     code: 'styled.h1`color:blue;`',
     filename: ''
+  },
+
+  'existing options': {
+    code: `
+      const Button = styled('button', {
+        existing: true,
+      })\`
+        color: blue;
+      \`
+    `,
+    opts: { autoLabel: true }
   }
 }
 

--- a/packages/babel-plugin-emotion/test/styled.test.js
+++ b/packages/babel-plugin-emotion/test/styled.test.js
@@ -307,7 +307,7 @@ const cases = {
     code: `
       const Button = styled('button', {
         existing: true,
-      })\`
+      }, otherArg, 'test', { anotherArg: 1 })\`
         color: blue;
       \`
     `,
@@ -318,7 +318,7 @@ const cases = {
     code: `
       const Button = styled('button', {
         existing: true,
-      })({
+      }, otherArg, 'test', { anotherArg: 1 })({
         color: 'blue'
       })
     `,

--- a/packages/babel-plugin-emotion/test/styled.test.js
+++ b/packages/babel-plugin-emotion/test/styled.test.js
@@ -312,6 +312,18 @@ const cases = {
       \`
     `,
     opts: { autoLabel: true }
+  },
+
+  'existing options object': {
+    code: `
+      const Button = styled('button', {
+        existing: true,
+      })({
+        color: 'blue'
+      })
+    `,
+    extract: false,
+    opts: { autoLabel: true }
   }
 }
 


### PR DESCRIPTION
fixes #582

**What**:

Preserving existing options passed to styled calls when using emotion's babel plugin

**Why**:

It would ease creating custom emotion wrappers.

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
- [ ] Documentation
- [x] Tests
- [x] Code complete

TODO:
- [ ] fix flow typings - I'd appreciate help with this, dunno why they are not compatible atm
- [x] handle more cases (like `buildStyledObjectCallExpression`)
- [x] decide what about rest of the arguments, they are lost at the moment too, should we preserve them?