### PR TITLE
feat(babel-plugin-emotion): Add name for anonymous exports

### DIFF
--- a/packages/babel-plugin-emotion/src/index.js
+++ b/packages/babel-plugin-emotion/src/index.js
@@ -262,7 +262,9 @@ export function buildStyledCallExpression(
     identifierName,
     state.opts.autoLabel,
     state.opts.labelFormat,
-    state.file.opts.filename
+    state.file.opts.filename,
+    t,
+    args
   )
 
   if (label) {
@@ -333,7 +335,9 @@ export function buildStyledObjectCallExpression(
     identifierName,
     state.opts.autoLabel,
     state.opts.labelFormat,
-    state.file.opts.filename
+    state.file.opts.filename,
+    t,
+    t.isCallExpression(path.node.callee) ? null : [path.node.callee.property]
   )
 
   const labelProperty = label

--- a/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
@@ -1,5 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`styled extract babel 6 autoLabel anonymous styled anonymous class component 1`] = `
+"import \\"./emotion.emotion.css\\";
+
+export default styled(class extends React.Component {}, {
+  e: \\"css-1e93lt2\\",
+  target: \\"e8nbyc50\\"
+})();
+
+
+emotion.emotion.css
+.css-1e93lt2{color:blue;}"
+`;
+
+exports[`styled extract babel 6 autoLabel anonymous styled class component 1`] = `
+"import \\"./emotion.emotion.css\\";
+
+export default styled(class Profile extends React.Component {}, {
+  e: \\"css-1aj1g6z\\",
+  target: \\"e8nbyc50\\"
+})();
+
+
+emotion.emotion.css
+.css-1aj1g6z{color:blue;}"
+`;
+
+exports[`styled extract babel 6 autoLabel anonymous styled dom component with object styles 1`] = `
+"
+export default /*#__PURE__*/styled('h1', {
+  target: 'e8nbyc50',
+  label: 'styled(h1)'
+})({
+  color: 'blue'
+});"
+`;
+
+exports[`styled extract babel 6 autoLabel anonymous styled dom component with string styles 1`] = `
+"import './emotion.emotion.css';
+
+export default styled('h1', {
+  e: 'css-1aj1g6z',
+  target: 'e8nbyc50'
+})();
+
+
+emotion.emotion.css
+.css-1aj1g6z{color:blue;}"
+`;
+
+exports[`styled extract babel 6 autoLabel anonymous styled function component 1`] = `
+"import \\"./emotion.emotion.css\\";
+
+export default styled(function Profile() {}, {
+  e: \\"css-1aj1g6z\\",
+  target: \\"e8nbyc50\\"
+})();
+
+
+emotion.emotion.css
+.css-1aj1g6z{color:blue;}"
+`;
+
+exports[`styled extract babel 6 autoLabel anonymous styled function component via variable identifier 1`] = `
+"import \\"./emotion.emotion.css\\";
+
+const Profile = () => <div />;
+export default styled(Profile, {
+  e: \\"css-1aj1g6z\\",
+  target: \\"e8nbyc50\\"
+})();
+
+
+emotion.emotion.css
+.css-1aj1g6z{color:blue;}"
+`;
+
 exports[`styled extract babel 6 autoLabel object styles 1`] = `
 "
 const Profile = () => {
@@ -347,6 +423,80 @@ import what from 'emotion';what('h1', {
 
 emotion.emotion.css
 .css-14ksm7b{color:blue;}"
+`;
+
+exports[`styled extract babel 7 autoLabel anonymous styled anonymous class component 1`] = `
+"import \\"./emotion.emotion.css\\";
+export default styled(class extends React.Component {}, {
+  e: \\"css-1e93lt2\\",
+  target: \\"e8nbyc50\\"
+})();
+
+
+emotion.emotion.css
+.css-1e93lt2{color:blue;}"
+`;
+
+exports[`styled extract babel 7 autoLabel anonymous styled class component 1`] = `
+"import \\"./emotion.emotion.css\\";
+export default styled(class Profile extends React.Component {}, {
+  e: \\"css-1aj1g6z\\",
+  target: \\"e8nbyc50\\"
+})();
+
+
+emotion.emotion.css
+.css-1aj1g6z{color:blue;}"
+`;
+
+exports[`styled extract babel 7 autoLabel anonymous styled dom component with object styles 1`] = `
+"export default
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e8nbyc50\\",
+  label: \\"styled(h1)\\"
+})({
+  color: 'blue'
+});"
+`;
+
+exports[`styled extract babel 7 autoLabel anonymous styled dom component with string styles 1`] = `
+"import \\"./emotion.emotion.css\\";
+export default styled('h1', {
+  e: \\"css-1aj1g6z\\",
+  target: \\"e8nbyc50\\"
+})();
+
+
+emotion.emotion.css
+.css-1aj1g6z{color:blue;}"
+`;
+
+exports[`styled extract babel 7 autoLabel anonymous styled function component 1`] = `
+"import \\"./emotion.emotion.css\\";
+export default styled(function Profile() {}, {
+  e: \\"css-1aj1g6z\\",
+  target: \\"e8nbyc50\\"
+})();
+
+
+emotion.emotion.css
+.css-1aj1g6z{color:blue;}"
+`;
+
+exports[`styled extract babel 7 autoLabel anonymous styled function component via variable identifier 1`] = `
+"import \\"./emotion.emotion.css\\";
+
+const Profile = () => <div />;
+
+export default styled(Profile, {
+  e: \\"css-1aj1g6z\\",
+  target: \\"e8nbyc50\\"
+})();
+
+
+emotion.emotion.css
+.css-1aj1g6z{color:blue;}"
 `;
 
 exports[`styled extract babel 7 autoLabel object styles 1`] = `
@@ -740,6 +890,56 @@ emotion.emotion.css
 .css-14ksm7b{color:blue;}"
 `;
 
