### PR TITLE
Add TS typings to create-emotion

### DIFF
--- a/packages/create-emotion/package.json
+++ b/packages/create-emotion/package.json
@@ -28,7 +28,7 @@
     "babel-cli": "^6.24.1",
     "babel-plugin-transform-define": "^1.3.0",
     "cross-env": "^5.0.5",
-    "dtslint": "^0.2.0",
+    "dtslint": "^0.3.0",
     "npm-run-all": "^4.0.2",
     "rimraf": "^2.6.1",
     "rollup": "^0.51.3"

--- a/packages/create-emotion/package.json
+++ b/packages/create-emotion/package.json
@@ -4,6 +4,7 @@
   "description": "The Next Generation of CSS-in-JS.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
+  "types": "types/index.d.ts",
   "files": [
     "src",
     "dist",
@@ -12,6 +13,7 @@
   "scripts": {
     "build": "npm-run-all clean rollup",
     "clean": "rimraf dist",
+    "test:typescript": "dtslint types",
     "rollup": "rollup -c ../../rollup.config.js",
     "watch": "rollup -c ../../rollup.config.js --watch"
   },
@@ -20,6 +22,7 @@
     "@emotion/memoize": "^0.6.1",
     "@emotion/stylis": "^0.6.5",
     "@emotion/unitless": "^0.6.2",
+    "csstype": "^2.5.2",
     "stylis": "^3.5.0",
     "stylis-rule-sheet": "^0.0.10"
   },

--- a/packages/create-emotion/types/index.d.ts
+++ b/packages/create-emotion/types/index.d.ts
@@ -6,30 +6,25 @@ import * as CSS from 'csstype';
 export interface MultiDimensionalArray<T> extends Array<T | MultiDimensionalArray<T>> {}
 
 export type CSSBaseObject = CSS.PropertiesFallback<number | string>;
