### PR TITLE
Add Typescript typings for `primitives` and `primitives-core`

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2,7 +2,7 @@
 title: "Typescript"
 ---
 
-Emotion includes TypeScript definitions for `emotion`, `react-emotion`, `preact-emotion`, `create-emotion`, and `create-emotion-styled`. These definitions also infer types for css properties with the object syntax, HTML/SVG tag names, and prop types.
+Emotion includes TypeScript definitions for `emotion`, `react-emotion`, `preact-emotion`, `create-emotion`, `create-emotion-styled`, `@emotion/primitives` and `@emotion/primitives-core`. These definitions also infer types for css properties with the object syntax, HTML/SVG tag names, and prop types.
 
 ## emotion
 
@@ -269,3 +269,50 @@ const bodyStyle = myEmotion.css({
 ## create-emotion-styled
 
 The current typings for `create-emotion-styled` are only compatible with React, and will not work with Preact. For detail typing, see the [`react-emotion` section](#react-emotion) above.
+
+## @emotion/primitives
+
+The usage for `@emotion/primitives` is the same as for `react-emotion` except for creating emotion instances from strings.
+
+```tsx
+import styled from '@emotion/primitives'
+import { View } from 'react-primitives'
+
+const Component = styled.View({
+  color: 'red'
+})
+
+const OtherComponent = styled(View)({
+  color: 'red'
+})
+
+interface Props {
+  width: number
+}
+
+const ComponentWithProps = styled(View)(
+  ({ width }: Props) => ({
+    color: 'red',
+    width
+  })
+)
+```
+
+## @emotion/primitives-core
+
+```tsx
+import {
+  createStyled,
+  createCss
+} from '@emotion/primitives-core'
+
+import { StyleSheet } from 'react-primitives'
+
+createStyled(StyleSheet, {
+  shouldForwardProp: () => true
+})
+
+const css = createCss(StyleSheet)({
+  color: 'blue'
+})
+```

--- a/packages/primitives-core/package.json
+++ b/packages/primitives-core/package.json
@@ -7,7 +7,8 @@
   "module": "dist/index.esm.js",
   "files": [
     "src",
-    "dist"
+    "dist",
+    "types"
   ],
   "scripts": {
     "test:typescript": "dtslint types"

--- a/packages/primitives-core/package.json
+++ b/packages/primitives-core/package.json
@@ -3,14 +3,19 @@
   "version": "9.2.7",
   "description": "Shared utilities for emotion primitives and native",
   "main": "dist/index.cjs.js",
+  "types": "types/index.d.ts",
   "module": "dist/index.esm.js",
   "files": [
     "src",
     "dist"
   ],
+  "scripts": {
+    "test:typescript": "dtslint types"
+  },
   "license": "MIT",
   "dependencies": {
     "@emotion/is-prop-valid": "^0.6.3",
+    "@types/react-native": "^0.56.19",
     "css-to-react-native": "^2.2.1"
   },
   "peerDependencies": {

--- a/packages/primitives-core/types/common.d.ts
+++ b/packages/primitives-core/types/common.d.ts
@@ -11,6 +11,10 @@ import {
   ClassInterpolation
 } from 'create-emotion';
 
+export interface StyledOptions {
+  shouldForwardProp?: (name: string) => boolean;
+}
+
 export type BasePrimitivesStyle = ViewStyle | TextStyle | ImageStyle;
 
 export type BaseInterpolation =

--- a/packages/primitives-core/types/common.d.ts
+++ b/packages/primitives-core/types/common.d.ts
@@ -5,17 +5,21 @@
 
 import { ViewStyle, TextStyle, ImageStyle } from 'react-native';
 
-import {
-  Emotion,
-  ArrayInterpolation as BaseArrayInterpolation,
-  ClassInterpolation
-} from 'create-emotion';
-
 export interface StyledOptions {
   shouldForwardProp?: (name: string) => boolean;
 }
 
 export type BasePrimitivesStyle = ViewStyle | TextStyle | ImageStyle;
+
+export interface BaseArrayInterpolation extends Array<BaseInterpolation> {}
+
+export interface ClassInterpolation extends Function {
+  __emotion_real: any;
+  __emotion_styles: BaseInterpolation[];
+  __emotion_base: ClassInterpolation;
+  __emotion_target: string;
+  __emotion_forwardProp: undefined | null | ((arg: string) => boolean);
+}
 
 export type BaseInterpolation =
   | undefined
@@ -30,6 +34,7 @@ export type BaseInterpolation =
 
 export interface ArrayInterpolation<Props>
   extends Array<Interpolation<Props>> {}
+
 export type FunctionInterpolation<Props> = (
   props: Props,
   context: any

--- a/packages/primitives-core/types/common.d.ts
+++ b/packages/primitives-core/types/common.d.ts
@@ -1,0 +1,37 @@
+// Definitions by:
+// Junyoung Clare Jang <https://github.com/Ailrun>
+// Sam Pettersson <https://github.com/iamsamwhoami>
+// TypeScript Version: 2.3
+
+import { ViewStyle, TextStyle, ImageStyle } from 'react-native';
+
+import {
+  Emotion,
+  ArrayInterpolation as BaseArrayInterpolation,
+  ClassInterpolation
+} from 'create-emotion';
+
+export type BasePrimitivesStyle = ViewStyle | TextStyle | ImageStyle;
+
+export type BaseInterpolation =
+  | undefined
+  | null
+  | boolean
+  | string
+  | number
+  | TemplateStringsArray
+  | BasePrimitivesStyle
+  | BaseArrayInterpolation
+  | ClassInterpolation;
+
+export interface ArrayInterpolation<Props>
+  extends Array<Interpolation<Props>> {}
+export type FunctionInterpolation<Props> = (
+  props: Props,
+  context: any
+) => Interpolation<Props>;
+
+export type Interpolation<Props> =
+  | BaseInterpolation
+  | ArrayInterpolation<Props>
+  | FunctionInterpolation<Props>;

--- a/packages/primitives-core/types/index.d.ts
+++ b/packages/primitives-core/types/index.d.ts
@@ -1,0 +1,45 @@
+// Definitions by:
+// Junyoung Clare Jang <https://github.com/Ailrun>
+// Sam Pettersson <https://github.com/iamsamwhoami>
+// TypeScript Version: 2.3
+
+import { Emotion, Interpolation as BaseInterpolation } from 'create-emotion';
+import * as React from 'react';
+
+import {
+  CreateStyled,
+  CreateStyledOtherComponent,
+  CreateStyledStatelessComponent,
+  StyledComponent,
+  StyledComponentMethods,
+  StyledOtherComponent,
+  StyledStatelessComponent
+} from './react';
+
+import {
+  ArrayInterpolation,
+  FunctionInterpolation,
+  Interpolation
+} from './common';
+
+import { StyledOptions, Themed } from 'create-emotion-styled/types/common';
+
+export {
+  ArrayInterpolation,
+  FunctionInterpolation,
+  Interpolation,
+  StyledOptions,
+  Themed,
+  CreateStyled,
+  CreateStyledOtherComponent,
+  CreateStyledStatelessComponent,
+  StyledComponent,
+  StyledComponentMethods,
+  StyledOtherComponent,
+  StyledStatelessComponent
+};
+
+export default function createEmotionStyled(
+  emotion: Emotion,
+  view: typeof React
+): CreateStyled;

--- a/packages/primitives-core/types/index.d.ts
+++ b/packages/primitives-core/types/index.d.ts
@@ -3,7 +3,8 @@
 // Sam Pettersson <https://github.com/iamsamwhoami>
 // TypeScript Version: 2.3
 
-import { Emotion, Interpolation as BaseInterpolation } from 'create-emotion';
+import { StyleSheet } from 'react-primitives';
+import { Emotion } from 'create-emotion';
 import * as React from 'react';
 
 import {
@@ -19,10 +20,12 @@ import {
 import {
   ArrayInterpolation,
   FunctionInterpolation,
-  Interpolation
+  BaseInterpolation,
+  Interpolation,
+  StyledOptions
 } from './common';
 
-import { StyledOptions, Themed } from 'create-emotion-styled/types/common';
+import { Themed } from 'create-emotion-styled/types/common';
 
 export {
   ArrayInterpolation,
@@ -39,7 +42,15 @@ export {
   StyledStatelessComponent
 };
 
-export default function createEmotionStyled(
-  emotion: Emotion,
-  view: typeof React
-): CreateStyled;
+type CreatePrimitivesStyled = (
+  styleSheet: typeof StyleSheet,
+  options: StyledOptions
+) => CreateStyled;
+
+export const createStyled: CreatePrimitivesStyled;
+
+type CreatePrimitivesCss = (
+  styleSheet: typeof StyleSheet
+) => (...args: BaseInterpolation[]) => string;
+
+export const createCss: CreatePrimitivesCss;

--- a/packages/primitives-core/types/index.d.ts
+++ b/packages/primitives-core/types/index.d.ts
@@ -5,7 +5,6 @@
 
 import { StyleSheet } from 'react-primitives';
 import { Emotion } from 'create-emotion';
-import * as React from 'react';
 
 import {
   CreateStyled,

--- a/packages/primitives-core/types/react.d.ts
+++ b/packages/primitives-core/types/react.d.ts
@@ -4,9 +4,8 @@
 // TypeScript Version: 2.3
 
 import { ComponentType, ComponentClass, Ref, SFC } from 'react';
-import { ClassInterpolation } from 'create-emotion';
 
-import { Interpolation, StyledOptions } from './common';
+import { Interpolation, StyledOptions, ClassInterpolation } from './common';
 
 import {
   StyledOtherProps,

--- a/packages/primitives-core/types/react.d.ts
+++ b/packages/primitives-core/types/react.d.ts
@@ -1,0 +1,87 @@
+// Definitions by:
+// Junyoung Clare Jang <https://github.com/Ailrun>
+// Sam Pettersson <https://github.com/iamsamwhoami>
+// TypeScript Version: 2.3
+
+import { ComponentType, ComponentClass, Ref, SFC } from 'react';
+import { ClassInterpolation } from 'create-emotion';
+
+import { Interpolation } from './common';
+
+import {
+  StyledOptions,
+  StyledOtherProps,
+  StyledStatelessProps,
+  Themed
+} from 'create-emotion-styled/types/common';
+
+export interface StyledComponentMethods<
+  Props extends object,
+  InnerProps extends object,
+  Theme extends object
+> {
+  withComponent<IP extends object>(
+    component: SFC<IP>,
+    options?: StyledOptions
+  ): StyledStatelessComponent<Props, IP, Theme>;
+
+  withComponent<IP extends object>(
+    component: ComponentClass<IP> | ComponentType<IP>,
+    options?: StyledOptions
+  ): StyledOtherComponent<Props, IP, Theme>;
+}
+
+export interface StyledStatelessComponent<
+  Props extends object,
+  InnerProps extends object,
+  Theme extends object
+>
+  extends ComponentClass<StyledStatelessProps<Props & InnerProps, Theme>>,
+    ClassInterpolation,
+    StyledComponentMethods<Props, InnerProps, Theme> {}
+
+export interface StyledOtherComponent<
+  Props extends object,
+  InnerProps extends object,
+  Theme extends object
+>
+  extends ComponentClass<StyledOtherProps<Props & InnerProps, Theme, Ref<any>>>,
+    ClassInterpolation,
+    StyledComponentMethods<Props, InnerProps, Theme> {}
+
+export type StyledComponent<
+  Props extends object,
+  InnerProps extends object,
+  Theme extends object
+> =
+  | StyledStatelessComponent<Props, InnerProps, Theme>
+  | StyledOtherComponent<Props, InnerProps, Theme>;
+
+export type CreateStyledStatelessComponent<
+  InnerProps extends object,
+  Theme extends object
+> = <Props extends object, OverridedTheme extends object = Theme>(
+  ...args: Array<Interpolation<Themed<Props, OverridedTheme>>>
+) => StyledStatelessComponent<Props, InnerProps, OverridedTheme>;
+
+export type CreateStyledOtherComponent<
+  InnerProps extends object,
+  Theme extends object
+> = <Props extends object, OverridedTheme extends object = Theme>(
+  ...args: Array<Interpolation<Themed<Props, OverridedTheme>>>
+) => StyledOtherComponent<Props, InnerProps, OverridedTheme>;
+
+export interface CreateStyledFunction<Theme extends object> {
+  <IP extends object>(
+    component: SFC<IP>,
+    options?: StyledOptions
+  ): CreateStyledStatelessComponent<IP, Theme>;
+
+  <IP extends object>(
+    component: ComponentClass<IP> | ComponentType<IP>,
+    options?: StyledOptions
+  ): CreateStyledOtherComponent<IP, Theme>;
+}
+
+export interface CreateStyled<Theme extends object = any>
+  extends CreateStyledFunction<Theme> {}

--- a/packages/primitives-core/types/react.d.ts
+++ b/packages/primitives-core/types/react.d.ts
@@ -6,10 +6,9 @@
 import { ComponentType, ComponentClass, Ref, SFC } from 'react';
 import { ClassInterpolation } from 'create-emotion';
 
-import { Interpolation } from './common';
+import { Interpolation, StyledOptions } from './common';
 
 import {
-  StyledOptions,
   StyledOtherProps,
   StyledStatelessProps,
   Themed

--- a/packages/primitives-core/types/tests.ts
+++ b/packages/primitives-core/types/tests.ts
@@ -1,0 +1,10 @@
+import { StyleSheet } from 'react-primitives';
+import { createStyled, createCss } from '../';
+
+createStyled(StyleSheet, {
+  shouldForwardProp: () => true
+});
+
+const css = createCss(StyleSheet)({
+  color: 'blue'
+});

--- a/packages/primitives-core/types/tsconfig.json
+++ b/packages/primitives-core/types/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "baseUrl": "../",
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "lib": ["es6", "dom"],
+    "module": "commonjs",
+    "noEmit": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "target": "es5",
+    "typeRoots": ["../"],
+    "types": []
+  },
+  "include": ["./*.ts", "./*.tsx"]
+}

--- a/packages/primitives-core/types/tslint.json
+++ b/packages/primitives-core/types/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "dtslint/dtslint.json",
+  "rules": {
+    "no-relative-import-in-test": false
+  }
+}

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -6,7 +6,8 @@
   "types": "types/index.d.ts",
   "files": [
     "src",
-    "dist"
+    "dist",
+    "types"
   ],
   "scripts": {
     "test:typescript": "dtslint types"

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -3,12 +3,18 @@
   "version": "9.2.8",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
+  "types": "types/index.d.ts",
   "files": [
     "src",
     "dist"
   ],
+  "scripts": {
+    "test:typescript": "dtslint types"
+  },
   "dependencies": {
     "@emotion/primitives-core": "^9.2.7",
+    "@types/react-native": "^0.56.19",
+    "@types/react-primitives": "^0.6.2",
     "babel-plugin-emotion": "^9.2.8"
   },
   "peerDependencies": {

--- a/packages/primitives/types/index.d.ts
+++ b/packages/primitives/types/index.d.ts
@@ -1,0 +1,52 @@
+// Definitions by:
+// Junyoung Clare Jang <https://github.com/Ailrun>
+// Sam Pettersson <https://github.com/iamsamwhoami>
+// TypeScript Version: 2.3
+
+import {
+  CreateStyled,
+  Interpolation,
+  StyledComponent,
+  StyledOptions,
+  Themed,
+  CreateStyledOtherComponent
+} from '@emotion/primitives-core';
+
+import { BaseInterpolation } from '@emotion/primitives-core/types/common';
+
+import { ImageProps, ViewProps, TextProps } from 'react-native';
+
+export * from 'emotion';
+
+export type ThemedReactEmotionInterface<Theme extends object> = CreateStyled<
+  Theme
+>;
+
+declare module 'react-native' {
+  interface ViewProps {
+    css?: BaseInterpolation;
+  }
+
+  interface ImageProps {
+    css?: BaseInterpolation;
+  }
+
+  interface TextProps {
+    css?: BaseInterpolation;
+  }
+}
+
+export interface CreateStyledPrimitivesShorthand<Theme extends object> {
+  View: CreateStyledOtherComponent<ViewProps, Theme>;
+  Image: CreateStyledOtherComponent<ImageProps, Theme>;
+  Text: CreateStyledOtherComponent<TextProps, Theme>;
+}
+
+export { CreateStyled, Interpolation, StyledComponent, StyledOptions, Themed };
+
+export interface CreateStyledPrimitives<Theme extends object = any>
+  extends CreateStyled<Theme>,
+    CreateStyledPrimitivesShorthand<Theme> {}
+
+declare const styled: CreateStyledPrimitives;
+export default styled;

--- a/packages/primitives/types/index.d.ts
+++ b/packages/primitives/types/index.d.ts
@@ -22,20 +22,6 @@ export type ThemedReactEmotionInterface<Theme extends object> = CreateStyled<
   Theme
 >;
 
-declare module 'react-native' {
-  interface ViewProps {
-    css?: BaseInterpolation;
-  }
-
-  interface ImageProps {
-    css?: BaseInterpolation;
-  }
-
-  interface TextProps {
-    css?: BaseInterpolation;
-  }
-}
-
 export interface CreateStyledPrimitivesShorthand<Theme extends object> {
   View: CreateStyledOtherComponent<ViewProps, Theme>;
   Image: CreateStyledOtherComponent<ImageProps, Theme>;

--- a/packages/primitives/types/tests.tsx
+++ b/packages/primitives/types/tests.tsx
@@ -1,0 +1,195 @@
+// tslint:disable-next-line:no-implicit-dependencies
+import * as React from 'react';
+import styled, { flush, CreateStyledPrimitives } from '../';
+import { View, Text, Image } from 'react-primitives';
+import { Insets } from 'react-native';
+
+/*
+ * Inference react-primitives Props
+ */
+const Component1 = styled(View)({ color: 'red' });
+const mountComponent1 = <Component1 hitSlop={{ top: 1 }} />;
+
+const Component2 = styled.View`
+  color: red;
+`;
+const mountComponent2 = <Component2 hitSlop={{ top: 1 }} />;
+
+const Component3 = styled(View)`
+  color: red;
+`;
+const mountComponent3 = <Component3 hitSlop={{ top: 1 }} />;
+
+const Component4 = styled.View({ color: 'red' });
+const mountComponent4 = <Component4 hitSlop={{ top: 1 }} />;
+
+const Component5 = styled(View)({ color: 'red' });
+const mountComponent5 = <Component5 hitSlop={{ top: 1 }} />;
+
+/*
+ * Passing custom props
+ */
+interface CustomProps {
+  lookColor: string;
+}
+
+const Component6 = styled.View<CustomProps>(
+  { color: 'blue' },
+  props => ({
+    backgroundColor: props.lookColor
+  }),
+  props => ({
+    borderColor: props.lookColor
+  })
+);
+const mountComponent6 = <Component6 lookColor="red" />;
+
+const Component7 = styled(View)<CustomProps>({ color: 'blue' }, props => ({
+  backgroundColor: props.lookColor
+}));
+const mountComponent7 = <Component7 lookColor="red" />;
+
+const anotherColor = 'blue';
+const Component8 = styled(View)`
+  background: ${(props: CustomProps) => props.lookColor};
+  color: ${anotherColor};
+`;
+const mountComponent8 = <Component8 lookColor="red" />;
+
+/*
+ * With other components
+ */
+interface CustomProps2 {
+  customProp: string;
+}
+interface SFCComponentProps {
+  hitSlop?: Insets;
+  foo: string;
+}
+
+const SFCComponent: React.StatelessComponent<SFCComponentProps> = props => (
+  <View hitSlop={props.hitSlop}>{props.children}</View>
+);
+
+declare class MyClassC extends React.Component<CustomProps2> {}
+
+// infer SFCComponentProps
+const Component9 = styled(SFCComponent)({ color: 'red' });
+const mountComponent9 = <Component9 foo="bar" />;
+
+// infer SFCComponentProps
+const Component10 = styled(SFCComponent)`
+  color: red;
+`;
+const mountComponent10 = <Component10 foo="bar" />;
+
+const Component11 = styled(MyClassC)``;
+const mountComponent11 = <Component11 customProp="abc" />;
+
+// do not infer SFCComponentProps with pass CustomProps, need to pass both
+const Component12 = styled(SFCComponent)<CustomProps2>(
+  {
+    color: 'red'
+  },
+  props => ({
+    backgroundColor: props.customProp
+  })
+);
+const mountComponent12 = <Component12 customProp="red" foo="bar" />;
+
+// do not infer SFCComponentProps with pass CustomProps, need to pass both
+const Component13 = styled(SFCComponent)`
+  color: red;
+  backgroundcolor: ${(props: CustomProps2) => props.customProp};
+`;
+const mountComponent13 = <Component13 customProp="red" foo="bar" />;
+
+/*
+ * With explicit theme
+ */
+
+interface Theme {
+  color: {
+    primary: string
+    secondary: string
+  };
+}
+
+const _styled = styled as CreateStyledPrimitives<Theme>;
+
+const Component14 = _styled.View`
+    color: ${props => props.theme.color.primary}
+  `;
+const mountComponent14 = <Component14 hitSlop={{ top: 1 }} />;
+
+/*
+ * withComponent
+ */
+
+interface CustomProps3 {
+  bgColor: string;
+}
+
+const Component15 = styled.View<CustomProps3>(props => ({
+  backgroundColor: props.bgColor
+}));
+
+const Component16 = Component15.withComponent(Text);
+const mountComponent16 = <Component16 minimumFontScale={2} bgColor="red" />;
+
+const Component17 = Component15.withComponent(Image);
+const mountComponent17 = <Component17 source={{ uri: 'dummy' }} bgColor="red" />;
+
+/*
+   * Can use emotion helpers importing from react-emotion
+   */
+
+flush();
+
+/**
+ * innerRef
+ */
+
+const Component18 = styled(View)``;
+const mountComponent18 = (
+  <Component18 innerRef={(element: React.Ref<View>) => {}} />
+);
+
+const Component19 = styled.View``;
+const mountComponent19 = (
+  <Component19 innerRef={(element: React.Ref<View>) => {}} />
+);
+
+const Component20 = styled.View({});
+const mountComponent20 = (
+  <Component20 innerRef={(element: React.Ref<View>) => {}} />
+);
+
+const Component21 = Component18.withComponent(Image);
+const mountComponent21 = (
+  <Component21
+    innerRef={(element: React.Ref<View>) => {}}
+    source={{ uri: 'dummy' }}
+  />
+);
+
+/**
+ * css prop
+ */
+const Component22 = styled.View({ color: 'red' });
+const mountCssProp1 = <Component22 css={{ color: 'blue' }} />;
+const mountCssProp2 = (
+  <Component22
+    css={`
+      color: blue;
+    `}
+  />
+);
+const mountCssProp3 = <View css={{ color: 'blue' }} />;
+const mountCssProp4 = (
+  <View
+    css={`
+      color: blue;
+    `}
+  />
+);

--- a/packages/primitives/types/tests.tsx
+++ b/packages/primitives/types/tests.tsx
@@ -172,24 +172,3 @@ const mountComponent21 = (
     source={{ uri: 'dummy' }}
   />
 );
-
-/**
- * css prop
- */
-const Component22 = styled.View({ color: 'red' });
-const mountCssProp1 = <Component22 css={{ color: 'blue' }} />;
-const mountCssProp2 = (
-  <Component22
-    css={`
-      color: blue;
-    `}
-  />
-);
-const mountCssProp3 = <View css={{ color: 'blue' }} />;
-const mountCssProp4 = (
-  <View
-    css={`
-      color: blue;
-    `}
-  />
-);

--- a/packages/primitives/types/tsconfig.json
+++ b/packages/primitives/types/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "baseUrl": "../",
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "lib": ["es6", "dom"],
+    "module": "commonjs",
+    "noEmit": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "target": "es5",
+    "typeRoots": ["../"],
+    "types": []
+  },
+  "include": ["./*.ts", "./*.tsx"]
+}

--- a/packages/primitives/types/tslint.json
+++ b/packages/primitives/types/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "dtslint/dtslint.json",
+  "rules": {
+    "no-relative-import-in-test": false
+  }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Add Typescript types for `@emotion/primitives`.

<!-- Why are these changes necessary? -->
**Why**:
To be able to use `@emotion/primitives` type-safely in Typescript.

<!-- How were these changes implemented? -->
**How**:
Adding `types` folders following the ish same setup as `react-emotion` with some changes to reflect how `@emotion/primitives` works.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->

The type setup was quite complicated so I am not 100% sure I've typed everything correctly, but it should work ™️ 🙈 

<!-- Please add a `Tag:` prefixed label from the labels so that this PR shows up in the changelog -->
