### PR TITLE
Remove explicit enumerable: false from Styled.toString descriptor

### DIFF
--- a/packages/create-emotion-styled/src/index.js
+++ b/packages/create-emotion-styled/src/index.js
@@ -157,7 +157,6 @@ function createEmotionStyled(emotion: Emotion, view: ReactType) {
       Styled.__emotion_real = Styled
       Styled.__emotion_forwardProp = shouldForwardProp
       Object.defineProperty(Styled, 'toString', {
-        enumerable: false,
         value() {
           if (
             process.env.NODE_ENV !== 'production' &&


### PR DESCRIPTION
`enumerable: false` is the default, so not need to specify it manually 