### PR TITLE
Add defaultProps using the options argument in `styled`

### DIFF
--- a/docs/styled.md
+++ b/docs/styled.md
@@ -4,7 +4,6 @@ title: "Styled Components"
 
 `styled` is a way to create React or Preact components that have styles attached to them. It's available from [react-emotion](/packages/react-emotion) and [preact-emotion](/packages/preact-emotion). `styled` was heavily inspired by [styled-components](https://www.styled-components.com/) and [glamorous](https://glamorous.rocks/)
 
-
 ### Styling elements and components
 
 `styled` is very similar to `css` except you call it with an html tag or React/Preact component and then call that with a template literal for string styles or a regular function call for object styles.
@@ -48,26 +47,6 @@ render(
 )
 ```
 
-### Default Props
-
-Default props can be set via the second argument of `styled`. 
-
-`this.props` is merged with and overwrites any overlapping keys in `defaultProps`.  
-
-*Does not work with shorthand syntax*
-
-```jsx live
-const MyComponent = styled('input', {
-  props: {
-    'type': 'checkbox'
-  }
-})({
-  height: 40,
-  width: 40,
-  color: 'green'
-})
-```
-
 ### Styling any component
 
 `styled` can style any component as long as it accepts a `className` prop.
@@ -84,7 +63,6 @@ const Fancy = styled(Basic)`
 
 render(<Fancy />)
 ```
-
 
 ### `withComponent`
 

--- a/docs/styled.md
+++ b/docs/styled.md
@@ -4,6 +4,7 @@ title: "Styled Components"
 
 `styled` is a way to create React or Preact components that have styles attached to them. It's available from [react-emotion](/packages/react-emotion) and [preact-emotion](/packages/preact-emotion). `styled` was heavily inspired by [styled-components](https://www.styled-components.com/) and [glamorous](https://glamorous.rocks/)
 
+
 ### Styling elements and components
 
 `styled` is very similar to `css` except you call it with an html tag or React/Preact component and then call that with a template literal for string styles or a regular function call for object styles.
@@ -47,6 +48,26 @@ render(
 )
 ```
 
+### Default Props
+
+Default props can be set via the second argument of `styled`. 
+
+`this.props` is merged with and overwrites any overlapping keys in `defaultProps`.  
+
+*Does not work with shorthand syntax*
+
+```jsx live
+const MyComponent = styled('input', {
+  props: {
+    'type': 'checkbox'
+  }
+})({
+  height: 40,
+  width: 40,
+  color: 'green'
+})
+```
+
 ### Styling any component
 
 `styled` can style any component as long as it accepts a `className` prop.
@@ -65,9 +86,9 @@ render(<Fancy />)
 ```
 
 
-### Change the rendered tag using `withComponent`
+### `withComponent`
 
-Sometimes you want to create some styles with one component but then use those styles again with another component, the `withComponent` method can be used for this. This was inspired by [styled-components' `withComponent`](https://www.styled-components.com/docs/api#withcomponent).
+Change the underlying tag of the styled component.
 
 ```jsx live
 // Create a section element
@@ -76,12 +97,6 @@ const Section = styled('section')`
 `
 // Create an aside element with the same styles as Section
 const Aside = Section.withComponent('aside')
-render(
-  <div>
-    <Section>This is a section</Section>
-    <Aside>This is an an aside</Aside>
-  </div>
-)
 ```
 
 ### Targeting another emotion component

--- a/docs/with-props.md
+++ b/docs/with-props.md
@@ -2,18 +2,32 @@
 title: "Attaching Props"
 ---
 
-Sometimes it's useful to create components that already have props applied, like the example below with a password input. You use recompose's `withProps` higher-order component to do this.
-
-**[`withProps` documentation](https://github.com/acdlite/recompose/blob/master/docs/API.md#withprops)**
+Sometimes it's useful to create components that already have props applied, like the example below with a checkbox. You can use `.withProps` to do this. `this.props` is merged with and overwrites any overlapping keys from `withProps` except for classNames from withProps which are merged.
 
 ```jsx live
-import withProps from 'recompose/withProps'
+import styled from 'react-emotion'
 
