### PR TITLE
feat: Do not add hash in test environment

### DIFF
--- a/packages/create-emotion/test/__snapshots__/css.test.js.snap
+++ b/packages/create-emotion/test/__snapshots__/css.test.js.snap
@@ -261,7 +261,7 @@ exports[`css manually use label property 1`] = `
 `;
 
 exports[`css manually use label property 2`] = `
-".some-key-32iy0l-wow {
+".some-key-wow {
   color: hotpink;
 }"
 `;
@@ -458,6 +458,38 @@ exports[`css simple composition 1`] = `
 <div
   className="emotion-0"
 />
+`;
+
+exports[`css test environment className when label is present 1`] = `
+.emotion-0 {
+  float: right;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`css test environment className when label is present 2`] = `
+".some-key-label1-label2 {
+  float: right;
+}"
+`;
+
+exports[`css test environment className without label 1`] = `
+.emotion-0 {
+  float: right;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`css test environment className without label 2`] = `
+".some-key-1f7s68s {
+  float: right;
+}"
 `;
 
 exports[`css weakmap 1`] = `

--- a/packages/create-emotion/test/css.test.js
+++ b/packages/create-emotion/test/css.test.js
@@ -362,6 +362,31 @@ describe('css', () => {
     const tree = renderer.create(<div className={cls1} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
+
+  test('test environment className when label is present', () => {
+    flush()
+    const cls1 = differentCss`
+      float: left;
+      label: label1;
+      label: label2;
+    `
+
+    const tree = renderer.create(<div className={cls1} />).toJSON()
+    expect(tree).toMatchSnapshot()
+    expect(sheet).toMatchSnapshot()
+  })
+
+  test('test environment className without label', () => {
+    flush()
+    const cls1 = differentCss`
+      float: left;
+    `
+
+    const tree = renderer.create(<div className={cls1} />).toJSON()
+    expect(tree).toMatchSnapshot()
+    expect(sheet).toMatchSnapshot()
+  })
+
   test('manually use label property', () => {
     flush()
     const cls1 = differentCss`

--- a/packages/emotion-server/test/auto-label/__snapshots__/auto-label.test.js.snap
+++ b/packages/emotion-server/test/auto-label/__snapshots__/auto-label.test.js.snap
@@ -10,7 +10,7 @@ Object {
   unicode-range: U+0100-024f,U+1-1eff,U+20a0-20ab,U+20ad-20cf,U+2c60-2c7f,U+A720-A7FF;
 }
 
-@-webkit-keyframes animation-1fps0gg-bounce {
+@-webkit-keyframes animation-bounce {
   from, 20%, 53%, 80%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215,0.610,0.355,1.000);
     animation-timing-function: cubic-bezier(0.215,0.610,0.355,1.000);
@@ -42,7 +42,7 @@ Object {
   }
 }
 
