### PR TITLE
Add localIdent option to support same scenario as css-loader (WIP)

### DIFF
--- a/packages/babel-plugin-emotion/src/babel-utils.js
+++ b/packages/babel-plugin-emotion/src/babel-utils.js
@@ -92,14 +92,6 @@ export function addRuntimeImports(state: EmotionMacroPluginPass, t: Types) {
     state.emotionImports = undefined
   }
 }
-export function getName(identifierName?: string, prefix: string) {
-  const parts = []
-  parts.push(prefix)
-  if (identifierName) {
-    parts.push(identifierName)
-  }
-  return parts.join('-')
-}
 
 export function getLabel(
   identifierName?: string,

--- a/packages/babel-plugin-emotion/src/index.js
+++ b/packages/babel-plugin-emotion/src/index.js
@@ -98,7 +98,8 @@ export function replaceCssWithCallExpression(
   t: Types,
   staticCSSSrcCreator: (src: string, name: string) => string = src => src,
   removePath: boolean = false,
-  localIdentName?: string
+  localIdentName?: string,
+  getLocalIdent?: Function
 ) {
   try {
     let { hash, src } = createRawStringFromTemplateLiteral(path.node.quasi)
@@ -117,6 +118,10 @@ export function replaceCssWithCallExpression(
       )
         .replace(new RegExp('[^a-zA-Z0-9\\-_\u00A0-\uFFFF]', 'g'), '-')
         .replace(/^((-?[0-9])|--)/, '_$1')
+    }
+
+    if (typeof getLocalIdent !== 'undefined') {
+      generatedIdentName = getLocalIdent(generatedIdentName, identifierName);
     }
 
     // backwards compatibility so we don't break anything
@@ -721,7 +726,8 @@ export default function(babel: Babel) {
               t,
               src => src,
               false,
-              state.opts.localIdentName
+              state.opts.localIdentName,
+              state.opts.getLocalIdent
             )
           } else if (path.node.tag.name === state.importedNames.keyframes) {
             replaceCssWithCallExpression(
@@ -729,7 +735,8 @@ export default function(babel: Babel) {
               path.node.tag,
               state,
               t,
-              (src, name) => `@keyframes ${name} { ${src} }`
+              (src, name) => `@keyframes ${name} { ${src} }`,
+              state.opts.getLocalIdent
             )
           } else if (path.node.tag.name === state.importedNames.injectGlobal) {
             replaceCssWithCallExpression(
@@ -739,7 +746,8 @@ export default function(babel: Babel) {
               t,
               undefined,
               true,
-              ''
+              '',
+              state.opts.getLocalIdent
             )
           }
         }

--- a/packages/babel-plugin-emotion/src/index.js
+++ b/packages/babel-plugin-emotion/src/index.js
@@ -487,6 +487,8 @@ export default function(babel: Babel) {
             // path.hub.file.opts.filename !== 'unknown' ||
             state.opts.extractStatic
 
+          state.outputDir = state.opts.outputDir
+
           state.staticRules = []
 
           state.insertStaticRules = function(staticRules) {

--- a/packages/babel-plugin-emotion/src/index.js
+++ b/packages/babel-plugin-emotion/src/index.js
@@ -7,7 +7,6 @@ import { touchSync } from 'touch'
 import { addSideEffect } from '@babel/helper-module-imports'
 import {
   getIdentifierName,
-  getName,
   createRawStringFromTemplateLiteral,
   minify,
   getLabel
@@ -67,35 +66,74 @@ export type EmotionBabelPluginPass = BabelPluginPass & {
   opts: any
 }
 
+/**
+ * this function gives you the ability to change the generated css selector
+ * from the babel plugin, it's based on
+ */
+function getLocalIdentName(
+  filePath: string,
+  localName: string,
+  hash: string,
+  localIdentName: string
+) {
+  const parsedPath = nodePath.parse(filePath)
+  const directory = parsedPath.dir
+    .replace(/\\/g, '/')
+    .replace(/\.\.(\/)?/g, '_$1')
+  const filename = parsedPath.name
+  const ext = parsedPath.ext
+
+  return localIdentName
+    .replace('[path]', directory)
+    .replace('[name]', filename)
+    .replace('[hash]', hash)
+    .replace('[local]', localName)
+    .replace('[ext]', ext)
+}
+
 export function replaceCssWithCallExpression(
   path: BabelPath,
   identifier: Identifier,
   state: EmotionBabelPluginPass,
   t: Types,
-  staticCSSSrcCreator: (
-    src: string,
-    name: string,
-    hash: string
-  ) => string = src => src,
+  staticCSSSrcCreator: (src: string, name: string) => string = src => src,
   removePath: boolean = false,
-  staticCSSSelectorCreator: (name: string, hash: string) => string = (
-    name,
-    hash
-  ) => `.${name}-${hash}`
+  localIdentName?: string
 ) {
   try {
     let { hash, src } = createRawStringFromTemplateLiteral(path.node.quasi)
     const identifierName = getIdentifierName(path, t)
-    const name = getName(identifierName, 'css')
+
+    let generatedIdentName = ''
+    if (localIdentName) {
+      const fileName = path.hub.file.opts.generatorOpts
+        ? path.hub.file.opts.generatorOpts.sourceFileName
+        : path.hub.file.opts.sourceFileName
+      generatedIdentName = getLocalIdentName(
+        fileName,
+        identifierName,
+        hash,
+        localIdentName
+      )
+        .replace(new RegExp('[^a-zA-Z0-9\\-_\u00A0-\uFFFF]', 'g'), '-')
+        .replace(/^((-?[0-9])|--)/, '_$1')
+    }
+
+    // backwards compatibility so we don't break anything
+    if (typeof localIdentName === 'undefined') {
+      generatedIdentName = ['css', identifierName, hash]
+        .filter(Boolean)
+        .join('-')
+    }
 
     if (state.extractStatic && !path.node.quasi.expressions.length) {
       const staticCSSRules = staticStylis(
-        staticCSSSelectorCreator(name, hash),
-        staticCSSSrcCreator(src, name, hash)
+        `${generatedIdentName ? '.' : ''}${generatedIdentName}`,
+        staticCSSSrcCreator(src, generatedIdentName)
       )
       state.insertStaticRules([staticCSSRules])
       if (!removePath) {
-        return path.replaceWith(t.stringLiteral(`${name}-${hash}`))
+        return path.replaceWith(t.stringLiteral(generatedIdentName))
       }
       return path.replaceWith(t.identifier('undefined'))
     }
@@ -676,16 +714,22 @@ export default function(babel: Babel) {
             path.node.tag.name === state.importedNames.css ||
             state.cssPropIdentifiers.indexOf(path.node.tag) !== -1
           ) {
-            replaceCssWithCallExpression(path, path.node.tag, state, t)
+            replaceCssWithCallExpression(
+              path,
+              path.node.tag,
+              state,
+              t,
+              src => src,
+              false,
+              state.opts.localIdentName
+            )
           } else if (path.node.tag.name === state.importedNames.keyframes) {
             replaceCssWithCallExpression(
               path,
               path.node.tag,
               state,
               t,
-              (src, name, hash) => `@keyframes ${name}-${hash} { ${src} }`,
-              false,
-              () => ''
+              (src, name) => `@keyframes ${name} { ${src} }`
             )
           } else if (path.node.tag.name === state.importedNames.injectGlobal) {
             replaceCssWithCallExpression(
@@ -695,7 +739,7 @@ export default function(babel: Babel) {
               t,
               undefined,
               true,
-              () => ''
+              ''
             )
           }
         }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
I'm adding a feature to choose how the babel plugin exports css classes to an external stylesheet. It's based on the code from [css-loader from webpack](https://github.com/webpack-contrib/css-loader/tree/master).

<!-- Why are these changes necessary? -->
**Why**: I want my classnames to be unique the way I want them to be. I don't want to change my classNames when I change something in the file

<!-- How were these changes implemented? -->
**How**:
Added localIdentName to babel options so we can change the generated identifier. By default it fallbacks to the old scenario so this isn't a breaking change.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Code complete

<!-- feel free to add additional comments -->
Just wanted some feedback if you're willing to add this feature.

This makes it possible to generate classes like `components-header--headerClass`

I would also like to add a `getLocalIdent` function where you can generate it inside babelrc. This will only work with babel 7 where babelrc can be a js file.