+exports[`styled inline babel 6 autoLabel anonymous styled anonymous class component 1`] = `
+"
+export default /*#__PURE__*/styled(class extends React.Component {}, {
+  target: \\"e8nbyc50\\"
+})(\\"color:blue\\");"
+`;
+
+exports[`styled inline babel 6 autoLabel anonymous styled class component 1`] = `
+"
+export default /*#__PURE__*/styled(class Profile extends React.Component {}, {
+  label: \\"styled(Profile)\\",
+  target: \\"e8nbyc50\\"
+})(\\"color:blue;\\");"
+`;
+
+exports[`styled inline babel 6 autoLabel anonymous styled dom component with object styles 1`] = `
+"
+export default /*#__PURE__*/styled('h1', {
+  target: 'e8nbyc50',
+  label: 'styled(h1)'
+})({
+  color: 'blue'
+});"
+`;
+
+exports[`styled inline babel 6 autoLabel anonymous styled dom component with string styles 1`] = `
+"
+export default /*#__PURE__*/styled('h1', {
+  label: 'styled(h1)',
+  target: 'e8nbyc50'
+})('color:blue;');"
+`;
+
+exports[`styled inline babel 6 autoLabel anonymous styled function component 1`] = `
+"
+export default /*#__PURE__*/styled(function Profile() {}, {
+  label: \\"styled(Profile)\\",
+  target: \\"e8nbyc50\\"
+})(\\"color:blue;\\");"
+`;
+
+exports[`styled inline babel 6 autoLabel anonymous styled function component via variable identifier 1`] = `
+"
+const Profile = () => <div />;
+export default /*#__PURE__*/styled(Profile, {
+  label: \\"styled(Profile)\\",
+  target: \\"e8nbyc50\\"
+})(\\"color:blue;\\");"
+`;
+
 exports[`styled inline babel 6 autoLabel object styles 1`] = `
 "
 const Profile = () => {
@@ -1022,6 +1222,63 @@ exports[`styled inline babel 6 variable import: no dynamic 1`] = `
 "import what from 'emotion'; /*#__PURE__*/what('h1', {
   target: 'e8nbyc50'
 })('color:blue;');"
