### PR TITLE
ssr: fix insertion order in edge cases

### DIFF
--- a/packages/create-emotion-server/src/inline.js
+++ b/packages/create-emotion-server/src/inline.js
@@ -19,11 +19,13 @@ const createRenderStylesToString = (emotion: Emotion, nonceString: string) => (
   const regex = new RegExp(`<|${cssKey}-([a-zA-Z0-9-]+)`, 'gm')
 
   const seen = {}
+  const order = {}
 
   let result = ''
   let globalIds = ''
   let globalStyles = ''
 
+  let i = 0
   for (const id in inserted) {
     if (inserted.hasOwnProperty(id)) {
       const style = inserted[id]
@@ -32,6 +34,7 @@ const createRenderStylesToString = (emotion: Emotion, nonceString: string) => (
         globalStyles += style
         globalIds += ` ${id}`
       }
+      order[id] = i++
     }
   }
 
@@ -39,17 +42,24 @@ const createRenderStylesToString = (emotion: Emotion, nonceString: string) => (
     result = generateStyleTag(cssKey, globalIds, globalStyles, nonceString)
   }
 
-  let ids = ''
-  let styles = ''
+  const styles = []
   let lastInsertionPoint = 0
   let match
 
   while ((match = regex.exec(html)) !== null) {
     if (match[0] === '<') {
-      if (ids !== '') {
-        result += generateStyleTag(cssKey, ids, styles, nonceString)
-        ids = ''
-        styles = ''
+      if (styles.length > 0) {
+        let stylesString = ''
+        let idsString = ''
+        if (styles.length > 1) {
+          styles.sort((a, b) => order[a.id] - order[b.id])
+        }
+        for (let j = 0; j < styles.length; j++) {
+          stylesString += styles[j].style
+          idsString += ` ${styles[j].id}`
+        }
+        result += generateStyleTag(cssKey, idsString, stylesString, nonceString)
+        styles.length = 0
       }
       result += html.substring(lastInsertionPoint, match.index)
       lastInsertionPoint = match.index
@@ -63,8 +73,7 @@ const createRenderStylesToString = (emotion: Emotion, nonceString: string) => (
     }
 
     seen[id] = true
-    styles += style
-    ids += ` ${id}`
+    styles.push({ id, style })
   }
 
   result += html.substring(lastInsertionPoint)

--- a/packages/create-emotion/test/__snapshots__/inline.test.js.snap
+++ b/packages/create-emotion/test/__snapshots__/inline.test.js.snap
@@ -2415,3 +2415,17 @@ exports[`renderStylesToString renders styles with ids 2`] = `
 </main>
 
 `;
+
+exports[`renderStylesToString retains the original style order 1`] = `
+
+<style data-emotion-some-key="14jcta0 jk0pkr"
+       nonce="some-nonce"
+>
+  .some-key-14jcta0{color:blue;}.some-key-jk0pkr{color:red;}
+</style>
+<div class="some-key-jk0pkr some-key-14jcta0"
+     data-reactroot
+>
+</div>
+
+`;

--- a/packages/create-emotion/test/inline.test.js
+++ b/packages/create-emotion/test/inline.test.js
@@ -42,6 +42,15 @@ describe('renderStylesToString', () => {
       )
     ).toMatchSnapshot()
   })
+  test('retains the original style order', () => {
+    const style1 = emotion.css`color: blue;`
+    const style2 = emotion.css`color: red;`
+    expect(
+      emotionServer.renderStylesToString(
+        renderToString(<div className={`${style2} ${style1}`} />)
+      )
+    ).toMatchSnapshot()
+  })
 })
 describe('hydration', () => {
   afterAll(() => {


### PR DESCRIPTION
This fixes a very minor and unlikely to happen regression in `renderStylesToString` where the inserted elements aren't re-inserted in the correct order. This still retains the performance profile of the original changes and keeps the algorithm O(n).

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Code complete

<!-- feel free to add additional comments -->

<!-- Please add a `Tag:` prefixed label from the labels so that this PR shows up in the changelog -->
