### PR TITLE
save results from stylis in emotion cache

### DIFF
--- a/extract.test.emotion.css
+++ b/extract.test.emotion.css
@@ -1,0 +1,5 @@
+.css-dae0kw{font-size:12px;}
+.css-s9f816{font-size:20px;}.css-s9f816 span{color:blue;}.css-s9f816 span:hover{color:green;}.css-s9f816 span:hover:after{content:'after';}
+.css-mdajr1{font-size:20px;}
+html{background:pink;}
+.css-14yvnlz{font-family:sans-serif;color:yellow;background-color:purple;}

--- a/packages/create-emotion/src/index.js
+++ b/packages/create-emotion/src/index.js
@@ -249,15 +249,15 @@ function createEmotion(
     stylis = (selector, styles) => {
       const result = sourceMapRegEx.exec(styles)
       currentSourceMap = result ? result[0] : ''
-      oldStylis(selector, styles)
+      let processedStyles
+      processedStyles = oldStylis(selector, styles)
       currentSourceMap = ''
+      return processedStyles
     }
   }
   function insert(scope, styles) {
     if (caches.inserted[name] === undefined) {
-      current = ''
-      stylis(scope, styles)
-      caches.inserted[name] = current
+      caches.inserted[name] = stylis(scope, styles)
     }
   }
   const css: CreateStyles<string> = function css() {

--- a/packages/create-emotion/src/index.js
+++ b/packages/create-emotion/src/index.js
@@ -76,10 +76,8 @@ function createEmotion(
   }
   // $FlowFixMe
   let caches: EmotionCaches = context.__SECRET_EMOTION__
-  let current
 
   function insertRule(rule: string) {
-    current += rule
     if (isBrowser) {
       sheet.insert(rule, currentSourceMap)
     }


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Save stylis results to emotion cache.

<!-- Why are these changes necessary? -->
**Why**: to fix #598 

<!-- How were these changes implemented? -->
**How**: See the original issue for details.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests
- [x] Code complete

~~Not sure if I need tests for this.~~ Currently working on fixing the tests.

I can't help but wonder if I'm simply mis-understanding things and the authors had a good reason for writing it the way they did.  Please comment if there's a better way to do this.
