### PR TITLE
Add a failing test case for jest-emotion with nested selectors

### DIFF
--- a/packages/jest-emotion/test/printer.test.js
+++ b/packages/jest-emotion/test/printer.test.js
@@ -101,7 +101,7 @@ describe('jest-emotion with nested selectors', () => {
     }
   `
 
-  it('replaces class names and inserts styles into React test component snapshots', () => {
+  it.skip('replaces class names and inserts styles into React test component snapshots', () => {
     const tree = renderer.create(<div className={divStyle} />).toJSON()
 
     const output = prettyFormat(tree, {

--- a/packages/jest-emotion/test/printer.test.js
+++ b/packages/jest-emotion/test/printer.test.js
@@ -89,3 +89,35 @@ describe('jest-emotion with DOM elements disabled', () => {
     expect(output).toMatchSnapshot()
   })
 })
+
+describe('jest-emotion with nested selectors', () => {
+  const emotionPlugin = createSerializer(emotion)
+
+  const divStyle = emotion.css`
+    color: blue;
+
+    header & {
+      color: 'red';
+    }
+  `
+
+  it('replaces class names and inserts styles into React test component snapshots', () => {
+    const tree = renderer.create(<div className={divStyle} />).toJSON()
+
+    const output = prettyFormat(tree, {
+      plugins: [emotionPlugin, ReactElement, ReactTestComponent, DOMElement]
+    })
+
+    expect(output).toBe(`.emotion-0 {
+  color: blue;
+}
+
+header .emotion-0 {
+  color: red;
+}
+
+<div
+  className="emotion-0"
+/>`)
+  })
+})


### PR DESCRIPTION
**What**: This adds a failing test case to illustrate a bug with jest-emotion with regard to nested selectors. It is not ready to merge.

**Why**:  The jest-emotion serializer seemingly is misbehaving when it attempts to serialize nested selectors.

**How**:
The test case is roughly printing this snippet -

```jsx
<div className={css(`
  color: blue;

  header & {
    color: 'red';
  }
`)} />
```

And expects to get this as the output:

```
.emotion-0 {
  color: blue;
}

header .emotion-0 {
  color: red;
}

<div
  className="emotion-0"
/>
```

However, the nested selector is missing from the output.

**Checklist**:
- [ ] Documentation (N/A)
- [X] Tests
- [ ] Code complete
