### PR TITLE
Bind reactPropsRegex to its test method instead of RegExp.prototype.test

### DIFF
--- a/next-packages/is-prop-valid/src/index.js
+++ b/next-packages/is-prop-valid/src/index.js
@@ -4,4 +4,4 @@ declare var codegen: { require: string => RegExp }
 
 const reactPropsRegex = codegen.require('./props')
 
-export default memoize(RegExp.prototype.test.bind(reactPropsRegex))
+export default memoize(reactPropsRegex.test.bind(reactPropsRegex))


### PR DESCRIPTION
Proposing this just because it's shorter