### PR TITLE
Update yarn.lock again...

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -14168,8 +14168,8 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 typescript@next:
-  version "3.0.0-dev.20180522"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.0-dev.20180522.tgz#9c9fc115ec0c5e727d7f291325b64fd5c891c3a5"
+  version "3.0.0-dev.20180526"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.0-dev.20180526.tgz#98e2ad71ce10db18a6b2e0d350e0f739e5ae896e"
 
 ua-parser-js@^0.7.9:
   version "0.7.18"
@@ -14438,8 +14438,8 @@ upper-case@^1.1.1:
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
 uri-js@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.1.tgz#4595a80a51f356164e22970df64c7abd6ade9850"
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
   dependencies:
     punycode "^2.1.0"
 
@@ -14992,8 +14992,8 @@ which-pm-runs@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
 
 which@^1.0.9, which@^1.1.1, which@^1.2.10, which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
**What**: Update yarn.lock again

**Why**: IDK why but dtslint cannot download 2.6 again...

**How**: remove yarn.lock and reintall it.

**Checklist**:
- [N/A] Documentation
- [x] Tests
- [N/A] Code complete

