### PR TITLE
styled-elements proof of concept

### DIFF
--- a/next-packages/core/__tests__/__snapshots__/styled-elements.js.snap
+++ b/next-packages/core/__tests__/__snapshots__/styled-elements.js.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Styled Elements - basic element 1`] = `
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  color: hotpink;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`Styled Elements - css 1`] = `
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  color: hotpink;
+  color: green;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`Styled Elements - nested elements 1`] = `
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  color: hotpink;
+}
+
+.emotion-0 {
+  font-size: 18px;
+}
+
+.emotion-1 {
+  outline: none;
+  border: none;
+  background-color: purple;
+}
+
+<div
+  className="emotion-2"
+>
+  <h1
+    className="emotion-0"
+  >
+    Hello
+  </h1>
+  <button
+    className="emotion-1"
+  >
+    Click Me
+  </button>
+</div>
+`;
+
+exports[`Styled Elements - prop function 1`] = `
+.emotion-0 {
+  font-size: 24px;
+}
+
+<div
+  className="emotion-0"
+  fontSize={24}
+/>
+`;
+
+exports[`Styled Elements - prop function with theming 1`] = `
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`Styled Elements - theming 1`] = `
+.emotion-0 {
+  color: hotpink;
+  color: green;
+}
+
+<div
+  className="emotion-0"
+/>
+`;

--- a/next-packages/core/__tests__/styled-elements.js
+++ b/next-packages/core/__tests__/styled-elements.js
@@ -1,0 +1,88 @@
+// @flow
+/** @jsx jsx */
+import 'test-utils/next-env'
+import { jsx } from '@emotion/core'
+import { StyledElementsProvider } from '@emotion/core/src/styled-element-context'
+import ThemeProvider from '@emotion/provider'
+import renderer from 'react-test-renderer'
+
+test('Styled Elements - basic element', () => {
+  const tree = renderer.create(
+    <StyledElementsProvider
+      components={{ div: { display: 'flex', color: 'hotpink' } }}
+    >
+      <div />
+    </StyledElementsProvider>
+  )
+
+  expect(tree.toJSON()).toMatchSnapshot()
+})
+
+test('Styled Elements - nested elements', () => {
+  const tree = renderer.create(
+    <StyledElementsProvider
+      components={{
+        div: { display: 'flex', color: 'hotpink' },
+        h1: { fontSize: 18 },
+        button: { outline: 'none', border: 'none', backgroundColor: 'purple' }
+      }}
+    >
+      <div>
+        <h1>Hello</h1>
+        <button>Click Me</button>
+      </div>
+    </StyledElementsProvider>
+  )
+
+  expect(tree.toJSON()).toMatchSnapshot()
+})
+
+test('Styled Elements - css', () => {
+  const tree = renderer.create(
+    <StyledElementsProvider
+      components={{ div: { display: 'flex', color: 'hotpink' } }}
+    >
+      <div css={{ color: 'green' }} />
+    </StyledElementsProvider>
+  )
+
+  expect(tree.toJSON()).toMatchSnapshot()
+})
+
+test('Styled Elements - prop function', () => {
+  const tree = renderer.create(
+    <StyledElementsProvider
+      components={{ div: ({ fontSize }) => ({ fontSize: fontSize || 8 }) }}
+    >
+      <div fontSize={24} />
+    </StyledElementsProvider>
+  )
+
+  expect(tree.toJSON()).toMatchSnapshot()
+})
+
+test('Styled Elements - theming', () => {
+  const tree = renderer.create(
+    <StyledElementsProvider components={{ div: { color: 'hotpink' } }}>
+      <ThemeProvider theme={{ primary: 'green' }}>
+        <div css={theme => ({ color: theme.primary })} />
+      </ThemeProvider>
+    </StyledElementsProvider>
+  )
+
+  expect(tree.toJSON()).toMatchSnapshot()
+})
+
+test('Styled Elements - prop function with theming', () => {
+  const tree = renderer.create(
+    <StyledElementsProvider
+      components={{ div: ({ theme }) => ({ color: theme.color }) }}
+    >
+      <ThemeProvider theme={{ primary: 'green' }}>
+        <div />
+      </ThemeProvider>
+    </StyledElementsProvider>
+  )
+
+  expect(tree.toJSON()).toMatchSnapshot()
+})

