### PR TITLE
Resolve type incompatibilities with legacy type

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -71,16 +71,30 @@ const App = () => (
 ```tsx
 import styled from 'react-emotion';
 
-const NotALink = styled('div')`
+const NotALink = styled<{}, 'div'>('div')`
   color: red;
 `
 
 const Link = NotALink.withComponent('a')
 
+type TextProps = {
+  className: string;
+  text: string;
+}
+const Text = ({ className, text }: TextProps) => <div className={className}>{text}</div>
+const StyledText = styled<{}, TextProps>(Text)`
+  fontSize: 20px;
+  color: white;
+`;
+
+const OtherLink = StyledText.withComponent('a');
+
 const App = () => <Link href="#">Click me</Link>
 
 // No errors!
 ```
+
+When you use `withComponent`, you should explicitly provide the type of props used to make style. If you don't, TS will think all props for `Text` are used to make style, and request user to give all those props when using the result component of `withComponent`.
 
 ### Passing Props
 
@@ -90,26 +104,26 @@ You can type the props of styled components.
 import styled from 'react-emotion'
 
 type ImageProps = {
-  src: string,
+  src: string;
   width: number;
 }
 
-const Image0 = styled('div')`
-  width: ${(props: ImageProps) => props.width};
+const Image0 = styled<ImageProps, 'div'>('div')`
+  width: ${(props) => props.width};
   background: url(${(props: ImageProps) => props.src}) center center;
   background-size: contain;
 `
 
 // Or with object styles
 
-const Image1 = styled('div')({
+const Image1 = styled<ImageProps, 'div'>('div')({
   backgroundSize: 'contain',
-}, (props: ImageProps) => ({
+}, (props) => ({
   width: props.width;
   background: `url(${props.src}) center center`,
 }));
 
-// Or with a generic type
+// Or with a generic function
 
 const Image1 = styled('div')<ImageProps>({
   backgroundSize: 'contain',
@@ -119,7 +133,8 @@ const Image1 = styled('div')<ImageProps>({
 }));
 ```
 
-* The generic type version only works with object styles due to https://github.com/Microsoft/TypeScript/issues/11947.
+* The generic function version only works with object styles in TS <= 2.8 due to https://github.com/Microsoft/TypeScript/issues/11947.
+* If you use TS > 2.9, generic function will works with string styles too, but it will break VSCode syntax highlighting. See https://github.com/emotion-js/emotion/issues/721#issuecomment-396954993
 
 ### React Components
 
@@ -128,8 +143,8 @@ import React, { SFC } from 'react'
 import styled from 'react-emotion'
 
 type ComponentProps = {
-  className?: string,
-  label: string
+  className?: string;
+  label: string;
 }
 
 const Component: SFC<ComponentProps> = ({ label, className }) => (
@@ -158,12 +173,12 @@ const App = () => (
 import React, { SFC } from 'react'
 import styled from 'react-emotion'
 
-type ComponentProps = {
-  className?: string,
-  label: string
+type ComponentProps0 = {
+  className?: string;
+  label: string;
 }
 
-const Component: SFC<ComponentProps> = ({ label, className }) => (
+const Component0: SFC<ComponentProps0> = ({ label, className }) => (
   <div className={className}>{label}</div>
 )
 
@@ -171,12 +186,33 @@ type StyledComponentProps = {
   bgColor: string
 };
 
-const StyledComponent0 = styled(Component)`
+const StyledComponent00 = styled<StyledComponentProps, ComponentProps0>(Component)`
   color: red;
-  background: ${(props: StyledComponentProps) => props.bgColor};
+  background: ${props => props.bgColor};
 `
 
-const StyledComponent1 = styled(Component)<StyledComponentProps>({
+const StyledComponent01 = styled(Component)<StyledComponentProps>({
+  color: 'red',
+}, props => ({
+  background: props.bgColor,
+}));
+
+type ComponentProps1 = {
+  className?: string;
+  label: string;
+  bgColor: string;
+}
+
+const Component1: SFC<ComponentProps1> = ({ label, className }) => (
+  <div className={className}>{label}</div>
+)
+
+const StyledComponent10 = styled(Component)`
+  color: red;
+  background: ${props => props.bgColor}
+`
+
+const StyledComponent11 = styled(Component)({
   color: 'red',
 }, props => ({
   background: props.bgColor,
@@ -184,8 +220,10 @@ const StyledComponent1 = styled(Component)<StyledComponentProps>({
 
 const App = () => (
   <div>
-    <StyledComponent0 bgColor="red" label="Some cool text" />
-    <StyledComponent1 bgColor="red" label="Some more cool text" />
+    <StyledComponent00 bgColor="red" label="Some cool text" />
+    <StyledComponent01 bgColor="red" label="Some more cool text" />
+    <StyledComponent10 bgColor="red" label="Much more cool text" />
+    <StyledComponent11 bgColor="red" label="The most cool text" />
   </div>
 )
 ```

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -94,7 +94,7 @@ const App = () => <Link href="#">Click me</Link>
 // No errors!
 ```
 
-When you use `withComponent`, you should explicitly provide the type of props used to make style. If you don't, TS will think all props for `Text` are used to make style, and request user to give all those props when using the result component of `withComponent`.
+The prop types used to construct the resulting style definition of `withComponent` should be explicitly provided to avoid TypeScript compiler error. If you don't, TS will think all props for `Text` are used to construct style definition, and request user to give all those props when using the result component of `withComponent`.
 
 ### Passing Props
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -109,8 +109,8 @@ type ImageProps = {
 }
 
 const Image0 = styled<ImageProps, 'div'>('div')`
-  width: ${(props) => props.width};
-  background: url(${(props: ImageProps) => props.src}) center center;
+  width: ${props => props.width};
+  background: url(${props => props.src}) center center;
   background-size: contain;
 `
 
@@ -118,7 +118,7 @@ const Image0 = styled<ImageProps, 'div'>('div')`
 
 const Image1 = styled<ImageProps, 'div'>('div')({
   backgroundSize: 'contain',
-}, (props) => ({
+}, props => ({
   width: props.width;
   background: `url(${props.src}) center center`,
 }));
@@ -134,7 +134,7 @@ const Image1 = styled('div')<ImageProps>({
 ```
 
 * The generic function version only works with object styles in TS <= 2.8 due to https://github.com/Microsoft/TypeScript/issues/11947.
-* If you use TS > 2.9, generic function will works with string styles too, but it will break VSCode syntax highlighting. See https://github.com/emotion-js/emotion/issues/721#issuecomment-396954993
+* If you use TS > 2.9, generic function will work with string styles too, but it will break VSCode syntax highlighting. See https://github.com/emotion-js/emotion/issues/721#issuecomment-396954993
 
 ### React Components
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -94,7 +94,7 @@ const App = () => <Link href="#">Click me</Link>
 // No errors!
 ```
 
-The prop types used to construct the resulting style definition of `withComponent` should be explicitly provided to avoid TypeScript compiler error. If you don't, TS will think all props for `Text` are used to construct style definition, and request user to give all those props when using the result component of `withComponent`.
+The prop types used to construct the resulting style definition of `withComponent` should be explicitly provided to avoid TypeScript compiler errors.
 
 ### Passing Props
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -114,18 +114,17 @@ const Image0 = styled<ImageProps, 'div'>('div')`
   background-size: contain;
 `
 
-// Or with object styles
-
-const Image1 = styled<ImageProps, 'div'>('div')({
+// Or with a generic function
+const Image1 = styled('div')<ImageProps>({
   backgroundSize: 'contain',
 }, props => ({
   width: props.width;
   background: `url(${props.src}) center center`,
 }));
 
-// Or with a generic function
-
-const Image1 = styled('div')<ImageProps>({
+// This one is only for compatibility,
+// so one should not write new code with this style.
+const Image1 = styled<ImageProps, 'div'>('div')({
   backgroundSize: 'contain',
 }, props => ({
   width: props.width;

--- a/packages/create-emotion-styled/types/react.d.ts
+++ b/packages/create-emotion-styled/types/react.d.ts
@@ -44,37 +44,37 @@ export type StyledComponent<Props extends object, InnerProps extends object, The
   | StyledOtherComponent<Props, InnerProps, Theme>
   ;
 
-export interface CreateStyledStatelessComponent<InnerProps extends object, Theme extends object> {
-  <Props extends object = InnerProps, OverridedTheme extends object = Theme>(
-    ...args: Array<Interpolation<Themed<Props, OverridedTheme>>>
-  ): StyledStatelessComponent<Props, InnerProps, OverridedTheme>;
+export interface CreateStyledStatelessComponent<Props extends object, InnerProps extends object, Theme extends object> {
+  <P extends object = Props, OverridedTheme extends object = Theme>(
+    ...args: Array<Interpolation<Themed<P, OverridedTheme>>>
+  ): StyledStatelessComponent<P, InnerProps, OverridedTheme>;
 }
 
-export interface CreateStyledOtherComponent<InnerProps extends object, Theme extends object> {
-  <Props extends object = InnerProps, OverridedTheme extends object = Theme>(
-    ...args: Array<Interpolation<Themed<Props, OverridedTheme>>>
-  ): StyledOtherComponent<Props, InnerProps, OverridedTheme>;
+export interface CreateStyledOtherComponent<Props extends object, InnerProps extends object, Theme extends object> {
+  <P extends object = Props, OverridedTheme extends object = Theme>(
+    ...args: Array<Interpolation<Themed<P, OverridedTheme>>>
+  ): StyledOtherComponent<P, InnerProps, OverridedTheme>;
 }
 
 export interface CreateStyledFunction<Theme extends object> {
-  <T extends keyof JSX.IntrinsicElements>(
+  <P extends object, T extends keyof JSX.IntrinsicElements>(
     tag: T,
     options?: StyledOptions,
-  ): CreateStyledOtherComponent<JSX.IntrinsicElements[T], Theme>;
+  ): CreateStyledOtherComponent<P & JSX.IntrinsicElements[T], JSX.IntrinsicElements[T], Theme>;
 
-  <IP extends object>(
+  <P extends object, IP extends object>(
     component: SFC<IP>,
     options?: StyledOptions,
-  ): CreateStyledStatelessComponent<IP, Theme>;
+  ): CreateStyledStatelessComponent<P & IP, IP, Theme>;
 
-  <IP extends object>(
+  <P extends object, IP extends object>(
     component: ComponentClass<IP> | ComponentType<IP>,
     options?: StyledOptions,
-  ): CreateStyledOtherComponent<IP, Theme>;
+  ): CreateStyledOtherComponent<P & IP, IP, Theme>;
 }
 
 export type CreateStyledShorthands<Theme extends object> = {
-  [T in keyof JSX.IntrinsicElements]: CreateStyledOtherComponent<JSX.IntrinsicElements[T], Theme>;
+  [T in keyof JSX.IntrinsicElements]: CreateStyledOtherComponent<JSX.IntrinsicElements[T], JSX.IntrinsicElements[T], Theme>;
 };
 
 export interface CreateStyled<Theme extends object = any>

--- a/packages/create-emotion-styled/types/react.d.ts
+++ b/packages/create-emotion-styled/types/react.d.ts
@@ -45,13 +45,13 @@ export type StyledComponent<Props extends object, InnerProps extends object, The
   ;
 
 export interface CreateStyledStatelessComponent<InnerProps extends object, Theme extends object> {
-  <Props extends object, OverridedTheme extends object = Theme>(
+  <Props extends object = InnerProps, OverridedTheme extends object = Theme>(
     ...args: Array<Interpolation<Themed<Props, OverridedTheme>>>
   ): StyledStatelessComponent<Props, InnerProps, OverridedTheme>;
 }
 
 export interface CreateStyledOtherComponent<InnerProps extends object, Theme extends object> {
-  <Props extends object, OverridedTheme extends object = Theme>(
+  <Props extends object = InnerProps, OverridedTheme extends object = Theme>(
     ...args: Array<Interpolation<Themed<Props, OverridedTheme>>>
   ): StyledOtherComponent<Props, InnerProps, OverridedTheme>;
 }

--- a/packages/create-emotion-styled/types/test.tsx
+++ b/packages/create-emotion-styled/types/test.tsx
@@ -131,9 +131,9 @@ const StyledTag1 = createStyled('label')`
 const StyledCompWithButton = StyledClassComp0.withComponent('button');
 const StyledCompWithFunComp2 = StyledFunComp0.withComponent(TestFunComp1);
 
-<StyledCompWithButton />;
-<StyledCompWithButton onClick={() => ''} />;
-<StyledCompWithButton onClick={() => ''} innerRef={(ref: HTMLButtonElement) => { }} />;
+<StyledCompWithButton some={4} />;
+<StyledCompWithButton some={2} onClick={() => ''} />;
+<StyledCompWithButton some={3} onClick={() => ''} innerRef={(ref: HTMLButtonElement) => { }} />;
 
 <StyledCompWithFunComp2 color='#ffff00' complex={{ id: 42, name: 'truth', friends: [69] }} world={1} />;
 // $ExpectError
@@ -222,3 +222,11 @@ const ComposingCompType = createStyled.div`
 <StyledComponentType0 value={5} />;
 <StyledComponentType1 value={4} />;
 <ComposingCompType />;
+
+interface InferProps {
+  w: number;
+}
+declare const InferComponent: React.SFC<InferProps>;
+const StyledInferComponent = createStyled(InferComponent)`
+  width: ${props => props.w};
+`;

--- a/packages/create-emotion-styled/types/test.tsx
+++ b/packages/create-emotion-styled/types/test.tsx
@@ -50,15 +50,15 @@ const TestFunComp1 = (props: TestFunProps1) => (
   </div>
 );
 
-const StyledClassComp0 = createStyled(TestClassComp)({
+const StyledClassComp0 = createStyled(TestClassComp)<{}>({
   width: '200px',
 }, (props) => ({
   height: props.theme.long ? '200px' : '100px',
 }));
 
-const StyledClassComp1 = createStyled(TestClassComp) `
+const StyledClassComp1 = createStyled(TestClassComp)`
   width: 200px;
-  height: ${(props) => props.theme ? '200px' : '100px'};
+  height: ${(props) => props.theme.long ? '200px' : '100px'};
 `;
 
 <StyledClassComp0 some={5} />;
@@ -131,9 +131,9 @@ const StyledTag1 = createStyled('label')`
 const StyledCompWithButton = StyledClassComp0.withComponent('button');
 const StyledCompWithFunComp2 = StyledFunComp0.withComponent(TestFunComp1);
 
-<StyledCompWithButton some={4} />;
-<StyledCompWithButton some={2} onClick={() => ''} />;
-<StyledCompWithButton some={3} onClick={() => ''} innerRef={(ref: HTMLButtonElement) => { }} />;
+<StyledCompWithButton />;
+<StyledCompWithButton onClick={() => ''} />;
+<StyledCompWithButton onClick={() => ''} innerRef={(ref: HTMLButtonElement) => { }} />;
 
 <StyledCompWithFunComp2 color='#ffff00' complex={{ id: 42, name: 'truth', friends: [69] }} world={1} />;
 // $ExpectError

--- a/packages/create-emotion-styled/types/tslint.json
+++ b/packages/create-emotion-styled/types/tslint.json
@@ -4,6 +4,7 @@
         "array-type": [true, "generic"],
         "callable-types": false,
         "no-import-default-of-export-equals": false,
-        "no-relative-import-in-test": false
+        "no-relative-import-in-test": false,
+        "no-unnecessary-generics": false
     }
 }

--- a/packages/preact-emotion/types/preact.d.ts
+++ b/packages/preact-emotion/types/preact.d.ts
@@ -44,13 +44,13 @@ export type StyledComponent<Props extends object, InnerProps extends object, The
   ;
 
 export interface CreateStyledStatelessComponent<InnerProps extends object, Theme extends object> {
-  <Props extends object, OverridedTheme extends object = Theme>(
+  <Props extends object = InnerProps, OverridedTheme extends object = Theme>(
     ...args: Array<Interpolation<Themed<Props, OverridedTheme>>>
   ): StyledStatelessComponent<Props, InnerProps, OverridedTheme>;
 }
 
 export interface CreateStyledOtherComponent<InnerProps extends object, Theme extends object> {
-  <Props extends object, OverridedTheme extends object = Theme>(
+  <Props extends object = InnerProps, OverridedTheme extends object = Theme>(
     ...args: Array<Interpolation<Themed<Props, OverridedTheme>>>
   ): StyledOtherComponent<Props, InnerProps, OverridedTheme>;
 }

--- a/packages/preact-emotion/types/preact.d.ts
+++ b/packages/preact-emotion/types/preact.d.ts
@@ -43,37 +43,37 @@ export type StyledComponent<Props extends object, InnerProps extends object, The
   | StyledOtherComponent<Props, InnerProps, Theme>
   ;
 
-export interface CreateStyledStatelessComponent<InnerProps extends object, Theme extends object> {
-  <Props extends object = InnerProps, OverridedTheme extends object = Theme>(
-    ...args: Array<Interpolation<Themed<Props, OverridedTheme>>>
-  ): StyledStatelessComponent<Props, InnerProps, OverridedTheme>;
+export interface CreateStyledStatelessComponent<Props extends object, InnerProps extends object, Theme extends object> {
+  <P extends object = Props, OverridedTheme extends object = Theme>(
+    ...args: Array<Interpolation<Themed<P, OverridedTheme>>>
+  ): StyledStatelessComponent<P, InnerProps, OverridedTheme>;
 }
 
-export interface CreateStyledOtherComponent<InnerProps extends object, Theme extends object> {
-  <Props extends object = InnerProps, OverridedTheme extends object = Theme>(
-    ...args: Array<Interpolation<Themed<Props, OverridedTheme>>>
-  ): StyledOtherComponent<Props, InnerProps, OverridedTheme>;
+export interface CreateStyledOtherComponent<Props extends object, InnerProps extends object, Theme extends object> {
+  <P extends object = Props, OverridedTheme extends object = Theme>(
+    ...args: Array<Interpolation<Themed<P, OverridedTheme>>>
+  ): StyledOtherComponent<P, InnerProps, OverridedTheme>;
 }
 
 export interface CreateStyledFunction<Theme extends object> {
-  <T extends keyof JSX.IntrinsicElements>(
+  <P extends object, T extends keyof JSX.IntrinsicElements>(
     tag: T,
     options?: StyledOptions,
-  ): CreateStyledOtherComponent<JSX.IntrinsicElements[T], Theme>;
+  ): CreateStyledOtherComponent<P & JSX.IntrinsicElements[T], JSX.IntrinsicElements[T], Theme>;
 
-  <IP extends object>(
+  <P extends object, IP extends object>(
     component: FunctionalComponent<IP>,
     options?: StyledOptions,
-  ): CreateStyledStatelessComponent<IP, Theme>;
+  ): CreateStyledStatelessComponent<P & IP, IP, Theme>;
 
-  <IP extends object>(
+  <P extends object, IP extends object>(
     component: ComponentConstructor<IP> | ComponentFactory<IP>,
     options?: StyledOptions,
-  ): CreateStyledOtherComponent<IP, Theme>;
+  ): CreateStyledOtherComponent<P & IP, IP, Theme>;
 }
 
 export type CreateStyledShorthands<Theme extends object> = {
-  [T in keyof JSX.IntrinsicElements]: CreateStyledOtherComponent<JSX.IntrinsicElements[T], Theme>;
+  [T in keyof JSX.IntrinsicElements]: CreateStyledOtherComponent<JSX.IntrinsicElements[T], JSX.IntrinsicElements[T], Theme>;
 };
 
 export interface CreateStyled<Theme extends object = any>

--- a/packages/preact-emotion/types/test.tsx
+++ b/packages/preact-emotion/types/test.tsx
@@ -212,3 +212,10 @@ const ComposingCompFactory = styled.div`
 <StyledComponentFactory0 value={5} />;
 <StyledComponentFactory1 value={4} />;
 <ComposingCompFactory />;
+interface InferProps {
+  w: number;
+}
+declare const InferComponent: Preact.FunctionalComponent<InferProps>;
+const StyledInferComponent = styled(InferComponent)`
+  width: ${props => props.w};
+`;

--- a/packages/preact-emotion/types/tslint.json
+++ b/packages/preact-emotion/types/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         "array-type": [true, "generic"],
         "callable-types": false,
-        "no-relative-import-in-test": false
+        "no-relative-import-in-test": false,
+        "no-unnecessary-generics": false
     }
 }


### PR DESCRIPTION
**What**: Enhance type inference for following case.
```tsx
interface Props {
  w: number;
}
declare const Comp: SFC<Props>;
const X = styled(Comp)`
  width: ${props => props.w};
`
```

and add type parameter for compatibilities with old type

```tsx
interface Props {
  w: number;
}
const X = styled<Props, 'div'>('div')`
  width: ${props => props.w};
`
```

**Why**: #721.

**How**: By adding default type parameter

**Checklist**:
- [x] Documentation
- [x] Tests
- [x] Code complete

Resolves #721.