### PR TITLE
Add ClassInterpolation to typings

### DIFF
--- a/packages/create-emotion-styled/types/react.d.ts
+++ b/packages/create-emotion-styled/types/react.d.ts
@@ -2,6 +2,7 @@
 // TypeScript Version: 2.3
 
 import React, { ComponentClass, Ref, SFC } from 'react';
+import { ClassInterpolation } from 'create-emotion';
 
 import {
   Interpolation,
@@ -30,10 +31,12 @@ export interface StyledComponentMethods<Props extends object, InnerProps extends
 
 export interface StyledStatelessComponent<Props extends object, InnerProps extends object, Theme extends object>
   extends ComponentClass<StyledStatelessProps<Props & InnerProps, Theme>>,
+    ClassInterpolation,
     StyledComponentMethods<Props, InnerProps, Theme> {}
 
 export interface StyledOtherComponent<Props extends object, InnerProps extends object, Theme extends object>
   extends ComponentClass<StyledOtherProps<Props & InnerProps, Theme, Ref<any>>>,
+    ClassInterpolation,
     StyledComponentMethods<Props, InnerProps, Theme> {}
 
 export type StyledComponent<Props extends object, InnerProps extends object, Theme extends object> =

--- a/packages/create-emotion-styled/types/test.tsx
+++ b/packages/create-emotion-styled/types/test.tsx
@@ -141,7 +141,7 @@ const StyledCompWithFunComp2 = StyledFunComp0.withComponent(TestFunComp1);
 
 const StyledCompShorthand0 = createStyled.a({
   textAlign: 'center',
-})
+});
 const StyledCompShorthand1 = createStyled.label`
   display: block;
 
@@ -168,13 +168,13 @@ const getEditorLogoColor = (editor: 'vscode' | 'emacs' | 'sublime') => {
     case 'sublime':
       return 'ff9800';
   }
-}
+};
 
 const StyledCompShorthandWithProps0 = createStyled.div<ShorthandProps>(props => ({
   backgroundColor: getEditorLogoColor(props.editor),
 }));
-const StyledCompShorthandWithProps1 = createStyled.section<ShorthandProps>`
-  backgroundColor: ${props => getEditorLogoColor(props.editor)};
+const StyledCompShorthandWithProps1 = createStyled.section`
+  backgroundColor: ${(props: ShorthandProps) => getEditorLogoColor(props.editor)};
 `;
 
 <StyledCompShorthandWithProps0 editor='emacs' />;
@@ -185,3 +185,9 @@ const StyledCompShorthandWithProps1 = createStyled.section<ShorthandProps>`
 
 // $ExpectError
 createStyled.asdf;
+
+const ComposingComp = createStyled.div`
+  ${StyledCompShorthand0} {
+    color: black;
+  }
+`;

--- a/packages/create-emotion/types/index.d.ts
+++ b/packages/create-emotion/types/index.d.ts
@@ -14,11 +14,20 @@ export interface CSSObject extends CSSBaseObject, CSSPseudoObject, CSSOthersObje
 
 export interface ArrayInterpolation extends Array<Interpolation> {}
 
+export interface ClassInterpolation extends Function {
+  __emotion_real: any;
+  __emotion_styles: Array<Interpolation>;
+  __emotion_base: ClassInterpolation;
+  __emotion_target: string;
+  __emotion_forwardProp: undefined | null | ((arg: string) => boolean);
+}
+
 export type Interpolation =
   | undefined | null | boolean | string | number
   | TemplateStringsArray
   | CSSObject
   | ArrayInterpolation
+  | ClassInterpolation
   ;
 
 export interface ArrayClassNameArg extends Array<ClassNameArg> {}


### PR DESCRIPTION
**What**: Add ClassInterpolation to typings

**Why**: Original typings do not accept class interpolations, i.e., `StyledComponent` as interpolation.

**How**: Add ClassInterpolation with private properties.

**Checklist**:
- [N/A] Documentation
- [x] Tests
- [x] Code complete

