### PR TITLE
styled: fix order of static class names

### DIFF
--- a/packages/create-emotion-styled/src/index.js
+++ b/packages/create-emotion-styled/src/index.js
@@ -121,11 +121,14 @@ function createEmotionStyled(emotion: Emotion, view: ReactType) {
               styles.concat(classInterpolations)
             )
           } else {
-            className += staticClassName
+            className = `${staticClassName} ${className}`
           }
 
           if (stableClassName !== undefined) {
-            className += ` ${stableClassName}`
+            if (staticClassName === undefined) {
+              className += ' '
+            }
+            className += stableClassName
           }
 
           return view.createElement(

--- a/packages/emotion/test/extract/__snapshots__/extract.test.js.snap
+++ b/packages/emotion/test/extract/__snapshots__/extract.test.js.snap
@@ -10,7 +10,7 @@ exports[`styled basic render nested 1`] = `
 
 exports[`styled className prop on styled 1`] = `
 <h1
-  className="some-class emotion-0 emotion-1"
+  className="emotion-0 some-class emotion-1"
 >
   hello world
 </h1>

--- a/packages/react-emotion/test/__snapshots__/index.test.js.snap
+++ b/packages/react-emotion/test/__snapshots__/index.test.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should append classNames in the correct order 1`] = `
+.emotion-0 {
+  color: blue;
+}
+
+.emotion-1 {
+  color: red;
+}
+
+<h1
+  className="emotion-0 emotion-1 emotion-2 emotion-3"
+>
+  Test
+</h1>
+`;
+
 exports[`styled basic render 1`] = `
 .emotion-0 {
   color: blue;

--- a/packages/react-emotion/test/index.test.js
+++ b/packages/react-emotion/test/index.test.js
@@ -1191,3 +1191,17 @@ test('composes shouldForwardProp on composed styled components', () => {
   expect(tree.props.filterMe).toBeUndefined()
   expect(tree.props.forwardMe).toBeDefined()
 })
+
+test('should append classNames in the correct order', () => {
+  const blue = css`
+    color: blue;
+  `
+  const red = css`
+    color: red;
+  `
+  const H1 = styled('h1', { e: blue })()
+  const RedH1 = styled(H1, { e: red })()
+
+  const tree = renderer.create(<RedH1>Test</RedH1>).toJSON()
+  expect(tree).toMatchSnapshot()
+})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Make the order of static class names match the desired style tag order.

<!-- Why are these changes necessary? -->
**Why**:
While the extractStatic doesn't suffer from this problem, we're doing something similar in our SSR and since the SSR inlines style tags based on the order of classNames, this makes it impossible to implement this optimization.

<!-- How were these changes implemented? -->
**How**:
Flipped the order of staticClassName within the component.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->

This is a fairly straightforward change but allows us to implement something that caches component styles for `styled` instead of having to render & hash them on each render. The latter is computationally expensive and accounts for good 20-40ms runtime (in production) for some of our more complex pages.

I would also consider the current behaviour a bug, since I would expect the order of classnames form the following to be reversed.

```
const H1 = styled.h1`color: blue;`;
const RedH1 styled(H1)`color: red;`;
```

What I will get is `className=RedH1 H1` rather than `className=H1 RedH1`.

<!-- Please add a `Tag:` prefixed label from the labels so that this PR shows up in the changelog -->
