### PR TITLE
jest-emotion: sometimes method `getAttribute` is not avail

### DIFF
--- a/packages/jest-emotion/src/utils.js
+++ b/packages/jest-emotion/src/utils.js
@@ -32,10 +32,7 @@ function getClassNamesFromCheerio(selectors, node) {
 }
 
 function getClassNamesFromDOMElement(selectors, node: any) {
-  return getClassNames(
-    selectors,
-    node.getAttribute && node.getAttribute('class')
-  )
+  return getClassNames(selectors, node.getAttribute('class'))
 }
 
 export function isReactElement(val: any): boolean {

--- a/packages/jest-emotion/src/utils.js
+++ b/packages/jest-emotion/src/utils.js
@@ -32,7 +32,10 @@ function getClassNamesFromCheerio(selectors, node) {
 }
 
 function getClassNamesFromDOMElement(selectors, node: any) {
-  return getClassNames(selectors, node.getAttribute && node.getAttribute('class'))
+  return getClassNames(
+    selectors, 
+    node.getAttribute && node.getAttribute('class')
+  )
 }
 
 export function isReactElement(val: any): boolean {

--- a/packages/jest-emotion/src/utils.js
+++ b/packages/jest-emotion/src/utils.js
@@ -63,6 +63,9 @@ function isCheerioElement(val: any): boolean {
 
 export function getClassNamesFromNodes(nodes: Array<any>) {
   return nodes.reduce((selectors, node) => {
+    if(Array.isArray(node)) {
+      return node.reduce((s, n) => [...s, ...getClassNamesFromNodes(selectors, n)], [])
+    } 
     if (isReactElement(node)) {
       return getClassNamesFromTestRenderer(selectors, node)
     } else if (isEnzymeElement(node)) {

--- a/packages/jest-emotion/src/utils.js
+++ b/packages/jest-emotion/src/utils.js
@@ -32,7 +32,7 @@ function getClassNamesFromCheerio(selectors, node) {
 }
 
 function getClassNamesFromDOMElement(selectors, node: any) {
-  return getClassNames(selectors, node.getAttribute('class'))
+  return getClassNames(selectors, node.getAttribute && node.getAttribute('class'))
 }
 
 export function isReactElement(val: any): boolean {

--- a/packages/jest-emotion/src/utils.js
+++ b/packages/jest-emotion/src/utils.js
@@ -33,7 +33,7 @@ function getClassNamesFromCheerio(selectors, node) {
 
 function getClassNamesFromDOMElement(selectors, node: any) {
   return getClassNames(
-    selectors, 
+    selectors,
     node.getAttribute && node.getAttribute('class')
   )
 }


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: bug in jest-emotion method `getAttribute` is not avail, while jest creating snapshot

<!-- Why are these changes necessary? -->
**Why**: in combination with `ReactDom.createPortal` it might can be `getAttribute` is not avail

<!-- How were these changes implemented? -->
**How**: just check if the method is avail

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->

<!-- Please add a `Tag:` prefixed label from the labels so that this PR shows up in the changelog -->
