### PR TITLE
Carry styles from flattened components with withComponent

### DIFF
--- a/packages/create-emotion-styled/src/index.js
+++ b/packages/create-emotion-styled/src/index.js
@@ -158,7 +158,7 @@ function createEmotionStyled(emotion: Emotion, view: ReactType) {
             ? // $FlowFixMe
               omitAssign(testAlwaysTrue, {}, options, nextOptions)
             : options
-        )(...args)
+        )(...styles)
       }
 
       return Styled

--- a/packages/react-emotion/test/__snapshots__/index.test.js.snap
+++ b/packages/react-emotion/test/__snapshots__/index.test.js.snap
@@ -796,8 +796,9 @@ exports[`styled with higher order component that hoists statics 1`] = `
 />
 `;
 
-exports[`styled withComponent does not carry styles from flattened component 1`] = `
+exports[`styled withComponent carries styles from flattened components 1`] = `
 .emotion-0 {
+  color: green;
   color: hotpink;
 }
 

--- a/packages/react-emotion/test/index.test.js
+++ b/packages/react-emotion/test/index.test.js
@@ -1109,7 +1109,7 @@ describe('styled', () => {
       .toJSON()
     expect(tree).toMatchSnapshot()
   })
-  test('withComponent does not carry styles from flattened component', () => {
+  test('withComponent carries styles from flattened components', () => {
     const SomeComponent = styled.div`
       color: green;
     `


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Carry styles from flattened components with withComponent

<!-- Why are these changes necessary? -->
**Why**:

Closes #587 
Closes #571 

I changed this behavior when I was working on v9 because I thought it was unexpected and if you wrap a styled component in another component it won't work but people seem to like so ¯\\\_(ツ)_/¯ 
<!-- How were these changes implemented? -->
**How**:

Spread `styles`(which includes styles from flattened styled components) instead of `args` onto styled call in `withComponent`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