-export type CSSPseudoObject<C> = { [K in CSS.Pseudos]?: CSSObject<C> };
-export interface CSSOthersObject<C> {
-  [propertiesName: string]: Interpolation<C>;
+export type CSSPseudoObject = { [K in CSS.Pseudos]?: CSSObject };
+export interface CSSOthersObject {
+  [propertiesName: string]: Interpolation;
 }
-export interface CSSObject<C> extends CSSBaseObject, CSSPseudoObject<C>, CSSOthersObject<C> {}
+export interface CSSObject extends CSSBaseObject, CSSPseudoObject, CSSOthersObject {}
 
-export type FunctionInterpolation<C> = (mergedProps: any, context: C) => Interpolation<C> | void;
+export interface ArrayInterpolation extends Array<Interpolation> {}
 
-export interface ArrayInterpolation<C> extends Array<Interpolation<C>> {}
-
-export type Interpolation<C> =
+export type Interpolation =
   | undefined | null | boolean | string | number
-  | CSSObject<C>
-  | ArrayInterpolation<C>
-  | FunctionInterpolation<C>
+  | CSSObject
+  | ArrayInterpolation
   ;
 
-export type FunctionClassNameArg = () => ClassNameArg | void;
 export interface ArrayClassNameArg extends Array<ClassNameArg> {}
 
 export type ClassNameArg =
   | undefined | null | boolean | string
   | { [key: string]: boolean }
-  | FunctionClassNameArg
   | ArrayClassNameArg
   ;
 
@@ -51,21 +46,25 @@ export interface EmotionCache {
   key: string;
 }
 
-export interface Emotion<C> {
+export interface Emotion {
   flush(): void;
   hydrate(ids: Array<string>): void;
   cx(...classNames: Array<ClassNameArg>): string;
   merge(className: string, sourceMap?: string): string;
   getRegisteredStyles(registeredStyles: Array<string>, classNames: string): string;
-  css(...args: Array<Interpolation<C>>): string;
-  injectGlobal(...args: Array<Interpolation<C>>): void;
-  keyframes(...args: Array<Interpolation<C>>): string;
+  css(...args: Array<Interpolation>): string;
+  injectGlobal(...args: Array<Interpolation>): void;
+  keyframes(...args: Array<Interpolation>): string;
   sheet: StyleSheet;
   caches: EmotionCache;
 }
 
-export interface EmotionBaseContext<C> {
-  __SECRET_EMOTION__?: Emotion<C>;
+export interface EmotionBaseContext {
+  __SECRET_EMOTION__?: Emotion;
+}
+
+export interface EmotionContext extends EmotionBaseContext {
+  [key: string]: any;
 }
 
 export type StylisPlugins =
@@ -82,4 +81,4 @@ export interface EmotionOption {
   container?: HTMLElement;
 }
 
-export default function createEmotion<C extends EmotionBaseContext<C>>(context: C, options?: EmotionOption): Emotion<C>;
+export default function createEmotion(context: EmotionContext, options?: EmotionOption): Emotion;

--- a/packages/create-emotion/types/index.d.ts
+++ b/packages/create-emotion/types/index.d.ts
@@ -1,0 +1,85 @@
+// Definitions by: Junyoung Clare Jang <https://github.com/Ailrun>
+// TypeScript Version: 2.3
+
+import * as CSS from 'csstype';
+
+export interface MultiDimensionalArray<T> extends Array<T | MultiDimensionalArray<T>> {}
+
+export type CSSBaseObject = CSS.PropertiesFallback<number | string>;
+export type CSSPseudoObject<C> = { [K in CSS.Pseudos]?: CSSObject<C> };
+export interface CSSOthersObject<C> {
+  [propertiesName: string]: Interpolation<C>;
+}
+export interface CSSObject<C> extends CSSBaseObject, CSSPseudoObject<C>, CSSOthersObject<C> {}
+
+export type FunctionInterpolation<C> = (mergedProps: any, context: C) => Interpolation<C> | void;
+
+export interface ArrayInterpolation<C> extends Array<Interpolation<C>> {}
+
+export type Interpolation<C> =
+  | undefined | null | boolean | string | number
+  | CSSObject<C>
+  | ArrayInterpolation<C>
+  | FunctionInterpolation<C>
+  ;
+
+export type FunctionClassNameArg = () => ClassNameArg | void;
+export interface ArrayClassNameArg extends Array<ClassNameArg> {}
+
+export type ClassNameArg =
+  | undefined | null | boolean | string
+  | { [key: string]: boolean }
+  | FunctionClassNameArg
+  | ArrayClassNameArg
+  ;
+
+export interface StyleSheet {
+  inject(): void;
+  speedy(bool: boolean): void;
+  insert(rule: string, sourceMap?: string): void;
+  flush(): void;
+}
+
+export interface EmotionCache {
+  registered: {
+    [key: string]: string;
+  };
+  inserted: {
+    [key: string]: string;
+  };
+  nonce?: string;
+  key: string;
+}
+
+export interface Emotion<C> {
+  flush(): void;
+  hydrate(ids: Array<string>): void;
+  cx(...classNames: Array<ClassNameArg>): string;
+  merge(className: string, sourceMap?: string): string;
+  getRegisteredStyles(registeredStyles: Array<string>, classNames: string): string;
+  css(...args: Array<Interpolation<C>>): string;
+  injectGlobal(...args: Array<Interpolation<C>>): void;
+  keyframes(...args: Array<Interpolation<C>>): string;
+  sheet: StyleSheet;
+  caches: EmotionCache;
+}
+
+export interface EmotionBaseContext<C> {
+  __SECRET_EMOTION__?: Emotion<C>;
+}
+
+export type StylisPlugins =
+  | null
+  | ((...args: Array<any>) => any)
+  | Array<(...args: Array<any>) => any>
+  ;
+
+export interface EmotionOption {
+  nonce?: string;
+  stylisPlugins?: StylisPlugins;
+  prefix?: boolean | ((key: string, value: string, context: 1 | 2 | 3) => boolean);
+  key?: string;
+  container?: HTMLElement;
+}
+
+export default function createEmotion<C extends EmotionBaseContext<C>>(context: C, options?: EmotionOption): Emotion<C>;

--- a/packages/create-emotion/types/index.d.ts
+++ b/packages/create-emotion/types/index.d.ts
@@ -16,6 +16,7 @@ export interface ArrayInterpolation extends Array<Interpolation> {}
 
 export type Interpolation =
   | undefined | null | boolean | string | number
+  | TemplateStringsArray
   | CSSObject
   | ArrayInterpolation
   ;

--- a/packages/create-emotion/types/tests.tsx
+++ b/packages/create-emotion/types/tests.tsx
@@ -1,5 +1,13 @@
 import createEmotion from '../';
 
+const emotion0 = createEmotion({
+  x: 5,
+});
+const emotion1 = createEmotion({
+  y: 4,
+  __SECRET_EMOTION__: emotion0,
+});
+
 const {
   flush,
   hydrate,
@@ -48,13 +56,6 @@ css([]);
 css([1]);
 css([['abc', 'asdf'], 'efw']);
 
-css(() => {
-  return 1;
-});
-css((a: number, b: {}) => {
-  return 1;
-});
-
 css({
   ':active': {
     borderRadius: '2px',
@@ -69,16 +70,6 @@ css({
 css(true, true);
 css('fa', 1123);
 css(['123'], 'asdf');
-css('fa', () => {
-});
-css('pa--emp', () => {
-  return null;
-});
-css('squid', () => {
-  return ['other-squid', {
-    alignSelf: 'middle',
-  }];
-});
 
 injectGlobal();
 injectGlobal(30);

--- a/packages/create-emotion/types/tests.tsx
+++ b/packages/create-emotion/types/tests.tsx
@@ -47,6 +47,14 @@ getRegisteredStyles([], 'abc');
 getRegisteredStyles(['abc'], 'bcd');
 getRegisteredStyles([], 'abc def fpfw');
 
+css`
+  height: 20px;
+`;
+css`
+  color: ${'green'};
+  font-size: ${10 + 4}px;
+`;
+
 css();
 css(1);
 css('abc');

--- a/packages/create-emotion/types/tests.tsx
+++ b/packages/create-emotion/types/tests.tsx
@@ -1,0 +1,127 @@
+import createEmotion from '../';
+
+const {
+  flush,
+  hydrate,
+  cx,
+  merge,
+  getRegisteredStyles,
+  css,
+  injectGlobal,
+  keyframes,
+  sheet,
+  caches,
+} = createEmotion({});
+
+flush();
+
+hydrate([]);
+hydrate(['123']);
+
+cx();
+cx(undefined);
+cx(null);
+cx(true);
+cx('123');
+cx('123', null, 'pf');
+cx({
+  abc: false,
+  fp: true,
+});
+cx([]);
+cx(['cl', {
+  fp: true,
+}]);
+
+merge('abc def fpfp');
+
+getRegisteredStyles([], 'abc');
+getRegisteredStyles(['abc'], 'bcd');
+getRegisteredStyles([], 'abc def fpfw');
+
+css();
+css(1);
+css('abc');
+css(true);
+
+css([]);
+css([1]);
+css([['abc', 'asdf'], 'efw']);
+
+css(() => {
+  return 1;
+});
+css((a: number, b: {}) => {
+  return 1;
+});
+
+css({
+  ':active': {
+    borderRadius: '2px',
+    overflowAnchor: 'none',
+    clear: ['both', 'left'],
+  },
+  '::before': {
+    borderRadius: '2px',
+  },
+});
+
+css(true, true);
+css('fa', 1123);
+css(['123'], 'asdf');
+css('fa', () => {
+});
+css('pa--emp', () => {
+  return null;
+});
+css('squid', () => {
+  return ['other-squid', {
+    alignSelf: 'middle',
+  }];
+});
+
+injectGlobal();
+injectGlobal(30);
+injectGlobal('this-is-class');
+injectGlobal({});
+injectGlobal([{
+  animationDelay: '200ms',
+}]);
+
+keyframes();
+keyframes({
+  from: {
+    marginLeft: '100%',
+  },
+  to: {
+    marginLeft: '50%',
+  },
+});
+keyframes([{
+  from: {
+    marginLeft: '100%',
+  },
+  to: {
+    marginLeft: '50%',
+  },
+}, {
+  '0%': {
+    width: '100px',
+  },
+  '50%': {
+    width: '50px',
+  },
+  '100%': {
+    width: '120px',
+  },
+}]);
+
+sheet.flush();
+sheet.inject();
+sheet.insert('');
+sheet.speedy(false);
+
+caches.inserted;
+caches.key;
+caches.nonce;
+caches.registered;

--- a/packages/create-emotion/types/tsconfig.json
+++ b/packages/create-emotion/types/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "baseUrl": "../",
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "lib": [
+      "es6",
+      "dom"
+    ],
+    "module": "commonjs",
+    "noEmit": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "target": "es5",
+    "typeRoots": [
+      "../"
+    ],
+    "types": []
+  },
+  "include": [
+    "./*.ts",
+    "./*.tsx"
+  ]
+}

--- a/packages/create-emotion/types/tslint.json
+++ b/packages/create-emotion/types/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dtslint.json",
+    "rules": {
+      "no-relative-import-in-test": false,
+      "array-type": [true, "generic"]
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3805,6 +3805,10 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
+csstype@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.2.tgz#4534308476ceede8fbe148b9b99f9baf1c80fa06"
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,6 +877,12 @@ ansi-styles@^3.0.0, ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
+
 ansi-wrap@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
@@ -2804,6 +2810,14 @@ chalk@^2.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+chalk@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 change-emitter@^0.1.2:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
@@ -3175,6 +3189,10 @@ commander@2.9.0, commander@2.9.x:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+commander@^2.12.1:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
 commander@~2.8.1:
   version "2.8.1"
@@ -4274,6 +4292,16 @@ dtslint@^0.2.0:
     fs-promise "^2.0.0"
     strip-json-comments "^2.0.1"
     tslint "^5.4.2"
+    typescript next
+
+dtslint@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/dtslint/-/dtslint-0.3.0.tgz#918e664a6f7e1f54ba22088daa2bc6e64a6001c1"
+  dependencies:
+    definitelytyped-header-parser Microsoft/definitelytyped-header-parser#production
+    fs-promise "^2.0.0"
+    strip-json-comments "^2.0.1"
+    tslint "^5.9.1"
     typescript next
 
 duplexer2@0.0.2:
@@ -6487,6 +6515,10 @@ has-flag@^1.0.0:
 has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
 has-gulplog@^0.1.0:
   version "0.1.0"
@@ -13261,6 +13293,12 @@ supports-color@^4.2.1, supports-color@^4.4.0:
   dependencies:
     has-flag "^2.0.0"
 
+supports-color@^5.3.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
+
 svg-tag-names@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/svg-tag-names/-/svg-tag-names-1.1.1.tgz#9641b29ef71025ee094c7043f7cdde7d99fbd50a"
@@ -13780,6 +13818,10 @@ tslib@^1.7.1:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.0.tgz#dc604ebad64bcbf696d613da6c954aa0e7ea1eb6"
 
+tslib@^1.8.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.1.tgz#a5d1f0532a49221c87755cfcc89ca37197242ba7"
+
 tslint@^5.4.2:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.8.0.tgz#1f49ad5b2e77c76c3af4ddcae552ae4e3612eb13"
@@ -13794,6 +13836,23 @@ tslint@^5.4.2:
     resolve "^1.3.2"
     semver "^5.3.0"
     tslib "^1.7.1"
+    tsutils "^2.12.1"
+
+tslint@^5.9.1:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.10.0.tgz#11e26bccb88afa02dd0d9956cae3d4540b5f54c3"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.3.0"
+    commander "^2.12.1"
+    diff "^3.2.0"
+    glob "^7.1.1"
+    js-yaml "^3.7.0"
+    minimatch "^3.0.4"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.8.0"
     tsutils "^2.12.1"
 
 tsutils@^2.12.1:


### PR DESCRIPTION
**What**: Add typings for create-emotion package

**Why**: To make TS user be able to use create-emotion package.

**How**: Using [csstype](https://github.com/frenic/csstype) package, who crawls css data from MDN.


**Checklist**:
- [N/A] Documentation
- [x] Tests
- [x] Code complete

I'm willing to add more strict typing (and the typing providing helpful autocompletions) for emotion package, but I think I should add typings for create-emotion, to avoid repeated code and revesed dependencies between typings.