+`;
+
+exports[`styled inline babel 7 autoLabel anonymous styled anonymous class component 1`] = `
+"export default
+/*#__PURE__*/
+styled(class extends React.Component {}, {
+  target: \\"e8nbyc50\\"
+})(\\"color:blue\\");"
+`;
+
+exports[`styled inline babel 7 autoLabel anonymous styled class component 1`] = `
+"export default
+/*#__PURE__*/
+styled(class Profile extends React.Component {}, {
+  label: \\"styled(Profile)\\",
+  target: \\"e8nbyc50\\"
+})(\\"color:blue;\\");"
+`;
+
+exports[`styled inline babel 7 autoLabel anonymous styled dom component with object styles 1`] = `
+"export default
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e8nbyc50\\",
+  label: \\"styled(h1)\\"
+})({
+  color: 'blue'
+});"
+`;
+
+exports[`styled inline babel 7 autoLabel anonymous styled dom component with string styles 1`] = `
+"export default
+/*#__PURE__*/
+styled('h1', {
+  label: \\"styled(h1)\\",
+  target: \\"e8nbyc50\\"
+})(\\"color:blue;\\");"
+`;
+
+exports[`styled inline babel 7 autoLabel anonymous styled function component 1`] = `
+"export default
+/*#__PURE__*/
+styled(function Profile() {}, {
+  label: \\"styled(Profile)\\",
+  target: \\"e8nbyc50\\"
+})(\\"color:blue;\\");"
+`;
+
+exports[`styled inline babel 7 autoLabel anonymous styled function component via variable identifier 1`] = `
+"const Profile = () => <div />;
+
+export default
+/*#__PURE__*/
+styled(Profile, {
+  label: \\"styled(Profile)\\",
+  target: \\"e8nbyc50\\"
+})(\\"color:blue;\\");"
 `;
 
 exports[`styled inline babel 7 autoLabel object styles 1`] = `

--- a/packages/babel-plugin-emotion/test/styled.test.js
+++ b/packages/babel-plugin-emotion/test/styled.test.js
@@ -279,6 +279,62 @@ const cases = {
     opts: { autoLabel: true }
   },
 
+  'autoLabel anonymous styled function component': {
+    code: `
+      export default styled(function Profile() {})\`
+        color: blue;
+      \`;
+    `,
+    opts: { autoLabel: true }
+  },
+
+  'autoLabel anonymous styled function component via variable identifier': {
+    code: `
+      const Profile = () => <div />;
+      export default styled(Profile)\`
+        color: blue;
+      \`;
+    `,
+    opts: { autoLabel: true }
+  },
+
+  'autoLabel anonymous styled class component': {
+    code: `
+      export default styled(class Profile extends React.Component {})\`
+        color: blue;
+      \`;
+    `,
+    opts: { autoLabel: true }
+  },
+
+  'autoLabel anonymous styled anonymous class component': {
+    code: `
+      export default styled(class extends React.Component{})\`
+        color: blue
+      \`
+    `,
+    opts: { autoLabel: true }
+  },
+
+  'autoLabel anonymous styled dom component with string styles': {
+    code: `
+      export default styled('h1')\`
+        color: blue;
+      \`;
+    `,
+    opts: { autoLabel: true }
+  },
+
+  'autoLabel anonymous styled dom component with object styles': {
+    code: `
+      export default styled.h1({
+        color: 'blue'
+      });
+    `,
+    opts: { autoLabel: true },
+    extract: false
+  },
+
   'component selector': {
     code: `
       const Child = styled.div\`


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: This will attempt to add a name for an anonymously exported styled component, if the component has an available name.

<!-- Why are these changes necessary? -->
**Why**: This will improve `autoLabel` for anonymous/default exports.

<!-- How were these changes implemented? -->
**How**: If there is no identifier name for the styled component use the component name that we are styling. The label becomes `styled(Component)`.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [ ] Code complete

<!-- feel free to add additional comments -->
Please let me know if there are better utility functions to use to get the name of the component of the argument to `styled`.