### PR TITLE
Upgrade babel-plugin-emotion's `touch` dependency to ^2.0.1

### DIFF
--- a/packages/babel-plugin-emotion/package.json
+++ b/packages/babel-plugin-emotion/package.json
@@ -21,7 +21,7 @@
     "find-root": "^1.1.0",
     "mkdirp": "^0.5.1",
     "source-map": "^0.5.7",
-    "touch": "^1.0.0"
+    "touch": "^2.0.1"
   },
   "devDependencies": {
     "babel-check-duplicated-nodes": "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16683,9 +16683,9 @@ topo@2.x.x:
   dependencies:
     hoek "4.x.x"
 
-touch@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/touch/-/touch-1.0.0.tgz#449cbe2dbae5a8c8038e30d71fa0ff464947c4de"
+touch@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-2.0.2.tgz#ca0b2a3ae3211246a61b16ba9e6cbf1596287164"
   dependencies:
     nopt "~1.0.10"
 


### PR DESCRIPTION
**What**:  Upgrade babel-plugin-emotion's `touch` dependency to `^2.0.1`

**Why**: Detailed in issue https://github.com/emotion-js/emotion/issues/861

**How**: Bumped the version number in `package.json`.

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete

Version diff for [`touch@1.0.0...touch@2.0.1`](https://github.com/isaacs/node-touch/compare/v1.0.0...v2.0.1).

Existing tests all still pass, and `yarn build` runs without errors. Please let me know if I need to add additional documentation for this upgrade. 

<!-- Please add a `Tag:` prefixed label from the labels so that this PR shows up in the changelog -->
