### PR TITLE
Add typescript types for channel and createBroadcast in emotion-theming

### DIFF
--- a/packages/emotion-theming/types/index.d.ts
+++ b/packages/emotion-theming/types/index.d.ts
@@ -20,3 +20,7 @@ export interface EmotionThemingModule<Theme> {
     ThemeProvider: ThemeProviderComponent<Theme>;
     withTheme<Props>(component: ComponentClass<Props> | SFC<Props>): ComponentClass<OptionalThemeProps<Props, Theme>>;
 }
+
+export const channel: string;
+
+export function createBroadcast(initialState: any): any;

--- a/packages/emotion-theming/types/tests.tsx
+++ b/packages/emotion-theming/types/tests.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as emotionTheming from '../';
 // tslint:disable-next-line:no-duplicate-imports
-import { ThemeProvider, withTheme, EmotionThemingModule } from '../';
+import { ThemeProvider, withTheme, EmotionThemingModule, channel, createBroadcast } from '../';
 
 const theme = { primary: "green", secondary: "white" };
 const CompSFC = (props: { prop: boolean }) => <div />;
@@ -37,3 +37,8 @@ const TypedThemedSFC = typedWithTheme(ThemedSFC);
 const TypedCompSFC = typedWithTheme(CompSFC);
 <TypedCompSFC prop />;
 <TypedCompSFC theme={theme} prop />;
+
+const context = {
+    [channel]: createBroadcast({})
+};
+context;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Added typescript types for channel and createBroadcast.

<!-- Why are these changes necessary? -->
**Why**:
To match exported types with actual objects being exported by emotion-theming.

<!-- How were these changes implemented? -->
**How**:
By manually modifying `emotion-theming` typescript type definitions file.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation - N/A
- [X] Tests
- [X] Code complete

<!-- feel free to add additional comments -->

<!-- Please add a `Tag:` prefixed label from the labels so that this PR shows up in the changelog -->
