### PR TITLE
Remove allowSyntheticDefaultImports from typings

### DIFF
--- a/packages/create-emotion-styled/types/index.d.ts
+++ b/packages/create-emotion-styled/types/index.d.ts
@@ -2,7 +2,7 @@
 // TypeScript Version: 2.3
 
 import { Emotion, Interpolation as BaseInterpolation } from 'create-emotion';
-import React, { ComponentClass, ReactHTML, ReactSVG, Ref, SFC } from 'react';
+import * as React from 'react';
 
 import {
   CreateStyled,

--- a/packages/create-emotion-styled/types/react.d.ts
+++ b/packages/create-emotion-styled/types/react.d.ts
@@ -1,7 +1,7 @@
 // Definitions by: Junyoung Clare Jang <https://github.com/Ailrun>
 // TypeScript Version: 2.3
 
-import React, { ComponentClass, Ref, SFC } from 'react';
+import { ComponentClass, Ref, SFC } from 'react';
 import { ClassInterpolation } from 'create-emotion';
 
 import {

--- a/packages/create-emotion-styled/types/test.tsx
+++ b/packages/create-emotion-styled/types/test.tsx
@@ -1,5 +1,5 @@
 import createEmotion from 'create-emotion';
-import React from 'react';
+import * as React from 'react';
 
 import createEmotionStyled, { StyledComponent } from '../';
 

--- a/packages/create-emotion-styled/types/tsconfig.json
+++ b/packages/create-emotion-styled/types/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/packages/emotion-server/types/tests.tsx
+++ b/packages/emotion-server/types/tests.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { renderToNodeStream, renderToString } from 'react-dom/server';
 import { extractCritical, renderStylesToNodeStream, renderStylesToString } from '../';
 

--- a/packages/emotion-server/types/tsconfig.json
+++ b/packages/emotion-server/types/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/packages/emotion-theming/types/tests.tsx
+++ b/packages/emotion-theming/types/tests.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import * as emotionTheming from '../';
 // tslint:disable-next-line:no-duplicate-imports
 import { ThemeProvider, withTheme, EmotionThemingModule } from '../';

--- a/packages/emotion-theming/types/tsconfig.json
+++ b/packages/emotion-theming/types/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "es2015",
     "declaration": true,
     "strict": true,
-    "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
     "jsx": "react",
     "lib": ["es6"],

--- a/packages/emotion/types/tests.tsx
+++ b/packages/emotion/types/tests.tsx
@@ -11,7 +11,7 @@ import {
   caches,
 } from '../';
 // tslint:disable-next-line:no-implicit-dependencies
-import React from 'react';
+import * as React from 'react';
 
 flush();
 

--- a/packages/emotion/types/tsconfig.json
+++ b/packages/emotion/types/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/packages/preact-emotion/types/test.tsx
+++ b/packages/preact-emotion/types/test.tsx
@@ -1,6 +1,8 @@
 // tslint:disable-next-line:no-implicit-dependencies
-import Preact, { h } from 'preact';
+import * as Preact from 'preact';
 import styled, { flush, CreateStyled } from '../';
+
+const h = Preact.h;
 
 let Component;
 let mount;

--- a/packages/preact-emotion/types/tsconfig.json
+++ b/packages/preact-emotion/types/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",

--- a/packages/react-emotion/types/tests.tsx
+++ b/packages/react-emotion/types/tests.tsx
@@ -1,5 +1,5 @@
 // tslint:disable-next-line:no-implicit-dependencies
-import React from 'react';
+import * as React from 'react';
 import styled, { flush, CreateStyled } from '../';
 
 let Component;

--- a/packages/react-emotion/types/tsconfig.json
+++ b/packages/react-emotion/types/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",


### PR DESCRIPTION
**What**: #707.

**Why**: It requires users to turn on allowSyntheticDefaultImports in there tsconfig.json

**How**: Remove default import for React/Preact and change it into namespace.

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [N/A] Documentation
- [x] Tests
- [x] Code complete