-const RedPasswordInput = withProps({
-  type: 'password'
-})(styled('input')`
-  background-color: red;
-`)
+const MyCheckbox = styled('input')`
+  height: 40px;
+  width: 40px;
+  color: green;
+`.withProps({
+  type: 'checkbox'
+})
+
+render(<MyCheckbox />)
+```
+
+`withProps` also accepts a function that recieves props.
+
+```jsx live
+import styled from 'react-emotion'
+
+const Input = styled('input')`
+  background-color: ${props => props.password && 'red'};
+`.withProps(
+  props => (props.password ? { type: 'password' } : {})
+)
 
 render(<RedPasswordInput />)
 ```

--- a/packages/create-emotion-styled/src/index.js
+++ b/packages/create-emotion-styled/src/index.js
@@ -25,10 +25,13 @@ function createEmotionStyled(emotion: Emotion, view: ReactType) {
     let staticClassName
     let identifierName
     let stableClassName
+    let defaultProps
+
     if (options !== undefined) {
       staticClassName = options.e
       identifierName = options.label
       stableClassName = options.target
+      defaultProps = options.props
     }
     const isReal = tag.__emotion_real === tag
     const baseTag =
@@ -85,7 +88,9 @@ function createEmotionStyled(emotion: Emotion, view: ReactType) {
           }
         }
         render() {
-          const { props, state } = this
+          const state = this.state
+          const props = Object.assign({}, defaultProps, this.props)
+
           this.mergedProps = omitAssign(testAlwaysTrue, {}, props, {
             theme: (state !== null && state.theme) || props.theme || {}
           })

--- a/packages/react-emotion/test/__snapshots__/index.test.js.snap
+++ b/packages/react-emotion/test/__snapshots__/index.test.js.snap
@@ -615,43 +615,6 @@ exports[`styled objects with spread properties 1`] = `
 </figure>
 `;
 
-exports[`styled option: props: { className } 1`] = `
-.emotion-0 {
-  color: blue;
-}
-
-<h1
-  className="blue emotion-0 emotion-1"
->
-  hello world
-</h1>
-`;
-
-exports[`styled option: props: { data- } 1`] = `
-.emotion-0 {
-  color: blue;
-}
-
-<h1
-  aria-label="blue"
-  className="emotion-0 emotion-1"
->
-  hello world
-</h1>
-`;
-
-exports[`styled option: props: { random } 1`] = `
-.emotion-0 {
-  color: blue;
-}
-
-<h1
-  className="emotion-0 emotion-1"
->
-  hello world
-</h1>
-`;
-
 exports[`styled prop filtering 1`] = `
 .emotion-0 {
   color: green;
@@ -921,4 +884,92 @@ exports[`styled withComponent with function interpolation 1`] = `
     </h2>
   </Styled(h2)>
 </article>
+`;
+
+exports[`styled withProps { className } 1`] = `
+.emotion-0 {
+  color: blue;
+}
+
+<h1
+  className="blue other emotion-0 emotion-1"
+>
+  hello world
+</h1>
+`;
+
+exports[`styled withProps { data- } 1`] = `
+.emotion-0 {
+  color: blue;
+}
+
+<h1
+  aria-label="blue"
+  className="emotion-0 emotion-1"
+>
+  hello world
+</h1>
+`;
+
+exports[`styled withProps { random } 1`] = `
+.emotion-0 {
+  color: blue;
+}
+
+<h1
+  className="emotion-0 emotion-1"
+>
+  hello world
+</h1>
+`;
+
+exports[`styled withProps component flattening 1`] = `
+.emotion-0 {
+  color: yellow;
+  color: hotpink;
+}
+
+<h1
+  className="emotion-0 emotion-1"
+  style={
+    Object {
+      "color": "hotpink",
+    }
+  }
+>
+  hello world
+</h1>
+`;
+
+exports[`styled withProps component flattening with multiple withProps 1`] = `
+.emotion-0 {
+  color: yellow;
+  color: hotpink;
+}
+
+<h1
+  className="emotion-0 emotion-1"
+  label="something"
+  style={
+    Object {
+      "color": "hotpink",
+    }
+  }
+>
+  hello world
+</h1>
+`;
+
+exports[`styled withProps function 1`] = `
+.emotion-0 {
+  color: yellow;
+}
+
+<h1
+  aria-label="something"
+  className="emotion-0 emotion-1"
+  label="something"
+>
+  hello world
+</h1>
 `;

--- a/packages/react-emotion/test/__snapshots__/index.test.js.snap
+++ b/packages/react-emotion/test/__snapshots__/index.test.js.snap
@@ -590,6 +590,43 @@ exports[`styled objects with spread properties 1`] = `
 </figure>
 `;
 
+exports[`styled option: props: { className } 1`] = `
+.emotion-0 {
+  color: blue;
+}
+
+<h1
+  className="blue emotion-0 emotion-1"
+>
+  hello world
+</h1>
+`;
+
+exports[`styled option: props: { data- } 1`] = `
+.emotion-0 {
+  color: blue;
+}
+
+<h1
+  aria-label="blue"
+  className="emotion-0 emotion-1"
+>
+  hello world
+</h1>
+`;
+
+exports[`styled option: props: { random } 1`] = `
+.emotion-0 {
+  color: blue;
+}
+
+<h1
+  className="emotion-0 emotion-1"
+>
+  hello world
+</h1>
+`;
+
 exports[`styled prop filtering 1`] = `
 .emotion-0 {
   color: green;

--- a/packages/react-emotion/test/index.test.js
+++ b/packages/react-emotion/test/index.test.js
@@ -82,7 +82,7 @@ describe('styled', () => {
 
   test('inline function return value is a function', () => {
     const fontSize = () => 20
-    const Blue = styled('h1') `
+    const Blue = styled('h1')`
       font-size: ${() => fontSize}px;
     `
 
@@ -93,7 +93,7 @@ describe('styled', () => {
 
   test('call expression', () => {
     const fontSize = 20
-    const Div = styled('div') `
+    const Div = styled('div')`
       font-size: ${fontSize}px;
     `
 
@@ -149,7 +149,7 @@ describe('styled', () => {
       }
     `
 
-    const H1 = styled('h1') `
+    const H1 = styled('h1')`
       ${mq};
       ${props =>
         props.prop &&
@@ -172,7 +172,7 @@ describe('styled', () => {
   })
 
   test('random expressions undefined return', () => {
-    const H1 = styled('h1') `
+    const H1 = styled('h1')`
       ${props =>
         props.prop &&
         css`
@@ -217,11 +217,11 @@ describe('styled', () => {
 
   test('composition', () => {
     const fontSize = 20
-    const H1 = styled('h1') `
+    const H1 = styled('h1')`
       font-size: ${fontSize + 'px'};
     `
 
-    const H2 = styled(H1) `
+    const H2 = styled(H1)`
       font-size: ${fontSize * 2 / 3 + 'px'};
     `
 
@@ -274,7 +274,7 @@ describe('styled', () => {
       { border: '3px solid currentColor' }
     ])
 
-    const Avatar = styled('img') `
+    const Avatar = styled('img')`
       ${prettyStyles};
       ${imageStyles};
       ${blue};
@@ -286,7 +286,7 @@ describe('styled', () => {
   })
 
   test('handles more than 10 dynamic properties', () => {
-    const H1 = styled('h1') `
+    const H1 = styled('h1')`
       text-decoration: ${'underline'};
       border-right: solid blue 54px;
       background: ${'white'};
@@ -314,11 +314,11 @@ describe('styled', () => {
 
   test('function in expression', () => {
     const fontSize = 20
-    const H1 = styled('h1') `
+    const H1 = styled('h1')`
       font-size: ${fontSize + 'px'};
     `
 
-    const H2 = styled(H1) `
+    const H2 = styled(H1)`
       font-size: ${({ scale }) => fontSize * scale + 'px'};
     `
 
@@ -345,13 +345,13 @@ describe('styled', () => {
       color: red;
     `
 
-    const BlueH1 = styled('h1') `
+    const BlueH1 = styled('h1')`
       ${cssB};
       color: blue;
       font-size: ${fontSize};
     `
 
-    const FinalH2 = styled(BlueH1) `
+    const FinalH2 = styled(BlueH1)`
       font-size: 32px;
     `
 
@@ -380,12 +380,12 @@ describe('styled', () => {
       height: 64px;
     `
 
-    const H1 = styled('h1') `
+    const H1 = styled('h1')`
       ${cssB};
       font-size: ${modularScale(4)};
     `
 
-    const H2 = styled(H1) `
+    const H2 = styled(H1)`
       font-size: 32px;
     `
 
@@ -429,17 +429,17 @@ describe('styled', () => {
       height: 64px;
     `
 
-    const Heading = styled('span') `
+    const Heading = styled('span')`
       background-color: ${p => p.theme.gold};
     `
 
-    const H1 = styled(Heading) `
+    const H1 = styled(Heading)`
       ${cssB};
       font-size: ${fontSize};
       color: ${p => p.theme.purple};
     `
 
-    const H2 = styled(H1) `
+    const H2 = styled(H1)`
       font-size: 32px;
     `
 
@@ -455,7 +455,7 @@ describe('styled', () => {
 
   test('higher order component', () => {
     const fontSize = 20
-    const Content = styled('div') `
+    const Content = styled('div')`
       font-size: ${fontSize}px;
     `
 
@@ -464,7 +464,7 @@ describe('styled', () => {
     `
 
     const flexColumn = Component => {
-      const NewComponent = styled(Component) `
+      const NewComponent = styled(Component)`
         ${squirtleBlueBackground};
         background-color: '#343a40';
         flex-direction: column;
@@ -489,7 +489,7 @@ describe('styled', () => {
       color: green;
     `
 
-    const H1 = styled('h1') `
+    const H1 = styled('h1')`
       ${props => (props.a ? cssA : cssB)};
     `
 
@@ -562,11 +562,11 @@ describe('styled', () => {
     const Button = styled.button`
       color: green;
     `
-    const OtherButton = styled(Button) `
+    const OtherButton = styled(Button)`
       display: none;
     `
 
-    const AnotherButton = styled(OtherButton) `
+    const AnotherButton = styled(OtherButton)`
       display: flex;
       justify-content: center;
     `
@@ -642,7 +642,7 @@ describe('styled', () => {
       display: flex;
       color: ${props => props.someProp};
     `)
-    const FinalComponent = styled(SomeComponent) `
+    const FinalComponent = styled(SomeComponent)`
       padding: 8px;
     `
     const tree = renderer.create(<FinalComponent />).toJSON()
@@ -678,7 +678,7 @@ describe('styled', () => {
     expect(tree).toMatchSnapshot()
   })
   test('no prop filtering on non string tags', () => {
-    const Link = styled(props => <a {...props} />) `
+    const Link = styled(props => <a {...props} />)`
       color: green;
     `
 
@@ -705,7 +705,7 @@ describe('styled', () => {
   })
 
   test('no prop filtering on string tags started with upper case', () => {
-    const Link = styled('SomeCustomLink') `
+    const Link = styled('SomeCustomLink')`
       color: green;
     `
 
@@ -732,7 +732,7 @@ describe('styled', () => {
   })
 
   test('basic SVG attributes survive prop filtering', () => {
-    const RedCircle = styled('circle') `
+    const RedCircle = styled('circle')`
       fill: #ff0000;
       stroke-width: 0.26458332;
     `
@@ -990,7 +990,7 @@ describe('styled', () => {
       zoomAndPan: 'abcd'
     }
 
-    const RedPath = styled('path') `
+    const RedPath = styled('path')`
       stroke-width: 0.26458332;
     `
 
@@ -1007,7 +1007,7 @@ describe('styled', () => {
     const BaseLink = styled.a`
       background-color: hotpink;
     `
-    const Link = styled(BaseLink) `
+    const Link = styled(BaseLink)`
       color: green;
     `
 
@@ -1035,13 +1035,13 @@ describe('styled', () => {
   test('throws if undefined is passed as the component', () => {
     expect(
       () =>
-        styled(undefined) `
+        styled(undefined)`
           display: flex;
         `
     ).toThrowErrorMatchingSnapshot()
   })
   test('withComponent will replace tags but keep styling classes', () => {
-    const Title = styled('h1') `
+    const Title = styled('h1')`
       color: green;
     `
     const Subtitle = Title.withComponent('h2')
@@ -1056,7 +1056,7 @@ describe('styled', () => {
     expect(enzymeToJson(wrapper)).toMatchSnapshot()
   })
   test('withComponent with function interpolation', () => {
-    const Title = styled('h1') `
+    const Title = styled('h1')`
       color: ${props => props.color || 'green'};
     `
     const Subtitle = Title.withComponent('h2')
@@ -1077,7 +1077,7 @@ describe('styled', () => {
         return <div className={this.props.className} />
       }
     }
-    const StyledComponent = styled(SomeComponent) `
+    const StyledComponent = styled(SomeComponent)`
       color: hotpink;
     `
     const wrapper = mount(<StyledComponent />)
@@ -1113,7 +1113,7 @@ describe('styled', () => {
     const SomeComponent = styled.div`
       color: green;
     `
-    const AnotherComponent = styled(SomeComponent) `
+    const AnotherComponent = styled(SomeComponent)`
       color: hotpink;
     `
     const OneMoreComponent = AnotherComponent.withComponent('p')
@@ -1121,32 +1121,71 @@ describe('styled', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('option: props: { className }', () => {
-    const H1 = styled('h1', { props: { className: 'blue' } }) `
+  test('withProps { className }', () => {
+    const H1 = styled.h1`
       color: blue;
-    `
+    `.withProps({ className: 'blue' })
+
+    const tree = renderer
+      .create(<H1 className="other">hello world</H1>)
+      .toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('withProps { data- }', () => {
+    const H1 = styled.h1`
+      color: blue;
+    `.withProps({ 'aria-label': 'blue' })
 
     const tree = renderer.create(<H1>hello world</H1>).toJSON()
 
     expect(tree).toMatchSnapshot()
   })
 
-  test('option: props: { data- }', () => {
-    const H1 = styled('h1', { props: { 'aria-label': 'blue' } }) `
+  test('withProps { random }', () => {
+    const H1 = styled.h1`
       color: blue;
-    `
+    `.withProps({ random: 'blue' })
 
     const tree = renderer.create(<H1>hello world</H1>).toJSON()
-
     expect(tree).toMatchSnapshot()
   })
 
-  test('option: props: { random }', () => {
-    const H1 = styled('h1', { props: { random: 'blue' } }) `
-      color: blue;
+  test('withProps component flattening', () => {
+    const _H1 = styled.h1`
+      color: yellow;
+    `.withProps({ style: { color: 'hotpink' } })
+
+    const H1 = styled(_H1)`
+      color: hotpink;
     `
 
     const tree = renderer.create(<H1>hello world</H1>).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('withProps component flattening with multiple withProps', () => {
+    const _H1 = styled.h1`
+      color: yellow;
+    `.withProps({ style: { color: 'hotpink' } })
+
+    const H1 = styled(_H1)`
+      color: hotpink;
+    `.withProps({ label: 'something' })
+
+    const tree = renderer.create(<H1>hello world</H1>).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('withProps function', () => {
+    const H1 = styled.h1`
+      color: yellow;
+    `.withProps(props => ({ 'aria-label': props.label }))
+
+    const tree = renderer
+      .create(<H1 label="something">hello world</H1>)
+      .toJSON()
     expect(tree).toMatchSnapshot()
   })
 
@@ -1166,7 +1205,7 @@ describe('styled', () => {
     const StyledSvg = styled(Svg, {
       shouldForwardProp: prop =>
         ['className', 'width', 'height'].indexOf(prop) !== -1
-    }) `
+    })`
       &,
       & * {
         fill: ${({ color }) => color};

--- a/packages/react-emotion/test/index.test.js
+++ b/packages/react-emotion/test/index.test.js
@@ -1120,4 +1120,34 @@ describe('styled', () => {
     const tree = renderer.create(<OneMoreComponent />).toJSON()
     expect(tree).toMatchSnapshot()
   })
+
+  test('option: props: { className }', () => {
+    const H1 = styled('h1', { props: { className: 'blue' } })`
+      color: blue;
+    `
+
+    const tree = renderer.create(<H1>hello world</H1>).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('option: props: { data- }', () => {
+    const H1 = styled('h1', { props: { 'aria-label': 'blue' } })`
+      color: blue;
+    `
+
+    const tree = renderer.create(<H1>hello world</H1>).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  test('option: props: { random }', () => {
+    const H1 = styled('h1', { props: { random: 'blue' } })`
+      color: blue;
+    `
+
+    const tree = renderer.create(<H1>hello world</H1>).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3524,14 +3524,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.6.0:
-  version "15.6.3"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 cross-env@^3.1.1:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-3.2.4.tgz#9e0585f277864ed421ce756f81a980ff0d698aba"
@@ -11032,16 +11024,7 @@ react-dev-utils@^4.2.1:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-react-dom@^15.6.0:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
-
-react-dom@^16.0.0, react-dom@^16.2.0:
+react-dom@^15.6.0, react-dom@^16.0.0, react-dom@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
   dependencies:
@@ -11155,17 +11138,7 @@ react-test-renderer@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react@^15.6.0:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
-  dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
-
-react@^16.0.0, react@^16.2.0:
+react@^15.6.0, react@^16.0.0, react@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
   dependencies:


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
You can specify default props in the options argument of `styled`

```javascript
const MyComponent = styled('input', {
  props: {
    'type': 'checkbox'
  }
})({
  height: 40,
  width: 40,
  color: 'green'
})
```

<!-- Why are these changes necessary? -->
**Why**:
I got annoyed.

<!-- How were these changes implemented? -->
**How**:
I did a simple merge in `render`. I may be missing something obvious but this should work fine.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
