### PR TITLE
Fix config being silently ignored in babel-plugin

### DIFF
--- a/packages/babel-plugin-emotion/__tests__/__snapshots__/styled.js.snap
+++ b/packages/babel-plugin-emotion/__tests__/__snapshots__/styled.js.snap
@@ -175,34 +175,55 @@ styled(
   window.whatever
 )\`\`
 
+const cfg = { shouldForwardProp: window.whatever }
+styled('button', cfg)({})
+
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import _styled from \\"@emotion/styled-base\\";
 
+function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+
 /*#__PURE__*/
 _styled('div', {
   shouldForwardProp: window.whatever,
   target: \\"ek6pnb20\\"
-}, window.whatever)(process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBRUEiLCJmaWxlIjoiZXhpc3Rpbmctb3B0aW9ucy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSAnQGVtb3Rpb24vc3R5bGVkJ1xuXG5zdHlsZWQoJ2RpdicsIHsgc2hvdWxkRm9yd2FyZFByb3A6IHdpbmRvdy53aGF0ZXZlciB9LCB3aW5kb3cud2hhdGV2ZXIpKClcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKWBgXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pKClcblxuc3R5bGVkKFxuICB3aW5kb3cud2hhdGV2ZXIsXG4gIHsgc2hvdWxkRm9yd2FyZFByb3A6IHdpbmRvdy53aGF0ZXZlciB9LFxuICB3aW5kb3cud2hhdGV2ZXJcbilgYFxuIl19 */\\");
+}, window.whatever)(process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBRUEiLCJmaWxlIjoiZXhpc3Rpbmctb3B0aW9ucy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSAnQGVtb3Rpb24vc3R5bGVkJ1xuXG5zdHlsZWQoJ2RpdicsIHsgc2hvdWxkRm9yd2FyZFByb3A6IHdpbmRvdy53aGF0ZXZlciB9LCB3aW5kb3cud2hhdGV2ZXIpKClcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKWBgXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pKClcblxuc3R5bGVkKFxuICB3aW5kb3cud2hhdGV2ZXIsXG4gIHsgc2hvdWxkRm9yd2FyZFByb3A6IHdpbmRvdy53aGF0ZXZlciB9LFxuICB3aW5kb3cud2hhdGV2ZXJcbilgYFxuXG5jb25zdCBjZmcgPSB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfVxuc3R5bGVkKCdidXR0b24nLCBjZmcpKHt9KVxuIl19 */\\");
 
 /*#__PURE__*/
 _styled('div', {
   shouldForwardProp: window.whatever,
   target: \\"ek6pnb21\\"
-}, window.whatever)(process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBSXNFIiwiZmlsZSI6ImV4aXN0aW5nLW9wdGlvbnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgc3R5bGVkIGZyb20gJ0BlbW90aW9uL3N0eWxlZCdcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKSgpXG5cbnN0eWxlZCgnZGl2JywgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sIHdpbmRvdy53aGF0ZXZlcilgYFxuXG5zdHlsZWQoXG4gIHdpbmRvdy53aGF0ZXZlcixcbiAgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sXG4gIHdpbmRvdy53aGF0ZXZlclxuKSgpXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pYGBcbiJdfQ== */\\");
+}, window.whatever)(process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBSXNFIiwiZmlsZSI6ImV4aXN0aW5nLW9wdGlvbnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgc3R5bGVkIGZyb20gJ0BlbW90aW9uL3N0eWxlZCdcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKSgpXG5cbnN0eWxlZCgnZGl2JywgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sIHdpbmRvdy53aGF0ZXZlcilgYFxuXG5zdHlsZWQoXG4gIHdpbmRvdy53aGF0ZXZlcixcbiAgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sXG4gIHdpbmRvdy53aGF0ZXZlclxuKSgpXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pYGBcblxuY29uc3QgY2ZnID0geyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH1cbnN0eWxlZCgnYnV0dG9uJywgY2ZnKSh7fSlcbiJdfQ== */\\");
 
 /*#__PURE__*/
 _styled(window.whatever, {
   shouldForwardProp: window.whatever,
   target: \\"ek6pnb22\\"
-}, window.whatever)(process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBTUEiLCJmaWxlIjoiZXhpc3Rpbmctb3B0aW9ucy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSAnQGVtb3Rpb24vc3R5bGVkJ1xuXG5zdHlsZWQoJ2RpdicsIHsgc2hvdWxkRm9yd2FyZFByb3A6IHdpbmRvdy53aGF0ZXZlciB9LCB3aW5kb3cud2hhdGV2ZXIpKClcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKWBgXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pKClcblxuc3R5bGVkKFxuICB3aW5kb3cud2hhdGV2ZXIsXG4gIHsgc2hvdWxkRm9yd2FyZFByb3A6IHdpbmRvdy53aGF0ZXZlciB9LFxuICB3aW5kb3cud2hhdGV2ZXJcbilgYFxuIl19 */\\");
+}, window.whatever)(process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBTUEiLCJmaWxlIjoiZXhpc3Rpbmctb3B0aW9ucy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSAnQGVtb3Rpb24vc3R5bGVkJ1xuXG5zdHlsZWQoJ2RpdicsIHsgc2hvdWxkRm9yd2FyZFByb3A6IHdpbmRvdy53aGF0ZXZlciB9LCB3aW5kb3cud2hhdGV2ZXIpKClcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKWBgXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pKClcblxuc3R5bGVkKFxuICB3aW5kb3cud2hhdGV2ZXIsXG4gIHsgc2hvdWxkRm9yd2FyZFByb3A6IHdpbmRvdy53aGF0ZXZlciB9LFxuICB3aW5kb3cud2hhdGV2ZXJcbilgYFxuXG5jb25zdCBjZmcgPSB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfVxuc3R5bGVkKCdidXR0b24nLCBjZmcpKHt9KVxuIl19 */\\");
 
 /*#__PURE__*/
 _styled(window.whatever, {
   shouldForwardProp: window.whatever,
   target: \\"ek6pnb23\\"
-}, window.whatever)(process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBZ0JDIiwiZmlsZSI6ImV4aXN0aW5nLW9wdGlvbnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgc3R5bGVkIGZyb20gJ0BlbW90aW9uL3N0eWxlZCdcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKSgpXG5cbnN0eWxlZCgnZGl2JywgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sIHdpbmRvdy53aGF0ZXZlcilgYFxuXG5zdHlsZWQoXG4gIHdpbmRvdy53aGF0ZXZlcixcbiAgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sXG4gIHdpbmRvdy53aGF0ZXZlclxuKSgpXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pYGBcbiJdfQ== */\\");"
+}, window.whatever)(process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBZ0JDIiwiZmlsZSI6ImV4aXN0aW5nLW9wdGlvbnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgc3R5bGVkIGZyb20gJ0BlbW90aW9uL3N0eWxlZCdcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKSgpXG5cbnN0eWxlZCgnZGl2JywgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sIHdpbmRvdy53aGF0ZXZlcilgYFxuXG5zdHlsZWQoXG4gIHdpbmRvdy53aGF0ZXZlcixcbiAgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sXG4gIHdpbmRvdy53aGF0ZXZlclxuKSgpXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pYGBcblxuY29uc3QgY2ZnID0geyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH1cbnN0eWxlZCgnYnV0dG9uJywgY2ZnKSh7fSlcbiJdfQ== */\\");
+
+const cfg = {
+  shouldForwardProp: window.whatever
+};
+
+/*#__PURE__*/
+_styled('button', _extends({}, {
+  target: \\"ek6pnb24\\"
+}, cfg))(process.env.NODE_ENV === \\"production\\" ? {
+  name: \\"0\\",
+  styles: \\"\\"
+} : {
+  name: \\"0\\",
+  styles: \\"\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBbUJBIiwiZmlsZSI6ImV4aXN0aW5nLW9wdGlvbnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgc3R5bGVkIGZyb20gJ0BlbW90aW9uL3N0eWxlZCdcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKSgpXG5cbnN0eWxlZCgnZGl2JywgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sIHdpbmRvdy53aGF0ZXZlcilgYFxuXG5zdHlsZWQoXG4gIHdpbmRvdy53aGF0ZXZlcixcbiAgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sXG4gIHdpbmRvdy53aGF0ZXZlclxuKSgpXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pYGBcblxuY29uc3QgY2ZnID0geyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH1cbnN0eWxlZCgnYnV0dG9uJywgY2ZnKSh7fSlcbiJdfQ== */\\"
+});"
 `;
 
 exports[`@emotion/babel-plugin-core styled function-interpolation 1`] = `

--- a/packages/babel-plugin-emotion/__tests__/styled-macro/__fixtures__/existing-options.js
+++ b/packages/babel-plugin-emotion/__tests__/styled-macro/__fixtures__/existing-options.js
@@ -15,3 +15,6 @@ styled(
   { shouldForwardProp: window.whatever },
   window.whatever
 )``
+
+const cfg = { shouldForwardProp: window.whatever }
+styled('button', cfg)({})

--- a/packages/babel-plugin-emotion/__tests__/styled-macro/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-emotion/__tests__/styled-macro/__snapshots__/index.js.snap
@@ -175,34 +175,55 @@ styled(
   window.whatever
 )\`\`
 
+const cfg = { shouldForwardProp: window.whatever }
+styled('button', cfg)({})
+
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import _styled from \\"@emotion/styled-base\\";
 
+function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+
 /*#__PURE__*/
 _styled('div', {
   shouldForwardProp: window.whatever,
   target: \\"ek6pnb20\\"
-}, window.whatever)(process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBRUEiLCJmaWxlIjoiZXhpc3Rpbmctb3B0aW9ucy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSAnQGVtb3Rpb24vc3R5bGVkL21hY3JvJ1xuXG5zdHlsZWQoJ2RpdicsIHsgc2hvdWxkRm9yd2FyZFByb3A6IHdpbmRvdy53aGF0ZXZlciB9LCB3aW5kb3cud2hhdGV2ZXIpKClcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKWBgXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pKClcblxuc3R5bGVkKFxuICB3aW5kb3cud2hhdGV2ZXIsXG4gIHsgc2hvdWxkRm9yd2FyZFByb3A6IHdpbmRvdy53aGF0ZXZlciB9LFxuICB3aW5kb3cud2hhdGV2ZXJcbilgYFxuIl19 */\\");
+}, window.whatever)(process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBRUEiLCJmaWxlIjoiZXhpc3Rpbmctb3B0aW9ucy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSAnQGVtb3Rpb24vc3R5bGVkL21hY3JvJ1xuXG5zdHlsZWQoJ2RpdicsIHsgc2hvdWxkRm9yd2FyZFByb3A6IHdpbmRvdy53aGF0ZXZlciB9LCB3aW5kb3cud2hhdGV2ZXIpKClcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKWBgXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pKClcblxuc3R5bGVkKFxuICB3aW5kb3cud2hhdGV2ZXIsXG4gIHsgc2hvdWxkRm9yd2FyZFByb3A6IHdpbmRvdy53aGF0ZXZlciB9LFxuICB3aW5kb3cud2hhdGV2ZXJcbilgYFxuXG5jb25zdCBjZmcgPSB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfVxuc3R5bGVkKCdidXR0b24nLCBjZmcpKHt9KVxuIl19 */\\");
 
 /*#__PURE__*/
 _styled('div', {
   shouldForwardProp: window.whatever,
   target: \\"ek6pnb21\\"
-}, window.whatever)(process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBSXNFIiwiZmlsZSI6ImV4aXN0aW5nLW9wdGlvbnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgc3R5bGVkIGZyb20gJ0BlbW90aW9uL3N0eWxlZC9tYWNybydcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKSgpXG5cbnN0eWxlZCgnZGl2JywgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sIHdpbmRvdy53aGF0ZXZlcilgYFxuXG5zdHlsZWQoXG4gIHdpbmRvdy53aGF0ZXZlcixcbiAgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sXG4gIHdpbmRvdy53aGF0ZXZlclxuKSgpXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pYGBcbiJdfQ== */\\");
+}, window.whatever)(process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBSXNFIiwiZmlsZSI6ImV4aXN0aW5nLW9wdGlvbnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgc3R5bGVkIGZyb20gJ0BlbW90aW9uL3N0eWxlZC9tYWNybydcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKSgpXG5cbnN0eWxlZCgnZGl2JywgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sIHdpbmRvdy53aGF0ZXZlcilgYFxuXG5zdHlsZWQoXG4gIHdpbmRvdy53aGF0ZXZlcixcbiAgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sXG4gIHdpbmRvdy53aGF0ZXZlclxuKSgpXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pYGBcblxuY29uc3QgY2ZnID0geyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH1cbnN0eWxlZCgnYnV0dG9uJywgY2ZnKSh7fSlcbiJdfQ== */\\");
 
 /*#__PURE__*/
 _styled(window.whatever, {
   shouldForwardProp: window.whatever,
   target: \\"ek6pnb22\\"
-}, window.whatever)(process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBTUEiLCJmaWxlIjoiZXhpc3Rpbmctb3B0aW9ucy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSAnQGVtb3Rpb24vc3R5bGVkL21hY3JvJ1xuXG5zdHlsZWQoJ2RpdicsIHsgc2hvdWxkRm9yd2FyZFByb3A6IHdpbmRvdy53aGF0ZXZlciB9LCB3aW5kb3cud2hhdGV2ZXIpKClcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKWBgXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pKClcblxuc3R5bGVkKFxuICB3aW5kb3cud2hhdGV2ZXIsXG4gIHsgc2hvdWxkRm9yd2FyZFByb3A6IHdpbmRvdy53aGF0ZXZlciB9LFxuICB3aW5kb3cud2hhdGV2ZXJcbilgYFxuIl19 */\\");
+}, window.whatever)(process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBTUEiLCJmaWxlIjoiZXhpc3Rpbmctb3B0aW9ucy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBzdHlsZWQgZnJvbSAnQGVtb3Rpb24vc3R5bGVkL21hY3JvJ1xuXG5zdHlsZWQoJ2RpdicsIHsgc2hvdWxkRm9yd2FyZFByb3A6IHdpbmRvdy53aGF0ZXZlciB9LCB3aW5kb3cud2hhdGV2ZXIpKClcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKWBgXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pKClcblxuc3R5bGVkKFxuICB3aW5kb3cud2hhdGV2ZXIsXG4gIHsgc2hvdWxkRm9yd2FyZFByb3A6IHdpbmRvdy53aGF0ZXZlciB9LFxuICB3aW5kb3cud2hhdGV2ZXJcbilgYFxuXG5jb25zdCBjZmcgPSB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfVxuc3R5bGVkKCdidXR0b24nLCBjZmcpKHt9KVxuIl19 */\\");
 
 /*#__PURE__*/
 _styled(window.whatever, {
   shouldForwardProp: window.whatever,
   target: \\"ek6pnb23\\"
-}, window.whatever)(process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBZ0JDIiwiZmlsZSI6ImV4aXN0aW5nLW9wdGlvbnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgc3R5bGVkIGZyb20gJ0BlbW90aW9uL3N0eWxlZC9tYWNybydcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKSgpXG5cbnN0eWxlZCgnZGl2JywgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sIHdpbmRvdy53aGF0ZXZlcilgYFxuXG5zdHlsZWQoXG4gIHdpbmRvdy53aGF0ZXZlcixcbiAgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sXG4gIHdpbmRvdy53aGF0ZXZlclxuKSgpXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pYGBcbiJdfQ== */\\");"
+}, window.whatever)(process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBZ0JDIiwiZmlsZSI6ImV4aXN0aW5nLW9wdGlvbnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgc3R5bGVkIGZyb20gJ0BlbW90aW9uL3N0eWxlZC9tYWNybydcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKSgpXG5cbnN0eWxlZCgnZGl2JywgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sIHdpbmRvdy53aGF0ZXZlcilgYFxuXG5zdHlsZWQoXG4gIHdpbmRvdy53aGF0ZXZlcixcbiAgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sXG4gIHdpbmRvdy53aGF0ZXZlclxuKSgpXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pYGBcblxuY29uc3QgY2ZnID0geyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH1cbnN0eWxlZCgnYnV0dG9uJywgY2ZnKSh7fSlcbiJdfQ== */\\");
+
+const cfg = {
+  shouldForwardProp: window.whatever
+};
+
+/*#__PURE__*/
+_styled('button', _extends({}, {
+  target: \\"ek6pnb24\\"
+}, cfg))(process.env.NODE_ENV === \\"production\\" ? {
+  name: \\"0\\",
+  styles: \\"\\"
+} : {
+  name: \\"0\\",
+  styles: \\"\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImV4aXN0aW5nLW9wdGlvbnMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBbUJBIiwiZmlsZSI6ImV4aXN0aW5nLW9wdGlvbnMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgc3R5bGVkIGZyb20gJ0BlbW90aW9uL3N0eWxlZC9tYWNybydcblxuc3R5bGVkKCdkaXYnLCB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSwgd2luZG93LndoYXRldmVyKSgpXG5cbnN0eWxlZCgnZGl2JywgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sIHdpbmRvdy53aGF0ZXZlcilgYFxuXG5zdHlsZWQoXG4gIHdpbmRvdy53aGF0ZXZlcixcbiAgeyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH0sXG4gIHdpbmRvdy53aGF0ZXZlclxuKSgpXG5cbnN0eWxlZChcbiAgd2luZG93LndoYXRldmVyLFxuICB7IHNob3VsZEZvcndhcmRQcm9wOiB3aW5kb3cud2hhdGV2ZXIgfSxcbiAgd2luZG93LndoYXRldmVyXG4pYGBcblxuY29uc3QgY2ZnID0geyBzaG91bGRGb3J3YXJkUHJvcDogd2luZG93LndoYXRldmVyIH1cbnN0eWxlZCgnYnV0dG9uJywgY2ZnKSh7fSlcbiJdfQ== */\\"
+});"
 `;
 
 exports[`@emotion/styled.macro function-interpolation 1`] = `

--- a/packages/babel-plugin-emotion/src/utils/get-styled-options.js
+++ b/packages/babel-plugin-emotion/src/utils/get-styled-options.js
@@ -22,9 +22,8 @@ export let getStyledOptions = (t: *, path: *, state: *) => {
     if (t.isObjectExpression(optionsArgument)) {
       properties.unshift(...optionsArgument.properties)
     } else {
-      console.warn(
-        "Second argument to a styled call is not an object, it's going to be removed."
-      )
+      // $FlowFixMe
+      properties.push(t.spreadElement(optionsArgument))
     }
   }
 

--- a/packages/babel-plugin-emotion/src/utils/get-styled-options.js
+++ b/packages/babel-plugin-emotion/src/utils/get-styled-options.js
@@ -19,12 +19,15 @@ export let getStyledOptions = (t: *, path: *, state: *) => {
   let args = path.node.arguments
   let optionsArgument = args.length >= 2 ? args[1] : null
   if (optionsArgument) {
-    if (t.isObjectExpression(optionsArgument)) {
-      properties.unshift(...optionsArgument.properties)
-    } else {
-      // $FlowFixMe
-      properties.push(t.spreadElement(optionsArgument))
+    if (!t.isObjectExpression(optionsArgument)) {
+      return t.callExpression(state.file.addHelper('extends'), [
+        t.objectExpression([]),
+        t.objectExpression(properties),
+        optionsArgument
+      ])
     }
+
+    properties.unshift(...optionsArgument.properties)
   }
 
   return t.objectExpression(

--- a/packages/styled/__tests__/styled.js
+++ b/packages/styled/__tests__/styled.js
@@ -577,21 +577,7 @@ describe('styled', () => {
 
     expect(tree).toMatchSnapshot()
   })
-  test("config works even if it's defined outside", () => {
-    const Button = ({ isRed, ...rest }) => (
-      <button {...rest}>{isRed ? 'passed' : 'not passed'}</button>
-    )
-    const StyledButton1 = styled(Button, {
-      shouldForwardProp: p => p !== 'isRed'
-    })({})
-    const tree1 = renderer.create(<StyledButton1 isRed />).toJSON()
-    expect(tree1.children).toEqual(['not passed'])
 
-    const cfg = { shouldForwardProp: p => p !== 'isRed' }
-    const StyledButton2 = styled(Button, cfg)({})
-    const tree2 = renderer.create(<StyledButton2 isRed />).toJSON()
-    expect(tree2.children).toEqual(['not passed'])
-  })
   test('throws if undefined is passed as the component', () => {
     expect(
       () =>

--- a/packages/styled/__tests__/styled.js
+++ b/packages/styled/__tests__/styled.js
@@ -577,6 +577,21 @@ describe('styled', () => {
 
     expect(tree).toMatchSnapshot()
   })
+  test("config works even if it's defined outside", () => {
+    const Button = ({ isRed, ...rest }) => (
+      <button {...rest}>{isRed ? 'passed' : 'not passed'}</button>
+    )
+    const StyledButton1 = styled(Button, {
+      shouldForwardProp: p => p !== 'isRed'
+    })({})
+    const tree1 = renderer.create(<StyledButton1 isRed />).toJSON()
+    expect(tree1.children).toEqual(['not passed'])
+
+    const cfg = { shouldForwardProp: p => p !== 'isRed' }
+    const StyledButton2 = styled(Button, cfg)({})
+    const tree2 = renderer.create(<StyledButton2 isRed />).toJSON()
+    expect(tree2.children).toEqual(['not passed'])
+  })
   test('throws if undefined is passed as the component', () => {
     expect(
       () =>

--- a/packages/styled/test/babel-plugin.test.js
+++ b/packages/styled/test/babel-plugin.test.js
@@ -1,0 +1,16 @@
+// @flow
+import 'test-utils/legacy-env'
+import React from 'react'
+import * as renderer from 'test-utils/compat-render-json'
+import styled from '@emotion/styled'
+
+test("config merging works even if it's referenced by variable", () => {
+  const Button = ({ isRed, ...rest }) => (
+    <button {...rest}>{isRed ? 'forwarded' : 'not forwarded'}</button>
+  )
+
+  const cfg = { shouldForwardProp: p => p !== 'isRed' }
+  const StyledButton = styled(Button, cfg)({})
+  const tree = renderer.create(<StyledButton isRed />).toJSON()
+  expect(tree.children).toEqual(['not forwarded'])
+})


### PR DESCRIPTION
Hi there, I just created a failing test case for you to inspect. 

The babel plugin seems to ignore the second parameter of `styled` if it's not an object but a reference to an object.

The code below works as expected when not using the babel-plugin, but when the babel-plugin is applied, the `cfg` seems to get ignored.

```jsx
const Button = ({ isRed, ...rest }) => (
  <button {...rest}>{isRed ? 'passed' : 'not passed'}</button>
)
const StyledButton1 = styled(Button, {shouldForwardProp: p => p !== 'isRed'})({})
<StyledButton2 isRed /> // -> isRed is not forwarded, as expected

const cfg = { shouldForwardProp: p => p !== 'isRed' }
const StyledButton2 = styled(Button, cfg)({})
<StyledButton2 isRed /> // -> isRed gets forwarded!
```