### PR TITLE
Remove unused type in create-emotion typing

### DIFF
--- a/packages/create-emotion/types/index.d.ts
+++ b/packages/create-emotion/types/index.d.ts
@@ -3,8 +3,6 @@
 
 import * as CSS from 'csstype';
 
-export interface MultiDimensionalArray<T> extends Array<T | MultiDimensionalArray<T>> {}
-
 export type CSSBaseObject = CSS.PropertiesFallback<number | string>;
 export type CSSPseudoObject = { [K in CSS.Pseudos]?: CSSObject };
 export interface CSSOthersObject {


### PR DESCRIPTION
**What**: Remove unused type

**Why**: Unused type could make user confused

**How**: Remove it

**Checklist**:
- [N/A] Documentation
- [x] Tests
- [x] Code complete
