### PR TITLE
Fix typings for using components as selectors.

### DIFF
--- a/packages/react-emotion/types/index.d.ts
+++ b/packages/react-emotion/types/index.d.ts
@@ -1,6 +1,6 @@
 // TypeScript Version: 2.3
 // tslint:disable-next-line:no-implicit-dependencies
-import { StatelessComponent, ComponentClass, CSSProperties } from 'react';
+import { ReactElement, StatelessComponent, ComponentClass, ComponentType, CSSProperties } from 'react';
 import { Interpolation as EmotionInterpolation } from 'emotion';
 
 export * from 'emotion';
@@ -8,24 +8,21 @@ export * from 'emotion';
 export type InterpolationFn<Props = {}> =
   (props: Props) =>
     | EmotionInterpolation
-    | InterpolationFn<Props>;
+    | InterpolationFn<Props>
+    | ReactElement<any>;
 
 export type InterpolationTypes<Props = {}> =
   | InterpolationFn<Props>
   | EmotionInterpolation;
 
 export type Interpolation<Props = {}> =
+  | ComponentClass<any>
   | InterpolationTypes<Props>
-  | Array<InterpolationTypes<Props>>
-  | ComponentRef;
+  | Array<InterpolationTypes<Props>>;
 
 export interface Options {
   string?: string;
 }
-
-type Component<Props> =
-  | ComponentClass<Props>
-  | StatelessComponent<Props>;
 
 export type ThemedProps<Props, Theme> = Props & {
   theme: Theme,
@@ -35,24 +32,20 @@ type ElementProps<Tag extends keyof JSX.IntrinsicElements> =
   & JSX.IntrinsicElements[Tag]
   & { innerRef?: JSX.IntrinsicElements[Tag]['ref'] };
 
-// tslint:disable:no-empty-interface
-interface ComponentRef {}
-
 export interface StyledComponent<Props, Theme, IntrinsicProps>
   extends
-    ComponentRef,
     ComponentClass<Props & IntrinsicProps>,
     StatelessComponent<Props & IntrinsicProps> {
   withComponent<Tag extends keyof JSX.IntrinsicElements>(tag: Tag):
     StyledComponent<Props, Theme, ElementProps<Tag>>;
 
-  withComponent(component: Component<Props>):
+  withComponent(component: ComponentType<Props>):
     StyledComponent<Props, Theme, {}>;
 
   displayName: string;
 
   __emotion_styles: string[];
-  __emotion_base: string | Component<Props & IntrinsicProps>;
+  __emotion_base: string | ComponentType<Props & IntrinsicProps>;
   __emotion_real: ThemedReactEmotionInterface<Theme>;
 }
 
@@ -106,7 +99,7 @@ export interface ThemedReactEmotionInterface<Theme> extends ShorthandsFactories<
 
   // overload for component
   <Props, CustomProps>(
-    component: Component<Props>,
+    component: ComponentType<Props>,
     options?: Options,
     // tslint:disable-next-line:no-unnecessary-generics
   ): CreateStyled<Props & CustomProps, Theme, {}>;

--- a/packages/react-emotion/types/index.d.ts
+++ b/packages/react-emotion/types/index.d.ts
@@ -8,15 +8,18 @@ export * from 'emotion';
 export type InterpolationFn<Props = {}> =
   (props: Props) =>
     | EmotionInterpolation
-    | InterpolationFn<Props>
-    | ReactElement<any>;
+    | InterpolationFn<Props>;
+
+// This is to differentiate between a normal interpolation function and a StyledComponent because
+// a StyledComponent also extends StatelessComponent and thus also matches InterpolationFn above
+type InterpolationStyledComponent = ComponentClass<any> & { __emotion_styles: string[]; };
 
 export type InterpolationTypes<Props = {}> =
+  | InterpolationStyledComponent
   | InterpolationFn<Props>
   | EmotionInterpolation;
 
 export type Interpolation<Props = {}> =
-  | ComponentClass<any>
   | InterpolationTypes<Props>
   | Array<InterpolationTypes<Props>>;
 


### PR DESCRIPTION
**What**: Fix the typings to allow react components to be used as component selectors (fixes #685).

**Why**: Because when using Typescript 2.8.3 i get the following error:

> Argument of type 'TemplateStringsArray' is not assignable to parameter of type 'CSSProperties | { [key: string]: ObjectStyleAttributes; } | ((props: ThemedProps<RowProps, Theme>...'.
>   Type 'TemplateStringsArray' is not assignable to type '(props: ThemedProps<RowProps, Theme>) => ObjectStyleAttributes'.
>     Type 'TemplateStringsArray' provides no match for the signature '(props: ThemedProps<RowProps, Theme>): ObjectStyleAttributes'.

**How**: I added a type to the list of allowed interpolation types.

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Code complete N/A

**_Update_**: I changed it to only allow styled components and not regular (stateless) components.