-@keyframes animation-1fps0gg-bounce {
+@keyframes animation-bounce {
   from, 20%, 53%, 80%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215,0.610,0.355,1.000);
     animation-timing-function: cubic-bezier(0.215,0.610,0.355,1.000);
@@ -85,7 +85,7 @@ Object {
   justify-content: center;
 }
 
-.css-1h80n0w-Main-hoverStyles {
+.css-Main-hoverStyles {
   color: hotpink;
   display: -webkit-box;
   display: -webkit-flex;
@@ -93,40 +93,40 @@ Object {
   display: flex;
 }
 
-.css-1h80n0w-Main-hoverStyles:hover {
+.css-Main-hoverStyles:hover {
   color: white;
   background-color: lightgray;
   border-color: aqua;
   box-shadow: -15px -15px 0 0 aqua,-30px -30px 0 0 cornflowerblue;
 }
 
-.css-1m3qzmz-Image {
-  -webkit-animation: animation-1fps0gg-bounce;
-  animation: animation-1fps0gg-bounce;
+.css-Image {
+  -webkit-animation: animation-bounce;
+  animation: animation-bounce;
   border-radius: 50%;
   height: 50px;
   width: 50px;
   background-color: red;
 }",
   "html": 
-<main class="css-1h80n0w-Main-hoverStyles enylr5n0"
+<main class="css-Main-hoverStyles enylr5n0"
       data-reactroot
 >
   <img size="30"
-       class="css-1m3qzmz-Image enylr5n1"
+       class="css-Image enylr5n1"
   >
   <img size="100"
-       class="css-1m3qzmz-Image enylr5n1"
+       class="css-Image enylr5n1"
   >
-  <img class="css-1m3qzmz-Image enylr5n1">
+  <img class="css-Image enylr5n1">
 </main>
 ,
   "ids": Array [
     "1yb14ab-getComponents",
-    "1fps0gg-bounce",
+    "bounce",
     "1teldhi-getComponents",
-    "1h80n0w-Main-hoverStyles",
-    "1m3qzmz-Image",
+    "Main-hoverStyles",
+    "Image",
   ],
 }
 `;
@@ -141,7 +141,7 @@ Object {
   unicode-range: U+0100-024f,U+1-1eff,U+20a0-20ab,U+20ad-20cf,U+2c60-2c7f,U+A720-A7FF;
 }
 
-@-webkit-keyframes animation-1fps0gg-bounce {
+@-webkit-keyframes animation-bounce {
   from, 20%, 53%, 80%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215,0.610,0.355,1.000);
     animation-timing-function: cubic-bezier(0.215,0.610,0.355,1.000);
@@ -173,7 +173,7 @@ Object {
   }
 }
 
-@keyframes animation-1fps0gg-bounce {
+@keyframes animation-bounce {
   from, 20%, 53%, 80%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215,0.610,0.355,1.000);
     animation-timing-function: cubic-bezier(0.215,0.610,0.355,1.000);
@@ -216,7 +216,7 @@ Object {
   justify-content: center;
 }
 
-.css-1h80n0w-Main-hoverStyles {
+.css-Main-hoverStyles {
   color: hotpink;
   display: -webkit-box;
   display: -webkit-flex;
@@ -224,14 +224,14 @@ Object {
   display: flex;
 }
 
-.css-1h80n0w-Main-hoverStyles:hover {
+.css-Main-hoverStyles:hover {
   color: white;
   background-color: lightgray;
   border-color: aqua;
   box-shadow: -15px -15px 0 0 aqua,-30px -30px 0 0 cornflowerblue;
 }",
   "html": 
-<main class="css-1h80n0w-Main-hoverStyles enylr5n0"
+<main class="css-Main-hoverStyles enylr5n0"
       data-reactroot
 >
   <div>
@@ -241,9 +241,9 @@ Object {
 ,
   "ids": Array [
     "1yb14ab-getComponents",
-    "1fps0gg-bounce",
+    "bounce",
     "1teldhi-getComponents",
-    "1h80n0w-Main-hoverStyles",
+    "Main-hoverStyles",
   ],
 }
 `;
@@ -258,7 +258,7 @@ Object {
   unicode-range: U+0100-024f,U+1-1eff,U+20a0-20ab,U+20ad-20cf,U+2c60-2c7f,U+A720-A7FF;
 }
 
-@-webkit-keyframes animation-1fps0gg-bounce {
+@-webkit-keyframes animation-bounce {
   from, 20%, 53%, 80%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215,0.610,0.355,1.000);
     animation-timing-function: cubic-bezier(0.215,0.610,0.355,1.000);
@@ -290,7 +290,7 @@ Object {
   }
 }
 
-@keyframes animation-1fps0gg-bounce {
+@keyframes animation-bounce {
   from, 20%, 53%, 80%, to {
     -webkit-animation-timing-function: cubic-bezier(0.215,0.610,0.355,1.000);
     animation-timing-function: cubic-bezier(0.215,0.610,0.355,1.000);
@@ -333,7 +333,7 @@ Object {
   justify-content: center;
 }
 
-.css-1h80n0w-Main-hoverStyles {
+.css-Main-hoverStyles {
   color: hotpink;
   display: -webkit-box;
   display: -webkit-flex;
@@ -341,57 +341,57 @@ Object {
   display: flex;
 }
 
-.css-1h80n0w-Main-hoverStyles:hover {
+.css-Main-hoverStyles:hover {
   color: white;
   background-color: lightgray;
   border-color: aqua;
   box-shadow: -15px -15px 0 0 aqua,-30px -30px 0 0 cornflowerblue;
 }
 
-.css-1m3qzmz-Image {
-  -webkit-animation: animation-1fps0gg-bounce;
-  animation: animation-1fps0gg-bounce;
+.css-Image {
+  -webkit-animation: animation-bounce;
+  animation: animation-bounce;
   border-radius: 50%;
   height: 50px;
   width: 50px;
   background-color: red;
 }",
   "html": 
-<main class="css-1h80n0w-Main-hoverStyles enylr5n0"
+<main class="css-Main-hoverStyles enylr5n0"
       data-reactroot
 >
   <img size="30"
-       class="css-1m3qzmz-Image enylr5n1"
+       class="css-Image enylr5n1"
   >
   <img size="100"
-       class="css-1m3qzmz-Image enylr5n1"
+       class="css-Image enylr5n1"
   >
-  <img class="css-1m3qzmz-Image enylr5n1">
+  <img class="css-Image enylr5n1">
 </main>
 ,
   "ids": Array [
     "1yb14ab-getComponents",
-    "1fps0gg-bounce",
+    "bounce",
     "1teldhi-getComponents",
-    "1h80n0w-Main-hoverStyles",
-    "1m3qzmz-Image",
+    "Main-hoverStyles",
+    "Image",
   ],
 }
 `;
 
 exports[`hydration only rules that are not in the critical css are inserted 2`] = `
-".css-1ypzo6g-hoverStyles {
+".css-hoverStyles {
   color: hotpink;
 }
 
-.css-1ypzo6g-hoverStyles:hover {
+.css-hoverStyles:hover {
   color: white;
   background-color: lightgray;
   border-color: aqua;
   box-shadow: -15px -15px 0 0 aqua,-30px -30px 0 0 cornflowerblue;
 }
 
-.css-lecien-getComponents {
+.css-getComponents {
   display: none;
 }"
 `;

--- a/packages/emotion/test/__snapshots__/css.test.js.snap
+++ b/packages/emotion/test/__snapshots__/css.test.js.snap
@@ -303,7 +303,7 @@ exports[`css manually use label property 1`] = `
 `;
 
 exports[`css manually use label property 2`] = `
-".css-1qqiudg-wow {
+".css-wow {
   color: hotpink;
 }"
 `;

--- a/packages/emotion/test/__snapshots__/cx.test.js.snap
+++ b/packages/emotion/test/__snapshots__/cx.test.js.snap
@@ -67,6 +67,19 @@ exports[`cx merge 4 1`] = `
 />
 `;
 
+exports[`cx merge 5 1`] = `
+.emotion-0 {
+  font-size: 20px;
+  background: green;
+  font-size: 20px;
+  background: blue;
+}
+
+<div
+  className="cls1 cls2 modal emotion-0"
+/>
+`;
+
 exports[`cx no extra whitespace 1`] = `"blockquote news"`;
 
 exports[`cx no extra whitespace 2`] = `"group news"`;

--- a/packages/emotion/test/auto-label/__snapshots__/auto-label.test.js.snap
+++ b/packages/emotion/test/auto-label/__snapshots__/auto-label.test.js.snap
@@ -19,11 +19,11 @@ exports[`meta css generated class name should have the correct id 1`] = `
 `;
 
 exports[`meta css generated class name should have the correct id 2`] = `
-".css-1staf2a-cls1 {
+".css-cls1 {
   color: blue;
 }
 
-.css-14o1mnu-cls2 .css-1staf2a-cls1 {
+.css-cls2 .css-cls1 {
   color: red;
 }"
 `;
@@ -76,18 +76,18 @@ exports[`meta css prop correctly adds the id 3`] = `
 `;
 
 exports[`meta css prop correctly adds the id 4`] = `
-".css-1bl9k6-SFC {
+".css-SFC {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.css-ptjj1k-ClsComp {
+.css-ClsComp {
   display: grid;
 }
 
-.css-c6rdfv-hoc {
+.css-hoc {
   display: block;
 }"
 `;
@@ -103,7 +103,7 @@ exports[`meta manually use label property 1`] = `
 `;
 
 exports[`meta manually use label property 2`] = `
-".css-1sy7nqn-wow-cls1 {
+".css-wow-cls1 {
   color: blue;
 }"
 `;

--- a/packages/emotion/test/cx.test.js
+++ b/packages/emotion/test/cx.test.js
@@ -47,6 +47,24 @@ describe('cx', () => {
     expect(tree).toMatchSnapshot()
   })
 
+  test('merge 5', () => {
+    const cls1 = css`
+      font-size: 20px;
+      background: green;
+      label: cls1;
+    `
+    const cls2 = css`
+      font-size: 20px;
+      background: blue;
+      label: cls2;
+    `
+
+    const tree = renderer
+      .create(<div className={cx(cls1, cls2, 'modal')} />)
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
   test('all types', () => {
     const cls1 = css`
       font-size: 20px;

--- a/packages/react-emotion/test/auto-label/__snapshots__/auto-label.test.js.snap
+++ b/packages/react-emotion/test/auto-label/__snapshots__/auto-label.test.js.snap
@@ -18,16 +18,16 @@ exports[`styled with autoLabel composition 1`] = `
 `;
 
 exports[`styled with autoLabel composition 2`] = `
-".css-1nvqkkc-cssA {
+".css-cssA {
   color: blue;
 }
 
-.css-1mq2fmo-cssA-cssB {
+.css-cssA-cssB {
   color: blue;
   color: red;
 }
 
-.css-1ep83l4-BlueH1-cssA-cssB-FinalH2 {
+.css-BlueH1-cssA-cssB-FinalH2 {
   color: blue;
   color: red;
   color: blue;
@@ -60,19 +60,19 @@ exports[`styled with autoLabel composition with objects 1`] = `
 `;
 
 exports[`styled with autoLabel composition with objects 2`] = `
-".css-10adwdu-cssB {
+".css-cssB {
   color: #333;
   font-size: 1.333em;
   height: 64px;
 }
 
 @media only screen and (-webkit-min-device-pixel-ratio:1.5), only screen and (min--moz-device-pixel-ratio:1.5), only screen and (-o-min-device-pixel-ratio:1.5/1), only screen and (min-resolution:144dpi), only screen and (min-resolution:1.5dppx) {
-  .css-10adwdu-cssB {
+  .css-cssB {
     font-size: 1.4323121856191332em;
   }
 }
 
-.css-vtmoew-H1-cssB-H2 {
+.css-H1-cssB-H2 {
   color: #333;
   font-size: 1.333em;
   height: 64px;
@@ -81,7 +81,7 @@ exports[`styled with autoLabel composition with objects 2`] = `
 }
 
 @media only screen and (-webkit-min-device-pixel-ratio:1.5), only screen and (min--moz-device-pixel-ratio:1.5), only screen and (-o-min-device-pixel-ratio:1.5/1), only screen and (min-resolution:144dpi), only screen and (min-resolution:1.5dppx) {
-  .css-vtmoew-H1-cssB-H2 {
+  .css-H1-cssB-H2 {
     font-size: 1.4323121856191332em;
   }
 }"
@@ -103,11 +103,11 @@ exports[`styled with autoLabel higher order component 1`] = `
 `;
 
 exports[`styled with autoLabel higher order component 2`] = `
-".css-l19ikj-squirtleBlueBackground {
+".css-squirtleBlueBackground {
   background-color: #7fc8d6;
 }
 
-.css-cairh6-Content-NewComponent-squirtleBlueBackground {
+.css-Content-NewComponent-squirtleBlueBackground {
   font-size: 20px;
   background-color: #7fc8d6;
   background-color: '#343a40';


### PR DESCRIPTION
This PR Closes #870 #869

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: 

in TEST environment:

```
const cls1 = css`
 font-size: 20px;
 background: green;
 label: label1;
`

const cls2 = css`
 font-size: 20px;
 background: red;
 label: label2;
`

const cn = cx(cls1, cls2, 'other')
```

Before:

```
console.log(cls1) // css-12345-label1
console.log(cls2) // css-12345-label2
console.log(cn) // other css-12345-label1-label2
```

After:

```
console.log(cls1) // css-label1
console.log(cls2) // css-label2
console.log(cn) // label1 label2 other css-12345-label1-label2
```

<!-- Why are these changes necessary? -->
**Why**:

With this feature, it is easier to use enzyme CSS selectors

<!-- How were these changes implemented? -->
**How**:

* If `process.env.NODE_ENV === 'test'` and `label` is not empty, disable hash.
* Do not disable hash for `injectGlobal` as it will break the `emotion-server` tests
* Add className without key to `rawClassName` list (it will be problematic with keys)

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation (any place I should add this?)
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->

<!-- Please add a `Tag:` prefixed label from the labels so that this PR shows up in the changelog -->
