### PR TITLE
Add typing for create-emotion-styled

### DIFF
--- a/packages/create-emotion-styled/package.json
+++ b/packages/create-emotion-styled/package.json
@@ -22,6 +22,7 @@
     "prop-types": ">= 15"
   },
   "devDependencies": {
+    "dtslint": "^0.3.0",
     "npm-run-all": "^4.0.2",
     "prop-types": "^15.6.0",
     "rimraf": "^2.6.1",

--- a/packages/create-emotion-styled/package.json
+++ b/packages/create-emotion-styled/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "npm-run-all clean rollup",
     "clean": "rimraf dist",
+    "test:typescript": "dtslint types",
     "rollup": "rollup -c ../../rollup.config.js",
     "watch": "rollup -c ../../rollup.config.js --watch"
   },

--- a/packages/create-emotion-styled/package.json
+++ b/packages/create-emotion-styled/package.json
@@ -22,6 +22,7 @@
     "prop-types": ">= 15"
   },
   "devDependencies": {
+    "@types/react": "16.0.16",
     "dtslint": "^0.3.0",
     "npm-run-all": "^4.0.2",
     "prop-types": "^15.6.0",

--- a/packages/create-emotion-styled/types/index.d.ts
+++ b/packages/create-emotion-styled/types/index.d.ts
@@ -17,7 +17,7 @@ export interface StyledOptions {
   e?: string;
   label?: string;
   target?: string;
-  shouldForwardProp?: (name?: string) => boolean;
+  shouldForwardProp?: (name: string) => boolean;
 }
 
 export type Themed<P extends object, T> = P & { theme: T };

--- a/packages/create-emotion-styled/types/index.d.ts
+++ b/packages/create-emotion-styled/types/index.d.ts
@@ -1,0 +1,101 @@
+// Definitions by: Junyoung Clare Jang <https://github.com/Ailrun>
+// TypeScript Version: 2.3
+
+import { Emotion, Interpolation as BaseInterpolation } from 'create-emotion';
+import React, { ComponentClass, ReactHTML, ReactSVG, Ref, SFC } from 'react';
+
+export interface ArrayInterpolation<Props> extends Array<Interpolation<Props>> {}
+export type FunctionInterpolation<Props> = (props: Props, context: any) => Interpolation<Props>;
+
+export type Interpolation<Props> =
+  | BaseInterpolation
+  | ArrayInterpolation<Props>
+  | FunctionInterpolation<Props>
+  ;
+
+export interface StyledOptions {
+  e?: string;
+  label?: string;
+  target?: string;
+  shouldForwardProp?: (name?: string) => boolean;
+}
+
+export type Themed<P extends object, T> = P & { theme: T };
+
+export type StyledStatelessComponentProps<P extends object, T> =
+  & P
+  & { theme?: T }
+  ;
+export type StyledOtherComponentProps<P extends object, T> =
+  & StyledStatelessComponentProps<P, T>
+  & { innerRef?: Ref<any> }
+  ;
+
+export interface StyledComponentMethods<Props extends object, InnerProps extends object, Theme> {
+  withComponent<T extends keyof ReactHTML>(
+    tag: T,
+    options?: StyledOptions,
+  ): StyledOtherComponent<Props, ReactHTML[T], Theme>;
+
+  withComponent<T extends keyof ReactSVG>(
+    tag: T,
+    options?: StyledOptions,
+  ): StyledOtherComponent<Props, ReactSVG[T], Theme>;
+
+  withComponent<IP extends object>(
+    component: SFC<IP>,
+    options?: StyledOptions,
+  ): StyledStatelessComponent<Props, IP, Theme>;
+
+  withComponent<IP extends object>(
+    component: ComponentClass<IP>,
+    options?: StyledOptions,
+  ): StyledOtherComponent<Props, IP, Theme>;
+}
+
+export interface StyledStatelessComponent<Props extends object, InnerProps extends object, Theme>
+  extends ComponentClass<StyledStatelessComponentProps<Props & InnerProps, Theme>>,
+    StyledComponentMethods<Props, InnerProps, Theme> {}
+
+export interface StyledOtherComponent<Props extends object, InnerProps extends object, Theme>
+  extends ComponentClass<StyledOtherComponentProps<Props & InnerProps, Theme>>,
+    StyledComponentMethods<Props, InnerProps, Theme> {}
+
+export type StyledComponent<Props extends object, InnerProps extends object, Theme> =
+  | StyledStatelessComponent<Props, InnerProps, Theme>
+  | StyledOtherComponent<Props, InnerProps, Theme>
+  ;
+
+export type CreateStyledStatelessComponent<InnerProps extends object, Theme> =
+  <Props extends object, OverridedTheme = Theme>(
+    ...args: Array<Interpolation<Themed<Props, OverridedTheme>>>
+  ) => StyledStatelessComponent<Props, InnerProps, OverridedTheme>;
+
+export type CreateStyledOtherComponent<InnerProps extends object, Theme> =
+  <Props extends object, OverridedTheme = Theme>(
+    ...args: Array<Interpolation<Themed<Props, OverridedTheme>>>
+  ) => StyledOtherComponent<Props, InnerProps, OverridedTheme>;
+
+export interface CreateStyled<Theme = any> {
+  <T extends keyof ReactHTML>(
+    tag: T,
+    options?: StyledOptions,
+  ): CreateStyledOtherComponent<ReactHTML[T], Theme>;
+
+  <T extends keyof ReactSVG>(
+    tag: T,
+    options?: StyledOptions,
+  ): CreateStyledOtherComponent<ReactSVG[T], Theme>;
+
+  <IP extends object>(
+    component: SFC<IP>,
+    options?: StyledOptions,
+  ): CreateStyledStatelessComponent<IP, Theme>;
+
+  <IP extends object>(
+    component: ComponentClass<IP>,
+    options?: StyledOptions,
+  ): CreateStyledOtherComponent<IP, Theme>;
+}
+
+export default function createEmotionStyled(emotion: Emotion, view: typeof React): CreateStyled;

--- a/packages/create-emotion-styled/types/index.d.ts
+++ b/packages/create-emotion-styled/types/index.d.ts
@@ -20,18 +20,18 @@ export interface StyledOptions {
   shouldForwardProp?: (name: string) => boolean;
 }
 
-export type Themed<P extends object, T> = P & { theme: T };
+export type Themed<P extends object, T extends object> = P & { theme: T };
 
-export type StyledStatelessComponentProps<P extends object, T> =
+export type StyledStatelessComponentProps<P extends object, T extends object> =
   & P
   & { theme?: T }
   ;
-export type StyledOtherComponentProps<P extends object, T> =
+export type StyledOtherComponentProps<P extends object, T extends object> =
   & StyledStatelessComponentProps<P, T>
   & { innerRef?: Ref<any> }
   ;
 
-export interface StyledComponentMethods<Props extends object, InnerProps extends object, Theme> {
+export interface StyledComponentMethods<Props extends object, InnerProps extends object, Theme extends object> {
   withComponent<T extends keyof ReactHTML>(
     tag: T,
     options?: StyledOptions,
@@ -53,30 +53,30 @@ export interface StyledComponentMethods<Props extends object, InnerProps extends
   ): StyledOtherComponent<Props, IP, Theme>;
 }
 
-export interface StyledStatelessComponent<Props extends object, InnerProps extends object, Theme>
+export interface StyledStatelessComponent<Props extends object, InnerProps extends object, Theme extends object>
   extends ComponentClass<StyledStatelessComponentProps<Props & InnerProps, Theme>>,
     StyledComponentMethods<Props, InnerProps, Theme> {}
 
-export interface StyledOtherComponent<Props extends object, InnerProps extends object, Theme>
+export interface StyledOtherComponent<Props extends object, InnerProps extends object, Theme extends object>
   extends ComponentClass<StyledOtherComponentProps<Props & InnerProps, Theme>>,
     StyledComponentMethods<Props, InnerProps, Theme> {}
 
-export type StyledComponent<Props extends object, InnerProps extends object, Theme> =
+export type StyledComponent<Props extends object, InnerProps extends object, Theme extends object> =
   | StyledStatelessComponent<Props, InnerProps, Theme>
   | StyledOtherComponent<Props, InnerProps, Theme>
   ;
 
-export type CreateStyledStatelessComponent<InnerProps extends object, Theme> =
-  <Props extends object, OverridedTheme = Theme>(
+export type CreateStyledStatelessComponent<InnerProps extends object, Theme extends object> =
+  <Props extends object, OverridedTheme extends object = Theme>(
     ...args: Array<Interpolation<Themed<Props, OverridedTheme>>>
   ) => StyledStatelessComponent<Props, InnerProps, OverridedTheme>;
 
-export type CreateStyledOtherComponent<InnerProps extends object, Theme> =
-  <Props extends object, OverridedTheme = Theme>(
+export type CreateStyledOtherComponent<InnerProps extends object, Theme extends object> =
+  <Props extends object, OverridedTheme extends object = Theme>(
     ...args: Array<Interpolation<Themed<Props, OverridedTheme>>>
   ) => StyledOtherComponent<Props, InnerProps, OverridedTheme>;
 
-export interface CreateStyled<Theme = any> {
+export interface CreateStyled<Theme extends object = any> {
   <T extends keyof ReactHTML>(
     tag: T,
     options?: StyledOptions,

--- a/packages/create-emotion-styled/types/test.tsx
+++ b/packages/create-emotion-styled/types/test.tsx
@@ -24,7 +24,7 @@ class TestClassComp extends React.Component<TestClassProps> {
   }
 }
 
-interface TestFunProps {
+interface TestFunProps0 {
   complex: {
     readonly id: number;
     name: string;
@@ -32,34 +32,39 @@ interface TestFunProps {
   };
 }
 
-const TestFunComp = (props: TestFunProps) => (
+const TestFunComp0 = (props: TestFunProps0) => (
   <div>
     {props.complex.friends.map((fid) => <div>{fid}</div>)}
   </div>
 );
 
-interface TestFunProps2 extends TestFunProps {
+interface TestFunProps1 extends TestFunProps0 {
   world: number;
 }
 
-const TestFunComp2 = (props: TestFunProps2) => (
+const TestFunComp1 = (props: TestFunProps1) => (
   <div>
     {props.world}
-    <TestFunComp complex={props.complex} />
+    <TestFunComp0 complex={props.complex} />
   </div>
 );
 
-const StyledClassComp = createStyled(TestClassComp)({
+const StyledClassComp0 = createStyled(TestClassComp)({
   width: '200px',
 }, (props) => ({
   height: props.theme ? '200px' : '100px',
 }));
 
+const StyledClassComp1 = createStyled(TestClassComp)`
+  width: 200px;
+  height: ${(props) => props.theme ? '200px' : '100px'};
+`;
+
 interface StyledFunProps {
   color: string;
 }
 
-const StyledFunComp = createStyled(TestFunComp)<StyledFunProps>([{
+const StyledFunComp0 = createStyled(TestFunComp0)<StyledFunProps>([{
   display: 'inline',
   position: 'fixed',
 }, {
@@ -70,7 +75,18 @@ const StyledFunComp = createStyled(TestFunComp)<StyledFunProps>([{
   color: props.color,
 }));
 
-const StyledCompWithButton = StyledClassComp.withComponent('button');
-const StyledCompWithFunComp2 = StyledFunComp.withComponent(TestFunComp2);
+const StyledFunComp1 = createStyled(TestFunComp0)`
+  display: inline;
+  position: fixed;
+  flexGrow: 20;
+  ${(props: StyledFunProps, context) => `
+    content: ${context.name};
+
+    color: ${props.color};
+  `}
+`;
+
+const StyledCompWithButton = StyledClassComp0.withComponent('button');
+const StyledCompWithFunComp2 = StyledFunComp0.withComponent(TestFunComp1);
 
 <StyledCompWithButton />;

--- a/packages/create-emotion-styled/types/test.tsx
+++ b/packages/create-emotion-styled/types/test.tsx
@@ -52,7 +52,7 @@ const TestFunComp1 = (props: TestFunProps1) => (
 const StyledClassComp0 = createStyled(TestClassComp)({
   width: '200px',
 }, (props) => ({
-  height: props.theme ? '200px' : '100px',
+  height: props.theme.long ? '200px' : '100px',
 }));
 
 const StyledClassComp1 = createStyled(TestClassComp)`

--- a/packages/create-emotion-styled/types/test.tsx
+++ b/packages/create-emotion-styled/types/test.tsx
@@ -7,7 +7,8 @@ const context = {
   name: 'emotion',
 };
 
-const createStyled = createEmotionStyled(createEmotion(context), React);
+const emotion = createEmotion(context);
+const createStyled = createEmotionStyled(emotion, React);
 
 interface TestClassProps {
   readonly some: number;
@@ -79,7 +80,7 @@ const StyledFunComp1 = createStyled(TestFunComp0)`
   display: inline;
   position: fixed;
   flexGrow: 20;
-  ${(props: StyledFunProps, context) => `
+  ${(props: StyledFunProps, context) => emotion.css`
     content: ${context.name};
 
     color: ${props.color};

--- a/packages/create-emotion-styled/types/test.tsx
+++ b/packages/create-emotion-styled/types/test.tsx
@@ -1,0 +1,76 @@
+import createEmotion from 'create-emotion';
+import React from 'react';
+
+import createEmotionStyled, { StyledComponent } from '../';
+
+const context = {
+  name: 'emotion',
+};
+
+const createStyled = createEmotionStyled(createEmotion(context), React);
+
+interface TestClassProps {
+  readonly some: number;
+  partial?: boolean;
+}
+
+class TestClassComp extends React.Component<TestClassProps> {
+  render() {
+    return (
+      <div>
+        {this.props.some}
+      </div>
+    );
+  }
+}
+
+interface TestFunProps {
+  complex: {
+    readonly id: number;
+    name: string;
+    friends: Array<number>;
+  };
+}
+
+const TestFunComp = (props: TestFunProps) => (
+  <div>
+    {props.complex.friends.map((fid) => <div>{fid}</div>)}
+  </div>
+);
+
+interface TestFunProps2 extends TestFunProps {
+  world: number;
+}
+
+const TestFunComp2 = (props: TestFunProps2) => (
+  <div>
+    {props.world}
+    <TestFunComp complex={props.complex} />
+  </div>
+);
+
+const StyledClassComp = createStyled(TestClassComp)({
+  width: '200px',
+}, (props) => ({
+  height: props.theme ? '200px' : '100px',
+}));
+
+interface StyledFunProps {
+  color: string;
+}
+
+const StyledFunComp = createStyled(TestFunComp)<StyledFunProps>([{
+  display: 'inline',
+  position: 'fixed',
+}, {
+  flexGrow: 20,
+}], (props, context) => ({
+  content: context.name,
+
+  color: props.color,
+}));
+
+const StyledCompWithButton = StyledClassComp.withComponent('button');
+const StyledCompWithFunComp2 = StyledFunComp.withComponent(TestFunComp2);
+
+<StyledCompWithButton />;

--- a/packages/create-emotion-styled/types/tsconfig.json
+++ b/packages/create-emotion-styled/types/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": "../",
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "lib": [
+      "es6",
+      "dom"
+    ],
+    "module": "commonjs",
+    "noEmit": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "target": "es5",
+    "typeRoots": [
+      "../"
+    ],
+    "types": []
+  },
+  "include": [
+    "./*.ts",
+    "./*.tsx"
+  ]
+}

--- a/packages/create-emotion-styled/types/tslint.json
+++ b/packages/create-emotion-styled/types/tslint.json
@@ -1,0 +1,8 @@
+{
+    "extends": "dtslint/dtslint.json",
+    "rules": {
+        "array-type": [true, "generic"],
+        "no-import-default-of-export-equals": false,
+        "no-relative-import-in-test": false
+    }
+}


### PR DESCRIPTION
**What**: Add typing for create-emotion-styled package

**Why**: To allow TS users to use create-emotion-styled

**How**: By consulting with glamorous typing and old react-emotion typing

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [N/A] Documentation
- [ ] Tests
- [ ] Code complete

I'm not sure this is complete typing. Could you give me more idea for testing? What usecases did I miss?

After typing for this package is completed and #667 is merged without complex problems, I want to fix `react-emotion` typing and add `preact-emotion` typing.