--- a/next-packages/core/src/jsx.js
+++ b/next-packages/core/src/jsx.js
@@ -1,20 +1,24 @@
 // @flow
 import * as React from 'react'
 import { consume } from './context'
+import { consumeStyledElementsContext } from './styled-element-context'
 import { getRegisteredStyles, insertStyles, isBrowser } from '@emotion/utils'
 import { serializeStyles } from '@emotion/serialize'
+import { testAlwaysTrue, pickAssign } from '@emotion/styled-base/src/utils'
 
 // $FlowFixMe
 export const jsx: typeof React.createElement = function(
   type: React.ElementType,
   props: Object
 ) {
-  if (props == null || props.css == null) {
-    // $FlowFixMe
-    return React.createElement.apply(undefined, arguments)
-  }
+  // if (props == null || props.css == null) {
+  //   // $FlowFixMe
+  //   return React.createElement.apply(undefined, arguments)
+  // }
 
   if (
+    props &&
+    props.css &&
     typeof props.css === 'string' &&
     process.env.NODE_ENV !== 'production' &&
     // check if there is a css declaration
@@ -27,58 +31,93 @@ export const jsx: typeof React.createElement = function(
     )
   }
 
-  return consume(context => {
-    let registeredStyles = []
+  return consume(themeContext =>
+    consumeStyledElementsContext(styledElementsContext => {
+      const newProps = {}
+      let registeredStyles = []
+      let className = ''
 
-    let className = ''
-    if (props.className !== undefined) {
-      className = getRegisteredStyles(
-        context.registered,
-        registeredStyles,
-        props.className
-      )
-    }
-    registeredStyles.push(
-      typeof props.css === 'function' ? props.css(context.theme) : props.css
-    )
-    const serialized = serializeStyles(context.registered, registeredStyles)
-    const rules = insertStyles(context, serialized, typeof type === 'string')
-    className += `${context.key}-${serialized.name}`
-
-    const newProps = {}
-    for (let key in props) {
-      if (Object.prototype.hasOwnProperty.call(props, key) && key !== 'css') {
-        newProps[key] = props[key]
+      if (styledElementsContext[type]) {
+        registeredStyles.push(
+          typeof styledElementsContext[type] === 'function'
+            ? styledElementsContext[type](
+                pickAssign(testAlwaysTrue, {}, props, {
+                  theme: themeContext.theme
+                })
+              )
+            : styledElementsContext[type]
+        )
       }
-    }
-    newProps.className = className
 
-    let argsLength = arguments.length
+      if (props && props.className !== undefined) {
+        className = getRegisteredStyles(
+          themeContext.registered,
+          registeredStyles,
+          props.className
+        )
+      }
 
-    let createElementArgArray = new Array(argsLength)
-    createElementArgArray[0] = type
-    createElementArgArray[1] = newProps
+      if (props && props.css) {
+        registeredStyles.push(
+          typeof props.css === 'function'
+            ? props.css(themeContext.theme)
+            : props.css
+        )
+      }
 
-    for (let i = 2; i < argsLength; i++) {
-      createElementArgArray[i] = arguments[i]
-    }
-
-    // $FlowFixMe
-    const ele = React.createElement.apply(undefined, createElementArgArray)
-    if (!isBrowser && rules !== undefined) {
-      return (
-        <React.Fragment>
-          <style
-            {...{
-              [`data-emotion-${context.key}`]: serialized.name,
-              dangerouslySetInnerHTML: { __html: rules },
-              nonce: context.sheet.nonce
-            }}
-          />
-          {ele}
-        </React.Fragment>
+      const serialized = serializeStyles(
+        themeContext.registered,
+        registeredStyles
       )
-    }
-    return ele
-  })
+
+      const rules = insertStyles(
+        themeContext,
+        serialized,
+        typeof type === 'string'
+      )
+
+      className += `${themeContext.key}-${serialized.name}`
+
+      if (props) {
+        for (let key in props) {
+          if (
+            Object.prototype.hasOwnProperty.call(props, key) &&
+            key !== 'css'
+          ) {
+            newProps[key] = props[key]
+          }
+        }
+      }
+
+      newProps.className = className
+
+      let argsLength = arguments.length
+      let createElementArgArray = new Array(argsLength)
+
+      createElementArgArray[1] = newProps
+      createElementArgArray[0] = type
+
+      for (let i = 2; i < argsLength; i++) {
+        createElementArgArray[i] = arguments[i]
+      }
+
+      // $FlowFixMe
+      const ele = React.createElement.apply(undefined, createElementArgArray)
+      if (!isBrowser && rules !== undefined) {
+        return (
+          <React.Fragment>
+            <style
+              {...{
+                [`data-emotion-${themeContext.key}`]: serialized.name,
+                dangerouslySetInnerHTML: { __html: rules },
+                nonce: themeContext.sheet.nonce
+              }}
+            />
+            {ele}
+          </React.Fragment>
+        )
+      }
+      return ele
+    })
+  )
 }

--- a/next-packages/core/src/styled-element-context.js
+++ b/next-packages/core/src/styled-element-context.js
@@ -1,0 +1,34 @@
+// @flow
+import * as React from 'react'
+
+let StyledElementsContext = React.createContext({})
+
+let StyledElementsProvider = ({ components, children }) => (
+  <StyledElementsContext.Provider value={components}>
+    {children}
+  </StyledElementsContext.Provider>
+)
+
+let withStyledElementsContext = function withStyledElementsContext<Props>(
+  func: (props: Props, context: StyledElementsContextType) => React.Node
+): React.StatelessFunctionalComponent<Props> {
+  return (props: Props) => (
+    <StyledElementsContext.Consumer>
+      {(contextComponents: StyledElementsContextType) => {
+        return func(props, contextComponents)
+      }}
+    </StyledElementsContext.Consumer>
+  )
+}
+
+let consumeStyledElementsContext = (
+  func: StyledElementsContextType => React.Node
+) => {
+  return <StyledElementsContext.Consumer>{func}</StyledElementsContext.Consumer>
+}
+
+export {
+  StyledElementsProvider,
+  consumeStyledElementsContext,
+  withStyledElementsContext
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
This is adding a new feature to the emotion 10 custom `createElement`. It allows the developer to style elements in a context provider that are applied to the elements as they are created.

```js
/** @jsx jsx */

<StyledElementsProvider
  components={{
    div: { display: 'flex', color: 'hotpink' },
    h1: { fontSize: 18 },
    button: { outline: 'none', border: 'none', backgroundColor: 'purple' }
  }}
>
  <div>
    <h1>Hello</h1>
    <button>Click Me</button>
  </div>
</StyledElementsProvider>
```

Will output:
```html
.emotion-2 {
  display: -webkit-box;
  display: -webkit-flex;
  display: -ms-flexbox;
  display: flex;
  color: hotpink;
}

.emotion-0 {
  font-size: 18px;
}

.emotion-1 {
  outline: none;
  border: none;
  background-color: purple;
}

<div
  className="emotion-2"
>
  <h1
    className="emotion-0"
  >
    Hello
  </h1>
  <button
    className="emotion-1"
  >
    Click Me
  </button>
</div>
```

A few more supported cases as of right now:
```js
<StyledElementsProvider
  components={{ div: ({ fontSize }) => ({ fontSize: fontSize || 8 }) }}
>
  <div fontSize={24} />
</StyledElementsProvider>
```

```js
<StyledElementsProvider
  components={{ div: ({ theme }) => ({ color: theme.color }) }}
>
  <ThemeProvider theme={{ primary: 'green' }}>
    <div />
  </ThemeProvider>
</StyledElementsProvider>
```
<!-- Why are these changes necessary? -->
**Why**:

Talking to @ChristopherBiscardi about how MDX custom component providers work I wanted to see if we could build something like that into emotion. This concept allows for a more focused approach to styling default elements. This concept should be expanded to include custom elements and add proper support for nested `StyledElementProvider`'s.

<!-- How were these changes implemented? -->
**How**:

Added some simple hooks into the `jsx` but I fear I may added some perf regressions with this initial attempt. Any help here would be appreciated.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->

<!-- Please add a `Tag:` prefixed label from the labels so that this PR shows up in the changelog -->
