### PR TITLE
Forward .defaultProps when reusing __emotion_base

### DIFF
--- a/packages/create-emotion-styled/src/index.js
+++ b/packages/create-emotion-styled/src/index.js
@@ -140,6 +140,10 @@ function createEmotionStyled(emotion: Emotion, view: ReactType) {
                 : baseTag.displayName || baseTag.name || 'Component'
             })`
 
+      if (tag.defaultProps !== undefined) {
+        // $FlowFixMe
+        Styled.defaultProps = tag.defaultProps
+      }
       Styled.contextTypes = contextTypes
       Styled.__emotion_styles = styles
       Styled.__emotion_base = baseTag

--- a/packages/react-emotion/test/__snapshots__/index.test.js.snap
+++ b/packages/react-emotion/test/__snapshots__/index.test.js.snap
@@ -678,6 +678,30 @@ exports[`styled random object expression 1`] = `
 </h1>
 `;
 
+exports[`styled should forward .defaultProps when reusing __emotion_base 1`] = `
+.emotion-0 {
+  text-align: center;
+  color: red;
+}
+
+.emotion-2 {
+  text-align: center;
+  color: red;
+  font-style: italic;
+}
+
+<div>
+  <h1
+    className="emotion-0 emotion-1"
+    color="red"
+  />
+  <h1
+    className="emotion-2 emotion-3"
+    color="red"
+  />
+</div>
+`;
+
 exports[`styled theme prop exists without ThemeProvider 1`] = `
 .emotion-0 {
   color: green;

--- a/packages/react-emotion/test/index.test.js
+++ b/packages/react-emotion/test/index.test.js
@@ -1148,4 +1148,31 @@ describe('styled', () => {
       .toJSON()
     expect(tree).toMatchSnapshot()
   })
+
+  test('should forward .defaultProps when reusing __emotion_base', () => {
+    const Title = styled('h1')`
+      text-align: center;
+      ${props => ({
+        color: props.color
+      })};
+    `
+
+    Title.defaultProps = {
+      color: 'red'
+    }
+
+    const Title2 = styled(Title)`
+      font-style: italic;
+    `
+
+    const tree = renderer
+      .create(
+        <div>
+          <Title />
+          <Title2 />
+        </div>
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
fixes #654 

I feel though that we should figure out more holistic approach as `.defaultProps` is only part of the problem - any other config (i.e. `shouldForwardProp`) will get lost too when reusing `__emotion_base`. This should act like `.withComponent` in this regard.

Thoughts?