### PR TITLE
Upgrade `babel-plugin-emotion` to Babel 7

### DIFF
--- a/packages/babel-plugin-emotion/package.json
+++ b/packages/babel-plugin-emotion/package.json
@@ -14,7 +14,7 @@
     "@emotion/hash": "^0.6.2",
     "@emotion/memoize": "^0.6.1",
     "@emotion/stylis": "^0.7.0",
-    "babel-core": "^6.26.3",
+    "@babel/core": "^7.0.0",
     "babel-plugin-macros": "^2.0.0",
     "babel-plugin-syntax-jsx": "^6.18.0",
     "convert-source-map": "^1.5.0",

--- a/packages/babel-plugin-emotion/test/__snapshots__/css-prop.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/css-prop.test.js.snap
@@ -22,68 +22,94 @@ emotion.emotion.css
 
 exports[`babel css prop inline babel 6 StringLiteral css prop value 1`] = `
 "import { css as _css } from \\"emotion\\";
-<div className={/*#__PURE__*/_css(\\"color:brown;\\")}></div>;"
+<div className={
+/*#__PURE__*/
+_css(\\"color:brown;\\")}></div>;"
 `;
 
 exports[`babel css prop inline babel 6 another relative custom instance 1`] = `
 "import { css as _css } from \\"../my-emotion-instance\\";
-<div className={/*#__PURE__*/_css(\\"color:brown;\\")}></div>;"
+<div className={
+/*#__PURE__*/
+_css(\\"color:brown;\\")}></div>;"
 `;
 
 exports[`babel css prop inline babel 6 basic inline 1`] = `
 "import { css as _css } from \\"emotion\\";
-<div className={/*#__PURE__*/_css(\\"color:brown;\\") + \\" a\\"}></div>;"
+<div className={
+/*#__PURE__*/
+_css(\\"color:brown;\\") + \\" a\\"}></div>;"
 `;
 
 exports[`babel css prop inline babel 6 basic object 1`] = `
 "import { css as _css } from \\"emotion\\";
-<div className={_css({ color: 'brown' }) + \\" a\\"}></div>;"
+<div className={_css({
+  color: 'brown'
+}) + \\" a\\"}></div>;"
 `;
 
 exports[`babel css prop inline babel 6 className as expression 1`] = `
 "import { merge as _merge } from \\"emotion\\";
 import { css as _css } from \\"emotion\\";
-<div className={_merge( /*#__PURE__*/_css(\\"color:brown;\\") + (\\" \\" + variable))}></div>;"
+<div className={_merge(
+/*#__PURE__*/
+_css(\\"color:brown;\\") + (\\" \\" + variable))}></div>;"
 `;
 
 exports[`babel css prop inline babel 6 className as expression string 1`] = `
 "import { merge as _merge } from \\"emotion\\";
 import { css as _css } from \\"emotion\\";
-<div className={_merge( /*#__PURE__*/_css(\\"color:brown;\\") + (\\" \\" + \`test__class\`))} this={\`hello\`}></div>;"
+<div className={_merge(
+/*#__PURE__*/
+_css(\\"color:brown;\\") + (\\" \\" + \`test__class\`))} this={\`hello\`}></div>;"
 `;
 
 exports[`babel css prop inline babel 6 css empty 1`] = `
 "import { css as _css } from \\"emotion\\";
-<div className={/*#__PURE__*/_css()}></div>;"
+<div className={
+/*#__PURE__*/
+_css()}></div>;"
 `;
 
 exports[`babel css prop inline babel 6 custom instance 1`] = `
 "import { css as _css } from \\"my-emotion-instance\\";
-<div className={/*#__PURE__*/_css(\\"color:brown;\\")}></div>;"
+<div className={
+/*#__PURE__*/
+_css(\\"color:brown;\\")}></div>;"
 `;
 
 exports[`babel css prop inline babel 6 dynamic inline 1`] = `
 "import { css as _css } from \\"emotion\\";
-<div className={/*#__PURE__*/_css(\\"color:\\", color, \\";\\") + \\" a\\"}></div>;"
+<div className={
+/*#__PURE__*/
+_css(\\"color:\\", color, \\";\\") + \\" a\\"}></div>;"
 `;
 
 exports[`babel css prop inline babel 6 emptyClassName 1`] = `
 "import { css as _css } from \\"emotion\\";
-<div className={/*#__PURE__*/_css(\\"color:brown;\\")}></div>;"
+<div className={
+/*#__PURE__*/
+_css(\\"color:brown;\\")}></div>;"
 `;
 
 exports[`babel css prop inline babel 6 hoisting object styles 1`] = `
 "import { css as _css } from \\"emotion\\";
-var _ref = { color: 'brown' };
+var _ref = {
+  color: 'brown'
+};
+
 const Profile = () => <div className={_css(_ref) + \\" a\\"}></div>;"
 `;
 
 exports[`babel css prop inline babel 6 hoisting string styles 1`] = `
 "import { css as _css } from \\"emotion\\";
 var _ref = \\"color:\\";
+
 const Profile = () => {
   const color = \\"blue\\";
-  <div className={/*#__PURE__*/_css(_ref, color)}></div>;
+  <div className={
+  /*#__PURE__*/
+  _css(_ref, color)}></div>;
 };"
 `;
 
@@ -92,8 +118,11 @@ exports[`babel css prop inline babel 6 label in class component 1`] = `
 
 class ClsComp extends React.Component {
   render() {
-    return <div className={/*#__PURE__*/_css(\\"foolabel:ClsComp;\\")}>Hello</div>;
+    return <div className={
+    /*#__PURE__*/
+    _css(\\"foolabel:ClsComp;\\")}>Hello</div>;
   }
+
 }"
 `;
 
@@ -102,8 +131,11 @@ exports[`babel css prop inline babel 6 label in higher order component 1`] = `
 
 const foo = W => class extends Component {
   render() {
-    return <div className={/*#__PURE__*/_css(\\"color:brown;label:foo;\\")}>Hello</div>;
+    return <div className={
+    /*#__PURE__*/
+    _css(\\"color:brown;label:foo;\\")}>Hello</div>;
   }
+
 };"
 `;
 
@@ -111,32 +143,46 @@ exports[`babel css prop inline babel 6 label in stateless functional component 1
 "import { css as _css } from \\"emotion\\";
 
 const SFC = () => {
-  return <div className={/*#__PURE__*/_css(\\"color:brown;label:SFC;\\")}>Hello</div>;
+  return <div className={
+  /*#__PURE__*/
+  _css(\\"color:brown;label:SFC;\\")}>Hello</div>;
 };"
 `;
 
 exports[`babel css prop inline babel 6 no css attr 1`] = `"<div></div>;"`;
 
-exports[`babel css prop inline babel 6 no import css prop 1`] = `"<div className={merge( /*#__PURE__*/css(\\"color:brown;\\") + (\\" \\" + \`test__class\`))}></div>;"`;
+exports[`babel css prop inline babel 6 no import css prop 1`] = `
+"<div className={merge(
+/*#__PURE__*/
+css(\\"color:brown;\\") + (\\" \\" + \`test__class\`))}></div>;"
+`;
 
 exports[`babel css prop inline babel 6 noClassName 1`] = `
 "import { css as _css } from \\"emotion\\";
-<div className={/*#__PURE__*/_css(\\"color:brown;\\")}></div>;"
+<div className={
+/*#__PURE__*/
+_css(\\"color:brown;\\")}></div>;"
 `;
 
 exports[`babel css prop inline babel 6 redefined-import: basic inline 1`] = `
 "import { css as _css } from \\"emotion\\";
-<div className={/*#__PURE__*/_css(\\"color:brown;\\") + \\" a\\"}></div>;"
+<div className={
+/*#__PURE__*/
+_css(\\"color:brown;\\") + \\" a\\"}></div>;"
 `;
 
 exports[`babel css prop inline babel 6 relative custom instance 1`] = `
 "import { css as _css } from \\"./my-emotion-instance\\";
-<div className={/*#__PURE__*/_css(\\"color:brown;\\")}></div>;"
+<div className={
+/*#__PURE__*/
+_css(\\"color:brown;\\")}></div>;"
 `;
 
 exports[`babel css prop inline babel 6 with spread arg in jsx opening tag 1`] = `
 "import { css as _css } from \\"emotion\\";
-<div className={/*#__PURE__*/_css(\\"color:brown;\\") + \\" a\\"} {...rest}></div>;"
+<div className={
+/*#__PURE__*/
+_css(\\"color:brown;\\") + \\" a\\"} {...rest}></div>;"
 `;
 
 exports[`babel css prop inline babel 7 StringLiteral css prop value 1`] = `

--- a/packages/babel-plugin-emotion/test/__snapshots__/css.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/css.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`babel css extract babel 6 babel css extract basic 1`] = `
 "import \\"./emotion.emotion.css\\";
-
 \\"css-5bxlk\\";
 
 
@@ -20,30 +19,37 @@ emotion.emotion.css
 `;
 
 exports[`babel css inline babel 6 ::placeholder 1`] = `
-"
-const cls1 = /*#__PURE__*/css({
+"const cls1 =
+/*#__PURE__*/
+css({
   '::placeholder': {
     color: 'green',
     display: 'flex'
   }
 });
-const cls2 = /*#__PURE__*/css('::placeholder{color:green;display:flex;}');"
+const cls2 =
+/*#__PURE__*/
+css(\\"::placeholder{color:green;display:flex;}\\");"
 `;
 
 exports[`babel css inline babel 6 :fullscreen 1`] = `
-"
-const cls1 = /*#__PURE__*/css({
+"const cls1 =
+/*#__PURE__*/
+css({
   ':fullscreen': {
     color: 'green',
     display: 'flex'
   }
 });
-const cls2 = /*#__PURE__*/css(':fullscreen{color:green;display:flex;}');"
+const cls2 =
+/*#__PURE__*/
+css(\\":fullscreen{color:green;display:flex;}\\");"
 `;
 
 exports[`babel css inline babel 6 array of objects 1`] = `
-"
-const cls2 = /*#__PURE__*/css([{
+"const cls2 =
+/*#__PURE__*/
+css([{
   display: 'flex',
   flex: 1,
   alignItems: \`\${'center'}\`
@@ -53,93 +59,145 @@ const cls2 = /*#__PURE__*/css([{
 `;
 
 exports[`babel css inline babel 6 autoLabel 1`] = `
-"
-function test() {
-  const cls1 = /*#__PURE__*/css(\\"font-size:20px;@media(min-width:420px){color:blue;\\", /*#__PURE__*/css(\\"width:96px;height:96px;label:cls1;\\"), \\";line-height:26px;}background:green;\\", { backgroundColor: \\"hotpink\\" }, \\";label:cls1;\\");
+"function test() {
+  const cls1 =
+  /*#__PURE__*/
+  css(\\"font-size:20px;@media(min-width:420px){color:blue;\\",
+  /*#__PURE__*/
+  css(\\"width:96px;height:96px;label:cls1;\\"), \\";line-height:26px;}background:green;\\", {
+    backgroundColor: \\"hotpink\\"
+  }, \\";label:cls1;\\");
+  const cls2 =
+  /*#__PURE__*/
+  css({
+    color: 'blue'
+  }, \\"label:cls2;\\");
+  const cls4 =
+  /*#__PURE__*/
+  css({
+    color: \\"hotpink\\"
+  }, \\"label:cls4;\\");
+  const cls3 =
+  /*#__PURE__*/
+  css(\\"display:flex;&:hover{color:hotpink;}label:cls3;\\");
 
-  const cls2 = /*#__PURE__*/css({ color: 'blue' }, \\"label:cls2;\\");
-  const cls4 = /*#__PURE__*/css({ color: \\"hotpink\\" }, \\"label:cls4;\\");
-
-  const cls3 = /*#__PURE__*/css(\\"display:flex;&:hover{color:hotpink;}label:cls3;\\");
   function inner() {
-    const styles = { color: \\"darkorchid\\" };
+    const styles = {
+      color: \\"darkorchid\\"
+    };
     const color = 'aquamarine';
-
-    const cls4 = /*#__PURE__*/css(cls3, \\";\\", cls1, \\";\\", () => ({ color: \\"darkorchid\\" }), \\";\\", () => ({ color }), \\";\\", /*#__PURE__*/css(\\"height:420px;width:\\", styles, \\"label:cls4;\\"), \\";label:cls4;\\");
+    const cls4 =
+    /*#__PURE__*/
+    css(cls3, \\";\\", cls1, \\";\\", () => ({
+      color: \\"darkorchid\\"
+    }), \\";\\", () => ({
+      color
+    }), \\";\\",
+    /*#__PURE__*/
+    css(\\"height:420px;width:\\", styles, \\"label:cls4;\\"), \\";label:cls4;\\");
   }
 }"
 `;
 
-exports[`babel css inline babel 6 basic object support 1`] = `"/*#__PURE__*/css({ display: 'flex' });"`;
+exports[`babel css inline babel 6 basic object support 1`] = `
+"/*#__PURE__*/
+css({
+  display: 'flex'
+});"
+`;
 
 exports[`babel css inline babel 6 comments 1`] = `
-"
-/*#__PURE__*/css(\\"color:hotpink;\\");"
+"/*#__PURE__*/
+css(\\"color:hotpink;\\");"
 `;
 
 exports[`babel css inline babel 6 css basic 1`] = `
-"
-/*#__PURE__*/css(\\"margin:12px 48px;color:#ffffff;display:flex;flex:1 0 auto;color:blue;@media(min-width:420px){line-height:40px;}width:\\", widthVar, \\";\\");"
+"/*#__PURE__*/
+css(\\"margin:12px 48px;color:#ffffff;display:flex;flex:1 0 auto;color:blue;@media(min-width:420px){line-height:40px;}width:\\", widthVar, \\";\\");"
 `;
 
 exports[`babel css inline babel 6 css basic as cows 1`] = `
-"
-import { css as cows } from 'emotion';
-/*#__PURE__*/cows('margin:12px 48px;color:#ffffff;display:flex;flex:1 0 auto;color:blue;@media(min-width:420px){line-height:40px;}width:', widthVar, ';');"
+"import { css as cows } from 'emotion';
+
+/*#__PURE__*/
+cows(\\"margin:12px 48px;color:#ffffff;display:flex;flex:1 0 auto;color:blue;@media(min-width:420px){line-height:40px;}width:\\", widthVar, \\";\\");"
 `;
 
 exports[`babel css inline babel 6 css basic renamed as option 1`] = `
-"
-/*#__PURE__*/cows(\\"margin:12px 48px;color:#ffffff;display:flex;flex:1 0 auto;color:blue;@media(min-width:420px){line-height:40px;}width:\\", widthVar, \\";\\");"
+"/*#__PURE__*/
+cows(\\"margin:12px 48px;color:#ffffff;display:flex;flex:1 0 auto;color:blue;@media(min-width:420px){line-height:40px;}width:\\", widthVar, \\";\\");"
 `;
 
-exports[`babel css inline babel 6 css random expression 1`] = `"/*#__PURE__*/css(\\"font-size:20px;@media(min-width:420px){color:blue;\\", /*#__PURE__*/css(\\"width:96px;height:96px;\\"), \\";line-height:26px;}background:green;\\", { backgroundColor: \\"hotpink\\" }, \\";\\");"`;
+exports[`babel css inline babel 6 css random expression 1`] = `
+"/*#__PURE__*/
+css(\\"font-size:20px;@media(min-width:420px){color:blue;\\",
+/*#__PURE__*/
+css(\\"width:96px;height:96px;\\"), \\";line-height:26px;}background:green;\\", {
+  backgroundColor: \\"hotpink\\"
+}, \\";\\");"
+`;
 
 exports[`babel css inline babel 6 css with float property 1`] = `
-"
-/*#__PURE__*/css(\\"float:left;\\");"
+"/*#__PURE__*/
+css(\\"float:left;\\");"
 `;
 
 exports[`babel css inline babel 6 custom instance 1`] = `
-"
-import { css as lol } from 'my-emotion-instance';
-/*#__PURE__*/lol('color:hotpink;');"
+"import { css as lol } from 'my-emotion-instance';
+
+/*#__PURE__*/
+lol(\\"color:hotpink;\\");"
 `;
 
 exports[`babel css inline babel 6 custom instance relative 1`] = `
-"
-import { css as lol } from './my-emotion-instance';
-/*#__PURE__*/lol('color:hotpink;');"
+"import { css as lol } from './my-emotion-instance';
+
+/*#__PURE__*/
+lol(\\"color:hotpink;\\");"
 `;
 
 exports[`babel css inline babel 6 custom instance relative complex 1`] = `
-"
-import { css as lol } from '../test/my-emotion-instance';
-/*#__PURE__*/lol('color:hotpink;');"
+"import { css as lol } from '../test/my-emotion-instance';
+
+/*#__PURE__*/
+lol(\\"color:hotpink;\\");"
 `;
 
 exports[`babel css inline babel 6 dynamic property objects 1`] = `
-"
-/*#__PURE__*/css({
+"/*#__PURE__*/
+css({
   fontSize: 10,
   [\`w\${'idth'}\`]: 20
 });"
 `;
 
-exports[`babel css inline babel 6 dynamically renamed-import: basic object support 1`] = `"import { css as cows } from 'emotion'; /*#__PURE__*/cows({ display: 'flex' });"`;
+exports[`babel css inline babel 6 dynamically renamed-import: basic object support 1`] = `
+"import { css as cows } from 'emotion';
+
+/*#__PURE__*/
+cows({
+  display: 'flex'
+});"
+`;
 
 exports[`babel css inline babel 6 hoisting 1`] = `
 "var _ref = \\"font-size:20px;@media(min-width:420px){color:blue;\\";
 var _ref2 = \\";line-height:26px;}background:green;\\";
-var _ref3 = { backgroundColor: \\"hotpink\\" };
+var _ref3 = {
+  backgroundColor: \\"hotpink\\"
+};
 var _ref4 = \\";\\";
 var _ref5 = \\"width:96px;height:96px;\\";
-var _ref6 = { color: 'blue' };
+var _ref6 = {
+  color: 'blue'
+};
 var _ref7 = \\"display:flex;&:hover{color:hotpink;}\\";
 var _ref8 = \\";\\";
 var _ref9 = \\";\\";
 
-var _ref10 = () => ({ color: \\"darkorchid\\" });
+var _ref10 = () => ({
+  color: \\"darkorchid\\"
+});
 
 var _ref11 = \\";\\";
 var _ref12 = \\";\\";
@@ -147,86 +205,165 @@ var _ref13 = \\";\\";
 var _ref14 = \\"height:420px;width:\\";
 
 function test() {
-  const cls1 = /*#__PURE__*/css(_ref, /*#__PURE__*/css(_ref5), _ref2, _ref3, _ref4);
+  const cls1 =
+  /*#__PURE__*/
+  css(_ref,
+  /*#__PURE__*/
+  css(_ref5), _ref2, _ref3, _ref4);
+  const cls2 =
+  /*#__PURE__*/
+  css(_ref6);
+  const cls3 =
+  /*#__PURE__*/
+  css(_ref7);
 
-  const cls2 = /*#__PURE__*/css(_ref6);
-
-  const cls3 = /*#__PURE__*/css(_ref7);
   function inner() {
-    const styles = { color: \\"darkorchid\\" };
+    const styles = {
+      color: \\"darkorchid\\"
+    };
     const color = 'aquamarine';
-
-    const cls4 = /*#__PURE__*/css(cls3, _ref8, cls1, _ref9, _ref10, _ref11, () => ({ color }), _ref12, /*#__PURE__*/css(_ref14, styles), _ref13);
+    const cls4 =
+    /*#__PURE__*/
+    css(cls3, _ref8, cls1, _ref9, _ref10, _ref11, () => ({
+      color
+    }), _ref12,
+    /*#__PURE__*/
+    css(_ref14, styles), _ref13);
   }
 }"
 `;
 
 exports[`babel css inline babel 6 interpolation in selector 1`] = `
-"
-const cls2 = /*#__PURE__*/css(\\"margin:12px 48px;color:#ffffff;\\", className, \\"{display:none;}\\");"
+"const cls2 =
+/*#__PURE__*/
+css(\\"margin:12px 48px;color:#ffffff;\\", className, \\"{display:none;}\\");"
 `;
 
 exports[`babel css inline babel 6 label format with filename and local 1`] = `
-"
-function test() {
-  const cls1 = /*#__PURE__*/css(\\"font-size:20px;@media(min-width:420px){color:blue;\\", /*#__PURE__*/css(\\"width:96px;height:96px;label:my-css-emotion-cls1;\\"), \\";line-height:26px;}background:green;\\", { backgroundColor: \\"hotpink\\" }, \\";label:my-css-emotion-cls1;\\");
+"function test() {
+  const cls1 =
+  /*#__PURE__*/
+  css(\\"font-size:20px;@media(min-width:420px){color:blue;\\",
+  /*#__PURE__*/
+  css(\\"width:96px;height:96px;label:my-css-emotion-cls1;\\"), \\";line-height:26px;}background:green;\\", {
+    backgroundColor: \\"hotpink\\"
+  }, \\";label:my-css-emotion-cls1;\\");
+  const cls2 =
+  /*#__PURE__*/
+  css({
+    color: 'blue'
+  }, \\"label:my-css-emotion-cls2;\\");
+  const cls4 =
+  /*#__PURE__*/
+  css({
+    color: \\"hotpink\\"
+  }, \\"label:my-css-emotion-cls4;\\");
+  const cls3 =
+  /*#__PURE__*/
+  css(\\"display:flex;&:hover{color:hotpink;}label:my-css-emotion-cls3;\\");
 
-  const cls2 = /*#__PURE__*/css({ color: 'blue' }, \\"label:my-css-emotion-cls2;\\");
-  const cls4 = /*#__PURE__*/css({ color: \\"hotpink\\" }, \\"label:my-css-emotion-cls4;\\");
-
-  const cls3 = /*#__PURE__*/css(\\"display:flex;&:hover{color:hotpink;}label:my-css-emotion-cls3;\\");
   function inner() {
-    const styles = { color: \\"darkorchid\\" };
+    const styles = {
+      color: \\"darkorchid\\"
+    };
     const color = 'aquamarine';
-
-    const cls4 = /*#__PURE__*/css(cls3, \\";\\", cls1, \\";\\", () => ({ color: \\"darkorchid\\" }), \\";\\", () => ({ color }), \\";\\", /*#__PURE__*/css(\\"height:420px;width:\\", styles, \\"label:my-css-emotion-cls4;\\"), \\";label:my-css-emotion-cls4;\\");
+    const cls4 =
+    /*#__PURE__*/
+    css(cls3, \\";\\", cls1, \\";\\", () => ({
+      color: \\"darkorchid\\"
+    }), \\";\\", () => ({
+      color
+    }), \\";\\",
+    /*#__PURE__*/
+    css(\\"height:420px;width:\\", styles, \\"label:my-css-emotion-cls4;\\"), \\";label:my-css-emotion-cls4;\\");
   }
 }"
 `;
 
 exports[`babel css inline babel 6 label with non word character variable name 1`] = `
-"
-const iconStyles$1 = /*#__PURE__*/css(\\"color:hotpink;label:iconStyles1;\\");"
+"const iconStyles$1 =
+/*#__PURE__*/
+css(\\"color:hotpink;label:iconStyles1;\\");"
 `;
 
 exports[`babel css inline babel 6 labelFormat 1`] = `
-"
-function test() {
-  const cls1 = /*#__PURE__*/css(\\"font-size:20px;@media(min-width:420px){color:blue;\\", /*#__PURE__*/css(\\"width:96px;height:96px;label:my-css-cls1;\\"), \\";line-height:26px;}background:green;\\", { backgroundColor: \\"hotpink\\" }, \\";label:my-css-cls1;\\");
+"function test() {
+  const cls1 =
+  /*#__PURE__*/
+  css(\\"font-size:20px;@media(min-width:420px){color:blue;\\",
+  /*#__PURE__*/
+  css(\\"width:96px;height:96px;label:my-css-cls1;\\"), \\";line-height:26px;}background:green;\\", {
+    backgroundColor: \\"hotpink\\"
+  }, \\";label:my-css-cls1;\\");
+  const cls2 =
+  /*#__PURE__*/
+  css({
+    color: 'blue'
+  }, \\"label:my-css-cls2;\\");
+  const cls4 =
+  /*#__PURE__*/
+  css({
+    color: \\"hotpink\\"
+  }, \\"label:my-css-cls4;\\");
+  const cls3 =
+  /*#__PURE__*/
+  css(\\"display:flex;&:hover{color:hotpink;}label:my-css-cls3;\\");
 
-  const cls2 = /*#__PURE__*/css({ color: 'blue' }, \\"label:my-css-cls2;\\");
-  const cls4 = /*#__PURE__*/css({ color: \\"hotpink\\" }, \\"label:my-css-cls4;\\");
-
-  const cls3 = /*#__PURE__*/css(\\"display:flex;&:hover{color:hotpink;}label:my-css-cls3;\\");
   function inner() {
-    const styles = { color: \\"darkorchid\\" };
+    const styles = {
+      color: \\"darkorchid\\"
+    };
     const color = 'aquamarine';
-
-    const cls4 = /*#__PURE__*/css(cls3, \\";\\", cls1, \\";\\", () => ({ color: \\"darkorchid\\" }), \\";\\", () => ({ color }), \\";\\", /*#__PURE__*/css(\\"height:420px;width:\\", styles, \\"label:my-css-cls4;\\"), \\";label:my-css-cls4;\\");
+    const cls4 =
+    /*#__PURE__*/
+    css(cls3, \\";\\", cls1, \\";\\", () => ({
+      color: \\"darkorchid\\"
+    }), \\";\\", () => ({
+      color
+    }), \\";\\",
+    /*#__PURE__*/
+    css(\\"height:420px;width:\\", styles, \\"label:my-css-cls4;\\"), \\";label:my-css-cls4;\\");
   }
 }"
 `;
 
 exports[`babel css inline babel 6 nested expanded properties 1`] = `
-"
-/*#__PURE__*/css(\\"margin:12px 48px;& .div{display:flex;}\\");"
+"/*#__PURE__*/
+css(\\"margin:12px 48px;& .div{display:flex;}\\");"
 `;
 
 exports[`babel css inline babel 6 object label 1`] = `
-"
-let obj = {
-  someProp: /*#__PURE__*/css({ color: 'green' }, 'label:someProp;'),
-  'anotherProp': /*#__PURE__*/css({ color: 'hotpink' }, 'label:anotherProp;')
+"let obj = {
+  someProp:
+  /*#__PURE__*/
+  css({
+    color: 'green'
+  }, \\"label:someProp;\\"),
+  'anotherProp':
+  /*#__PURE__*/
+  css({
+    color: 'hotpink'
+  }, \\"label:anotherProp;\\")
 };
+
 class Thing {
-  static Prop = /*#__PURE__*/css({ color: 'yellow' }, 'label:Prop;');
-  BadIdea = /*#__PURE__*/css({ color: 'red' }, 'label:BadIdea;');
+  static Prop =
+  /*#__PURE__*/
+  css({
+    color: 'yellow'
+  }, \\"label:Prop;\\");
+  BadIdea =
+  /*#__PURE__*/
+  css({
+    color: 'red'
+  }, \\"label:BadIdea;\\");
 }"
 `;
 
 exports[`babel css inline babel 6 object with a bunch of stuff 1`] = `
-"
-const cls2 = /*#__PURE__*/css({
+"const cls2 =
+/*#__PURE__*/
+css({
   float: 'left',
   display: 'flex',
   flex: 1,
@@ -235,29 +372,38 @@ const cls2 = /*#__PURE__*/css({
 `;
 
 exports[`babel css inline babel 6 objects 1`] = `
-"
-/*#__PURE__*/css({
-    borderRadius: '50%',
-    transition: 'transform 400ms ease-in-out',
-    boxSizing: 'border-box',
-    display: 'flex',
-    ':hover': {
-        transform: 'scale(1.2)'
-    }
+"/*#__PURE__*/
+css({
+  borderRadius: '50%',
+  transition: 'transform 400ms ease-in-out',
+  boxSizing: 'border-box',
+  display: 'flex',
+  ':hover': {
+    transform: 'scale(1.2)'
+  }
 });"
 `;
 
 exports[`babel css inline babel 6 only styles on nested selector 1`] = `
-"
-const cls1 = /*#__PURE__*/css(\\"display:flex;\\");
-const cls2 = /*#__PURE__*/css(\\"&:hover{background:pink;}\\");"
+"const cls1 =
+/*#__PURE__*/
+css(\\"display:flex;\\");
+const cls2 =
+/*#__PURE__*/
+css(\\"&:hover{background:pink;}\\");"
 `;
 
-exports[`babel css inline babel 6 renamed-import: basic object support 1`] = `"/*#__PURE__*/cows({ display: 'flex' });"`;
+exports[`babel css inline babel 6 renamed-import: basic object support 1`] = `
+"/*#__PURE__*/
+cows({
+  display: 'flex'
+});"
+`;
 
 exports[`babel css inline babel 6 symbols inside of "" 1`] = `
-"
-const cls = /*#__PURE__*/css(\\"content:\\\\\\"  {  }  \\\\\\"\\");"
+"const cls =
+/*#__PURE__*/
+css(\\"content:\\\\\\"  {  }  \\\\\\"\\");"
 `;
 
 exports[`babel css inline babel 7 ::placeholder 1`] = `

--- a/packages/babel-plugin-emotion/test/__snapshots__/inject-global.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/inject-global.test.js.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`injectGlobal babel 6 dynamic change import 1`] = `
-"
-import { injectGlobal as inject } from 'emotion';
-inject('body{margin:0;padding:0;& > div{display:flex;}}html{background:green;}');
+"import { injectGlobal as inject } from 'emotion';
+inject(\\"body{margin:0;padding:0;& > div{display:flex;}}html{background:green;}\\");
 injectGlobal\`
       body {
         margin: 0;
@@ -18,19 +17,12 @@ injectGlobal\`
     \`;"
 `;
 
-exports[`injectGlobal babel 6 injectGlobal basic 1`] = `
-"
-injectGlobal(\\"body{margin:0;padding:0;& > div{display:flex;}}html{background:green;}\\");"
-`;
+exports[`injectGlobal babel 6 injectGlobal basic 1`] = `"injectGlobal(\\"body{margin:0;padding:0;& > div{display:flex;}}html{background:green;}\\");"`;
 
-exports[`injectGlobal babel 6 injectGlobal with interpolation 1`] = `
-"
-injectGlobal(\\"body{margin:0;padding:0;display:\\", display, \\";& > div{display:none;}}html{background:green;}\\");"
-`;
+exports[`injectGlobal babel 6 injectGlobal with interpolation 1`] = `"injectGlobal(\\"body{margin:0;padding:0;display:\\", display, \\";& > div{display:none;}}html{background:green;}\\");"`;
 
 exports[`injectGlobal babel 6 static change import 1`] = `
-"
-inject(\\"body{margin:0;padding:0;& > div{display:flex;}}html{background:green;}\\");
+"inject(\\"body{margin:0;padding:0;& > div{display:flex;}}html{background:green;}\\");
 injectGlobal\`
       body {
         margin: 0;
@@ -87,8 +79,7 @@ injectGlobal\`
 exports[`injectGlobal babel 7 with @font-face 1`] = `"injectGlobal(\\"@font-face{font-family:'Patrick Hand SC';font-style:normal;font-weight:400;src:local('Patrick Hand SC'),local('PatrickHandSC-Regular'),url(https://fonts.gstatic.com/s/patrickhandsc/v4/OYFWCgfCR-7uHIovjUZXsZ71Uis0Qeb9Gqo8IZV7ckE.woff2) format('woff2');unicode-range:U+0100-024f,U+1-1eff,U+20a0-20ab,U+20ad-20cf,U+2c60-2c7f,U+A720-A7FF;}\\");"`;
 
 exports[`injectGlobal extract babel 6 dynamic change import 1`] = `
-"import './emotion.emotion.css';
-
+"import \\"./emotion.emotion.css\\";
 import { injectGlobal as inject } from 'emotion';
 undefined;
 injectGlobal\`
@@ -111,7 +102,6 @@ body{margin:0;padding:0;}body > div{display:-webkit-box;display:-webkit-flex;dis
 
 exports[`injectGlobal extract babel 6 injectGlobal basic 1`] = `
 "import \\"./emotion.emotion.css\\";
-
 undefined;
 
 
@@ -119,14 +109,10 @@ emotion.emotion.css
 body{margin:0;padding:0;}body > div{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;}html{background:green;}"
 `;
 
-exports[`injectGlobal extract babel 6 injectGlobal with interpolation 1`] = `
-"
-injectGlobal(\\"body{margin:0;padding:0;display:\\", display, \\";& > div{display:none;}}html{background:green;}\\");"
-`;
+exports[`injectGlobal extract babel 6 injectGlobal with interpolation 1`] = `"injectGlobal(\\"body{margin:0;padding:0;display:\\", display, \\";& > div{display:none;}}html{background:green;}\\");"`;
 
 exports[`injectGlobal extract babel 6 static change import 1`] = `
 "import \\"./emotion.emotion.css\\";
-
 undefined;
 injectGlobal\`
       body {

--- a/packages/babel-plugin-emotion/test/__snapshots__/keyframes.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/keyframes.test.js.snap
@@ -1,9 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`keyframes babel 6 dynamic change import 1`] = `
-"
-import { keyframes as frames } from 'emotion';
-const rotate360 = /*#__PURE__*/frames('from{transform:rotate(0deg);}to{transform:rotate(360deg);}');
+"import { keyframes as frames } from 'emotion';
+const rotate360 =
+/*#__PURE__*/
+frames(\\"from{transform:rotate(0deg);}to{transform:rotate(360deg);}\\");
 const rotate3601 = keyframes\`
         from {
           transform: rotate(0deg);
@@ -15,18 +16,21 @@ const rotate3601 = keyframes\`
 `;
 
 exports[`keyframes babel 6 keyframes basic 1`] = `
-"
-const rotate360 = /*#__PURE__*/keyframes(\\"from{transform:rotate(0deg);}to{transform:rotate(360deg);}\\");"
+"const rotate360 =
+/*#__PURE__*/
+keyframes(\\"from{transform:rotate(0deg);}to{transform:rotate(360deg);}\\");"
 `;
 
 exports[`keyframes babel 6 keyframes with interpolation 1`] = `
-"
-const rotate360 = /*#__PURE__*/keyframes(\\"from{transform:rotate(0deg);}to{transform:rotate(\\", endingRotation, \\");}\\");"
+"const rotate360 =
+/*#__PURE__*/
+keyframes(\\"from{transform:rotate(0deg);}to{transform:rotate(\\", endingRotation, \\");}\\");"
 `;
 
 exports[`keyframes babel 6 static change import 1`] = `
-"
-const rotate360 = /*#__PURE__*/frames(\\"from{transform:rotate(0deg);}to{transform:rotate(360deg);}\\");
+"const rotate360 =
+/*#__PURE__*/
+frames(\\"from{transform:rotate(0deg);}to{transform:rotate(360deg);}\\");
 const rotate3601 = keyframes\`
         from {
           transform: rotate(0deg);
@@ -79,10 +83,9 @@ const rotate3601 = keyframes\`
 `;
 
 exports[`keyframes extract babel 6 dynamic change import 1`] = `
-"import './emotion.emotion.css';
-
+"import \\"./emotion.emotion.css\\";
 import { keyframes as frames } from 'emotion';
-const rotate360 = 'css-rotate360-bhsghd';
+const rotate360 = \\"css-rotate360-bhsghd\\";
 const rotate3601 = keyframes\`
         from {
           transform: rotate(0deg);
@@ -99,7 +102,6 @@ emotion.emotion.css
 
 exports[`keyframes extract babel 6 keyframes basic 1`] = `
 "import \\"./emotion.emotion.css\\";
-
 const rotate360 = \\"css-rotate360-bhsghd\\";
 
 
@@ -108,13 +110,13 @@ emotion.emotion.css
 `;
 
 exports[`keyframes extract babel 6 keyframes with interpolation 1`] = `
-"
-const rotate360 = /*#__PURE__*/keyframes(\\"from{transform:rotate(0deg);}to{transform:rotate(\\", endingRotation, \\");}\\");"
+"const rotate360 =
+/*#__PURE__*/
+keyframes(\\"from{transform:rotate(0deg);}to{transform:rotate(\\", endingRotation, \\");}\\");"
 `;
 
 exports[`keyframes extract babel 6 static change import 1`] = `
 "import \\"./emotion.emotion.css\\";
-
 const rotate360 = \\"css-rotate360-bhsghd\\";
 const rotate3601 = keyframes\`
         from {

--- a/packages/babel-plugin-emotion/test/__snapshots__/macro.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/macro.test.js.snap
@@ -1,63 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`macro babel 6 css 1`] = `
-"import { css as _css } from '../src';
+"import { css as _css } from \\"../src\\";
 
-/*#__PURE__*/_css('margin:12px 48px;color:#ffffff;display:flex;flex:1 0 auto;color:blue;width:', widthVar, ';');"
+/*#__PURE__*/
+_css(\\"margin:12px 48px;color:#ffffff;display:flex;flex:1 0 auto;color:blue;width:\\", widthVar, \\";\\");"
 `;
 
 exports[`macro babel 6 css call with no args 1`] = `
-"import { css as _css } from '../src';
+"import { css as _css } from \\"../src\\";
 
-const cls1 = /*#__PURE__*/_css();"
+const cls1 =
+/*#__PURE__*/
+_css();"
 `;
 
 exports[`macro babel 6 css inside of css 1`] = `
-"import { css as _css } from '../src';
+"import { css as _css } from \\"../src\\";
 
-const cls2 = /*#__PURE__*/_css('font-size:20px;@media (min-width:420px){color:blue;', /*#__PURE__*/_css('width:96px;height:96px;'), ';line-height:40px;}background:green;');"
+const cls2 =
+/*#__PURE__*/
+_css(\\"font-size:20px;@media (min-width:420px){color:blue;\\",
+/*#__PURE__*/
+_css(\\"width:96px;height:96px;\\"), \\";line-height:40px;}background:green;\\");"
 `;
 
 exports[`macro babel 6 css object 1`] = `
-"import { css as _css } from '../src';
+"import { css as _css } from \\"../src\\";
 
-const cls1 = /*#__PURE__*/_css({ display: 'flex' });"
+const cls1 =
+/*#__PURE__*/
+_css({
+  display: 'flex'
+});"
 `;
 
 exports[`macro babel 6 flush 1`] = `
-"import { flush as _flush } from '../src';
-
+"import { flush as _flush } from \\"../src\\";
 const someOtherVar = _flush;"
 `;
 
 exports[`macro babel 6 hydrate 1`] = `
-"import { hydrate as _hydrate } from '../src';
-
+"import { hydrate as _hydrate } from \\"../src\\";
 const someOtherVar = _hydrate;"
 `;
 
 exports[`macro babel 6 injectGlobal 1`] = `
-"import { injectGlobal as _injectGlobal } from '../src';
+"import { injectGlobal as _injectGlobal } from \\"../src\\";
 
-_injectGlobal('body{margin:0;padding:0;& > div{display:none;&:hover{color:green;& span{color:red;&:after{content:\\"end of line\\"}}}}}html{background:green;}');"
+_injectGlobal(\\"body{margin:0;padding:0;& > div{display:none;&:hover{color:green;& span{color:red;&:after{content:\\\\\\"end of line\\\\\\"}}}}}html{background:green;}\\");"
 `;
 
 exports[`macro babel 6 keyframes 1`] = `
-"import { keyframes as _keyframes } from '../src';
+"import { keyframes as _keyframes } from \\"../src\\";
 
-const rotate360 = /*#__PURE__*/_keyframes('from{transform:rotate(0deg);}to{transform:rotate(360deg);}');"
+const rotate360 =
+/*#__PURE__*/
+_keyframes(\\"from{transform:rotate(0deg);}to{transform:rotate(360deg);}\\");"
 `;
 
 exports[`macro babel 6 multiple imports 1`] = `
-"import { keyframes as _keyframes, css as _css } from '../src';
+"import { keyframes as _keyframes, css as _css } from \\"../src\\";
 
-const rotate360 = /*#__PURE__*/_keyframes('from{transform:rotate(0deg);}to{transform:rotate(360deg);}');
-const thing = /*#__PURE__*/_css('margin:12px 48px;color:#ffffff;display:flex;flex:1 0 auto;color:blue;width:', widthVar, ';');"
+const rotate360 =
+/*#__PURE__*/
+_keyframes(\\"from{transform:rotate(0deg);}to{transform:rotate(360deg);}\\");
+
+const thing =
+/*#__PURE__*/
+_css(\\"margin:12px 48px;color:#ffffff;display:flex;flex:1 0 auto;color:blue;width:\\", widthVar, \\";\\");"
 `;
 
 exports[`macro babel 6 some import that does not exist 1`] = `
-"import { thisDoesNotExist as _thisDoesNotExist } from '../src';
-
+"import { thisDoesNotExist as _thisDoesNotExist } from \\"../src\\";
 const someOtherVar = _thisDoesNotExist;"
 `;
 
@@ -138,51 +153,60 @@ const someOtherVar = _thisDoesNotExist;"
 `;
 
 exports[`styled macro babel 6 css from react 1`] = `
-"import { css as _css } from './styled';
+"import { css as _css } from \\"./styled\\";
 
-const someCls = /*#__PURE__*/_css('display:flex;');"
+const someCls =
+/*#__PURE__*/
+_css(\\"display:flex;\\");"
 `;
 
 exports[`styled macro babel 6 object function 1`] = `
-"import _styled from './styled';
+"import _styled from \\"./styled\\";
 
-const SomeComponent = /*#__PURE__*/_styled('div', {
-  target: 'ef2fk0r0'
+const SomeComponent =
+/*#__PURE__*/
+_styled('div', {
+  target: \\"ef2fk0r0\\"
 })({
   display: 'flex'
 });"
 `;
 
 exports[`styled macro babel 6 object member 1`] = `
-"import _styled from './styled';
+"import _styled from \\"./styled\\";
 
-const SomeComponent = /*#__PURE__*/_styled('div', {
-  target: 'ef2fk0r0'
+const SomeComponent =
+/*#__PURE__*/
+_styled(\\"div\\", {
+  target: \\"ef2fk0r0\\"
 })({
   display: 'flex'
 });"
 `;
 
 exports[`styled macro babel 6 some import that does not exist 1`] = `
-"import { thisDoesNotExist as _thisDoesNotExist } from './styled';
-
+"import { thisDoesNotExist as _thisDoesNotExist } from \\"./styled\\";
 const someOtherVar = _thisDoesNotExist;"
 `;
 
 exports[`styled macro babel 6 tagged template literal function 1`] = `
-"import _styled from './styled';
+"import _styled from \\"./styled\\";
 
-const SomeComponent = /*#__PURE__*/_styled('div', {
-  target: 'ef2fk0r0'
-})('display:flex;');"
+const SomeComponent =
+/*#__PURE__*/
+_styled('div', {
+  target: \\"ef2fk0r0\\"
+})(\\"display:flex;\\");"
 `;
 
 exports[`styled macro babel 6 tagged template literal member 1`] = `
-"import _styled from './styled';
+"import _styled from \\"./styled\\";
 
-const SomeComponent = /*#__PURE__*/_styled('div', {
-  target: 'ef2fk0r0'
-})('display:flex;');"
+const SomeComponent =
+/*#__PURE__*/
+_styled(\\"div\\", {
+  target: \\"ef2fk0r0\\"
+})(\\"display:flex;\\");"
 `;
 
 exports[`styled macro babel 7 css from react 1`] = `

--- a/packages/babel-plugin-emotion/test/__snapshots__/primitives.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/primitives.test.js.snap
@@ -1,26 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`styled inline babel 6 does not change call expressions 1`] = `
-"
-/*#__PURE__*/styled('SomeFakeComponent', {
-    target: 'e8nbyc50'
-})('color:hotpink;');
-/*#__PURE__*/styled('SomeFakeComponent', {
-    target: 'e8nbyc51'
+"/*#__PURE__*/
+styled('SomeFakeComponent', {
+  target: \\"e1u6ll0g0\\"
+})(\\"color:hotpink;\\");
+
+/*#__PURE__*/
+styled('SomeFakeComponent', {
+  target: \\"e1u6ll0g1\\"
 })({});"
 `;
 
 exports[`styled inline babel 6 does not change to a call expression when beginning with a upper case letter 1`] = `
-"
-/*#__PURE__*/styled.View(\\"color:hotpink;\\");
-/*#__PURE__*/styled.View({});"
+"/*#__PURE__*/
+styled.View(\\"color:hotpink;\\");
+
+/*#__PURE__*/
+styled.View({});"
 `;
 
 exports[`styled inline babel 6 other name with @emotion/primitives 1`] = `
-"
-import someOtherName from '@emotion/primitives';
-/*#__PURE__*/someOtherName.View('color:hotpink;');
-/*#__PURE__*/someOtherName.View({});"
+"import someOtherName from '@emotion/primitives';
+
+/*#__PURE__*/
+someOtherName.View(\\"color:hotpink;\\");
+
+/*#__PURE__*/
+someOtherName.View({});"
 `;
 
 exports[`styled inline babel 7 does not change call expressions 1`] = `

--- a/packages/babel-plugin-emotion/test/__snapshots__/source-map.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/source-map.test.js.snap
@@ -1,39 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`source map babel 6 css object 1`] = `"/*#__PURE__*/css({ color: 'hotpink' }, '/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImVtb3Rpb24uanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEiLCJmaWxlIjoiZW1vdGlvbi5qcyIsInNvdXJjZXNDb250ZW50IjpbImNzcyh7Y29sb3I6ICdob3RwaW5rJ30pIl19 */');"`;
+exports[`source map babel 6 css object 1`] = `
+"/*#__PURE__*/
+css({
+  color: 'hotpink'
+}, \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImVtb3Rpb24uanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEiLCJmaWxlIjoiZW1vdGlvbi5qcyIsInNvdXJjZXNDb250ZW50IjpbImNzcyh7Y29sb3I6ICdob3RwaW5rJ30pIl19 */\\");"
+`;
 
 exports[`source map babel 6 css prop 1`] = `
 "import { css as _css } from \\"emotion\\";
-
-<div className={/*#__PURE__*/_css(\\"width:128px;height:128px;background-color:#8c81d8;border-radius:4px;& img{width:96px;height:96px;border-radius:50%;transition:all 400ms ease-in-out;&:hover{transform:scale(1.2);}}/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNpdGUuc291cmNlLW1hcC50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVXIiwiZmlsZSI6InNpdGUuc291cmNlLW1hcC50ZXN0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiXG4gICAgPGRpdlxuICAgICAgY3NzPXtgXG4gICAgICAgIHdpZHRoOiAxMjhweDtcbiAgICAgICAgaGVpZ2h0OiAxMjhweDtcbiAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogIzhjODFkODtcbiAgICAgICAgYm9yZGVyLXJhZGl1czogNHB4O1xuICBcbiAgICAgICAgJiBpbWcge1xuICAgICAgICAgIHdpZHRoOiA5NnB4O1xuICAgICAgICAgIGhlaWdodDogOTZweDtcbiAgICAgICAgICBib3JkZXItcmFkaXVzOiA1MCU7XG4gICAgICAgICAgdHJhbnNpdGlvbjogYWxsIDQwMG1zIGVhc2UtaW4tb3V0O1xuICBcbiAgICAgICAgICAmOmhvdmVyIHtcbiAgICAgICAgICAgIHRyYW5zZm9ybTogc2NhbGUoMS4yKTtcbiAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICAgIGB9XG4gICAgLz5cbiAgIl19 */\\")} />;"
+<div className={
+/*#__PURE__*/
+_css(\\"width:128px;height:128px;background-color:#8c81d8;border-radius:4px;& img{width:96px;height:96px;border-radius:50%;transition:all 400ms ease-in-out;&:hover{transform:scale(1.2);}}/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNpdGUuc291cmNlLW1hcC50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVXIiwiZmlsZSI6InNpdGUuc291cmNlLW1hcC50ZXN0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiXG4gICAgPGRpdlxuICAgICAgY3NzPXtgXG4gICAgICAgIHdpZHRoOiAxMjhweDtcbiAgICAgICAgaGVpZ2h0OiAxMjhweDtcbiAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogIzhjODFkODtcbiAgICAgICAgYm9yZGVyLXJhZGl1czogNHB4O1xuICBcbiAgICAgICAgJiBpbWcge1xuICAgICAgICAgIHdpZHRoOiA5NnB4O1xuICAgICAgICAgIGhlaWdodDogOTZweDtcbiAgICAgICAgICBib3JkZXItcmFkaXVzOiA1MCU7XG4gICAgICAgICAgdHJhbnNpdGlvbjogYWxsIDQwMG1zIGVhc2UtaW4tb3V0O1xuICBcbiAgICAgICAgICAmOmhvdmVyIHtcbiAgICAgICAgICAgIHRyYW5zZm9ybTogc2NhbGUoMS4yKTtcbiAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICAgIGB9XG4gICAgLz5cbiAgIl19 */\\")} />;"
 `;
 
 exports[`source map babel 6 css prop with merge 1`] = `
-"import { merge as _merge } from 'emotion';
-import { css as _css } from 'emotion';
-
+"import { merge as _merge } from \\"emotion\\";
+import { css as _css } from \\"emotion\\";
 <div className={_merge(_css({
   color: 'plum'
-}, '/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNpdGUuc291cmNlLW1hcC50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUdRIiwiZmlsZSI6InNpdGUuc291cmNlLW1hcC50ZXN0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiXG4gICAgICA8ZGl2XG4gICAgICAgIGNsYXNzTmFtZT17c29tZUNsYXNzTmFtZX1cbiAgICAgICAgY3NzPXt7XG4gICAgICAgICAgY29sb3I6ICdwbHVtJ1xuICAgICAgICB9fVxuICAgICAgLz5cbiAgICAiXX0= */') + (' ' + someClassName), '/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNpdGUuc291cmNlLW1hcC50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUdRIiwiZmlsZSI6InNpdGUuc291cmNlLW1hcC50ZXN0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiXG4gICAgICA8ZGl2XG4gICAgICAgIGNsYXNzTmFtZT17c29tZUNsYXNzTmFtZX1cbiAgICAgICAgY3NzPXt7XG4gICAgICAgICAgY29sb3I6ICdwbHVtJ1xuICAgICAgICB9fVxuICAgICAgLz5cbiAgICAiXX0= */')} />;"
+}, \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNpdGUuc291cmNlLW1hcC50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUdRIiwiZmlsZSI6InNpdGUuc291cmNlLW1hcC50ZXN0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiXG4gICAgICA8ZGl2XG4gICAgICAgIGNsYXNzTmFtZT17c29tZUNsYXNzTmFtZX1cbiAgICAgICAgY3NzPXt7XG4gICAgICAgICAgY29sb3I6ICdwbHVtJ1xuICAgICAgICB9fVxuICAgICAgLz5cbiAgICAiXX0= */\\") + (\\" \\" + someClassName), \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNpdGUuc291cmNlLW1hcC50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUdRIiwiZmlsZSI6InNpdGUuc291cmNlLW1hcC50ZXN0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiXG4gICAgICA8ZGl2XG4gICAgICAgIGNsYXNzTmFtZT17c29tZUNsYXNzTmFtZX1cbiAgICAgICAgY3NzPXt7XG4gICAgICAgICAgY29sb3I6ICdwbHVtJ1xuICAgICAgICB9fVxuICAgICAgLz5cbiAgICAiXX0= */\\")} />;"
 `;
 
 exports[`source map babel 6 css prop with objects 1`] = `
-"import { css as _css } from 'emotion';
-
+"import { css as _css } from \\"emotion\\";
 <div className={_css({
   color: 'plum'
-}, '/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNpdGUuc291cmNlLW1hcC50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVRIiwiZmlsZSI6InNpdGUuc291cmNlLW1hcC50ZXN0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiXG4gICAgICA8ZGl2XG4gICAgICAgIGNzcz17e1xuICAgICAgICAgIGNvbG9yOiAncGx1bSdcbiAgICAgICAgfX1cbiAgICAgIC8+XG4gICAgIl19 */')} />;"
+}, \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNpdGUuc291cmNlLW1hcC50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVRIiwiZmlsZSI6InNpdGUuc291cmNlLW1hcC50ZXN0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiXG4gICAgICA8ZGl2XG4gICAgICAgIGNzcz17e1xuICAgICAgICAgIGNvbG9yOiAncGx1bSdcbiAgICAgICAgfX1cbiAgICAgIC8+XG4gICAgIl19 */\\")} />;"
 `;
 
 exports[`source map babel 6 css source map 1`] = `
-"
-/*#__PURE__*/css(\\"margin:12px 48px;color:#ffffff;display:flex;flex:1 0 auto;color:blue;@media(min-width:420px){line-height:40px;}width:\\", widthVar, \\";/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNzcy5zb3VyY2UtbWFwLnRlc3QuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQ1ciLCJmaWxlIjoiY3NzLnNvdXJjZS1tYXAudGVzdC5qcyIsInNvdXJjZXNDb250ZW50IjpbIlxuICAgICAgICBjc3NgXG4gICAgICAgIG1hcmdpbjogMTJweCA0OHB4O1xuICAgICAgICBjb2xvcjogI2ZmZmZmZjtcbiAgICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgICAgZmxleDogMSAwIGF1dG87XG4gICAgICAgIGNvbG9yOiBibHVlO1xuICAgICAgICBAbWVkaWEobWluLXdpZHRoOiA0MjBweCkge1xuICAgICAgICAgIGxpbmUtaGVpZ2h0OiA0MHB4O1xuICAgICAgICB9XG4gICAgICAgIHdpZHRoOiAke3dpZHRoVmFyfTtcbiAgICAgIGAiXX0= */\\");"
+"/*#__PURE__*/
+css(\\"margin:12px 48px;color:#ffffff;display:flex;flex:1 0 auto;color:blue;@media(min-width:420px){line-height:40px;}width:\\", widthVar, \\";/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNzcy5zb3VyY2UtbWFwLnRlc3QuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQ1ciLCJmaWxlIjoiY3NzLnNvdXJjZS1tYXAudGVzdC5qcyIsInNvdXJjZXNDb250ZW50IjpbIlxuICAgICAgICBjc3NgXG4gICAgICAgIG1hcmdpbjogMTJweCA0OHB4O1xuICAgICAgICBjb2xvcjogI2ZmZmZmZjtcbiAgICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgICAgZmxleDogMSAwIGF1dG87XG4gICAgICAgIGNvbG9yOiBibHVlO1xuICAgICAgICBAbWVkaWEobWluLXdpZHRoOiA0MjBweCkge1xuICAgICAgICAgIGxpbmUtaGVpZ2h0OiA0MHB4O1xuICAgICAgICB9XG4gICAgICAgIHdpZHRoOiAke3dpZHRoVmFyfTtcbiAgICAgIGAiXX0= */\\");"
 `;
 
 exports[`source map babel 6 styled object styles source map 1`] = `
-"
-/*#__PURE__*/styled('div', {
-  target: 'e5gcmo60'
+"/*#__PURE__*/
+styled('div', {
+  target: \\"eev0nov0\\"
 })({
   color: 'blue',
   '&:hover': {
@@ -48,13 +52,15 @@ exports[`source map babel 6 styled object styles source map 1`] = `
     },
     color: 'green'
   }
-}, '/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNzcy1uZXN0ZWQuc291cmNlLW1hcC50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUNNIiwiZmlsZSI6ImNzcy1uZXN0ZWQuc291cmNlLW1hcC50ZXN0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiXG4gICAgICBzdHlsZWQoJ2RpdicpKHtcbiAgICAgICAgY29sb3I6ICdibHVlJyxcbiAgICAgICAgJyY6aG92ZXInOiB7XG4gICAgICAgICAgJyYgLm5hbWUnOiB7XG4gICAgICAgICAgICBjb2xvcjogJ2FtZXRoeXN0JyxcbiAgICAgICAgICAgICcmOmZvY3VzJzoge1xuICAgICAgICAgICAgICBjb2xvcjogJ2J1cmx5d29vZCcsXG4gICAgICAgICAgICAgIFttcVswXV06IHtcbiAgICAgICAgICAgICAgICBjb2xvcjogJ3JlYmVjY2FwdXJwbGUnXG4gICAgICAgICAgICAgIH1cbiAgICAgICAgICAgIH1cbiAgICAgICAgICB9LFxuICAgICAgICAgIGNvbG9yOiAnZ3JlZW4nXG4gICAgICAgIH1cbiAgICAgIH0pXG4gICAgIl19 */');"
+}, \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNzcy1uZXN0ZWQuc291cmNlLW1hcC50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUNNIiwiZmlsZSI6ImNzcy1uZXN0ZWQuc291cmNlLW1hcC50ZXN0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiXG4gICAgICBzdHlsZWQoJ2RpdicpKHtcbiAgICAgICAgY29sb3I6ICdibHVlJyxcbiAgICAgICAgJyY6aG92ZXInOiB7XG4gICAgICAgICAgJyYgLm5hbWUnOiB7XG4gICAgICAgICAgICBjb2xvcjogJ2FtZXRoeXN0JyxcbiAgICAgICAgICAgICcmOmZvY3VzJzoge1xuICAgICAgICAgICAgICBjb2xvcjogJ2J1cmx5d29vZCcsXG4gICAgICAgICAgICAgIFttcVswXV06IHtcbiAgICAgICAgICAgICAgICBjb2xvcjogJ3JlYmVjY2FwdXJwbGUnXG4gICAgICAgICAgICAgIH1cbiAgICAgICAgICAgIH1cbiAgICAgICAgICB9LFxuICAgICAgICAgIGNvbG9yOiAnZ3JlZW4nXG4gICAgICAgIH1cbiAgICAgIH0pXG4gICAgIl19 */\\");"
 `;
 
 exports[`source map babel 6 styled source map 1`] = `
-"const Avatar = /*#__PURE__*/styled('img', {
-  target: 'e1367ks30'
-})('width:96px;height:96px;border-radius:', props => props.theme.borderRadius, ';border:1px solid ', props => props.theme.borderColor, ';/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInN0eWxlZC5zb3VyY2UtbWFwLnRlc3QuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQTRCIiwiZmlsZSI6InN0eWxlZC5zb3VyY2UtbWFwLnRlc3QuanMiLCJzb3VyY2VzQ29udGVudCI6WyJjb25zdCBBdmF0YXIgPSBzdHlsZWQoJ2ltZycpYFxuICAgICAgICB3aWR0aDogOTZweDtcbiAgICAgICAgaGVpZ2h0OiA5NnB4O1xuXG4gICAgICAgIGJvcmRlci1yYWRpdXM6ICR7cHJvcHMgPT5cbiAgICAgICAgICBwcm9wcy50aGVtZS5ib3JkZXJSYWRpdXN9O1xuXG4gICAgICAgIGJvcmRlcjogMXB4IHNvbGlkICR7cHJvcHMgPT5cbiAgICAgICAgICBwcm9wcy50aGVtZS5ib3JkZXJDb2xvcn07XG4gICAgICBgIl19 */');"
+"const Avatar =
+/*#__PURE__*/
+styled('img', {
+  target: \\"e1phmxw70\\"
+})(\\"width:96px;height:96px;border-radius:\\", props => props.theme.borderRadius, \\";border:1px solid \\", props => props.theme.borderColor, \\";/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInN0eWxlZC5zb3VyY2UtbWFwLnRlc3QuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQTRCIiwiZmlsZSI6InN0eWxlZC5zb3VyY2UtbWFwLnRlc3QuanMiLCJzb3VyY2VzQ29udGVudCI6WyJjb25zdCBBdmF0YXIgPSBzdHlsZWQoJ2ltZycpYFxuICAgICAgICB3aWR0aDogOTZweDtcbiAgICAgICAgaGVpZ2h0OiA5NnB4O1xuXG4gICAgICAgIGJvcmRlci1yYWRpdXM6ICR7cHJvcHMgPT5cbiAgICAgICAgICBwcm9wcy50aGVtZS5ib3JkZXJSYWRpdXN9O1xuXG4gICAgICAgIGJvcmRlcjogMXB4IHNvbGlkICR7cHJvcHMgPT5cbiAgICAgICAgICBwcm9wcy50aGVtZS5ib3JkZXJDb2xvcn07XG4gICAgICBgIl19 */\\");"
 `;
 
 exports[`source map babel 7 css object 1`] = `

--- a/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
+++ b/packages/babel-plugin-emotion/test/__snapshots__/styled.test.js.snap
@@ -1,11 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`styled extract babel 6 autoLabel object styles 1`] = `
-"
-const Profile = () => {
-  const H1 = /*#__PURE__*/styled('h1', {
-    target: 'e8nbyc50',
-    label: 'H1'
+"const Profile = () => {
+  const H1 =
+  /*#__PURE__*/
+  styled(\\"h1\\", {
+    target: \\"e1u6ll0g0\\",
+    label: \\"H1\\"
   })({
     borderRadius: '50%',
     transition: 'transform 400ms ease-in-out',
@@ -19,14 +20,13 @@ const Profile = () => {
 `;
 
 exports[`styled extract babel 6 autoLabel string styles 1`] = `
-"import './emotion.emotion.css';
+"import \\"./emotion.emotion.css\\";
 
 const Profile = () => {
   const ProfileH1 = styled('h1', {
-    e: 'css-kmz3n4',
-    target: 'e8nbyc50'
+    e: \\"css-kmz3n4\\",
+    target: \\"e1u6ll0g0\\"
   })();
-
   return <H1>Hello</H1>;
 };
 
@@ -36,17 +36,18 @@ emotion.emotion.css
 `;
 
 exports[`styled extract babel 6 basic 1`] = `
-"const H1 = /*#__PURE__*/styled('h1', {
-  target: 'e8nbyc50'
-})('font-size:', fontSize + 'px', ';');"
+"const H1 =
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
+})(\\"font-size:\\", fontSize + 'px', \\";\\");"
 `;
 
 exports[`styled extract babel 6 comments 1`] = `
 "import \\"./emotion.emotion.css\\";
-
 styled(\\"div\\", {
-    e: \\"css-n0xpvi\\",
-    target: \\"e8nbyc50\\"
+  e: \\"css-n0xpvi\\",
+  target: \\"e1u6ll0g0\\"
 })();
 
 
@@ -55,20 +56,19 @@ emotion.emotion.css
 `;
 
 exports[`styled extract babel 6 component selector 1`] = `
-"import './emotion.emotion.css';
-
-const Child = styled('div', {
-  e: 'css-1vhj9jp',
-  target: 'e8nbyc50'
+"import \\"./emotion.emotion.css\\";
+const Child = styled(\\"div\\", {
+  e: \\"css-1vhj9jp\\",
+  target: \\"e1u6ll0g0\\"
 })();
-
 const SecondChild = Child.withComponent('span', {
-  target: 'e8nbyc51'
+  target: \\"e1u6ll0g1\\"
 });
-
-const Parent = /*#__PURE__*/styled('div', {
-  target: 'e8nbyc52'
-})(Child, '{color:blue;}', SecondChild, '{color:pink;}');
+const Parent =
+/*#__PURE__*/
+styled(\\"div\\", {
+  target: \\"e1u6ll0g2\\"
+})(Child, \\"{color:blue;}\\", SecondChild, \\"{color:pink;}\\");
 
 
 emotion.emotion.css
@@ -76,13 +76,15 @@ emotion.emotion.css
 `;
 
 exports[`styled extract babel 6 composition based on props 1`] = `
-"import './emotion.emotion.css';
-const cls1 = 'css-cls1-1ltut9y';
-const H1 = /*#__PURE__*/styled('h1', {
-  target: 'e8nbyc50'
+"import \\"./emotion.emotion.css\\";
+const cls1 = \\"css-cls1-1ltut9y\\";
+const H1 =
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
 })(props => {
   return props.a ? cssA : cssB;
-}, ';font-size:', fontSize + 'px', ';height:20px;transform:translateX(', props => props.translateX, ');');
+}, \\";font-size:\\", fontSize + 'px', \\";height:20px;transform:translateX(\\", props => props.translateX, \\");\\");
 
 
 emotion.emotion.css
@@ -93,7 +95,7 @@ exports[`styled extract babel 6 config rename 1`] = `
 "import \\"./emotion.emotion.css\\";
 what(\\"h1\\", {
   e: \\"css-14ksm7b\\",
-  target: \\"e8nbyc50\\"
+  target: \\"e1u6ll0g0\\"
 })();
 
 
@@ -102,19 +104,22 @@ emotion.emotion.css
 `;
 
 exports[`styled extract babel 6 dynamic fns 1`] = `
-"const Avatar = /*#__PURE__*/styled('img', {
-  target: 'e8nbyc50'
-})('width:96px;height:96px;border-radius:', props => props.theme.borderRadius, ';border:1px solid ', props => props.theme.borderColor, ';');"
+"const Avatar =
+/*#__PURE__*/
+styled('img', {
+  target: \\"e1u6ll0g0\\"
+})(\\"width:96px;height:96px;border-radius:\\", props => props.theme.borderRadius, \\";border:1px solid \\", props => props.theme.borderColor, \\";\\");"
 `;
 
 exports[`styled extract babel 6 existing options 1`] = `
-"import './emotion.emotion.css';
-
+"import \\"./emotion.emotion.css\\";
 const Button = styled('button', {
   existing: true,
-  e: 'css-1aj1g6z',
-  target: 'e8nbyc50'
-}, otherArg, 'test', { anotherArg: 1 })();
+  e: \\"css-1aj1g6z\\",
+  target: \\"e1u6ll0g0\\"
+}, otherArg, 'test', {
+  anotherArg: 1
+})();
 
 
 emotion.emotion.css
@@ -122,27 +127,31 @@ emotion.emotion.css
 `;
 
 exports[`styled extract babel 6 existing options object 1`] = `
-"
-const Button = /*#__PURE__*/styled('button', {
+"const Button =
+/*#__PURE__*/
+styled('button', {
   existing: true,
-  target: 'e8nbyc50',
-  label: 'Button'
-}, otherArg, 'test', { anotherArg: 1 })({
+  target: \\"e1u6ll0g0\\",
+  label: \\"Button\\"
+}, otherArg, 'test', {
+  anotherArg: 1
+})({
   color: 'blue'
 });"
 `;
 
 exports[`styled extract babel 6 function call 1`] = `
-"/*#__PURE__*/styled(MyComponent, {
-  target: 'e8nbyc50'
-})('font-size:', fontSize + 'px', ';');"
+"/*#__PURE__*/
+styled(MyComponent, {
+  target: \\"e1u6ll0g0\\"
+})(\\"font-size:\\", fontSize + 'px', \\";\\");"
 `;
 
 exports[`styled extract babel 6 hash generation no file system 1`] = `
 "import \\"./emotion.css\\";
 styled(\\"h1\\", {
   e: \\"css-14ksm7b\\",
-  target: \\"ezpcgkn0\\"
+  target: \\"e1kqw4hu0\\"
 })();
 
 
@@ -160,11 +169,15 @@ exports[`styled extract babel 6 hoisting 1`] = `
     transform: 'scale(1.2)'
   }
 };
-var _ref2 = [{ color: 'blue' }];
+var _ref2 = [{
+  color: 'blue'
+}];
 
 const Profile = () => {
-  const H1 = /*#__PURE__*/styled('h1', {
-    target: 'e8nbyc50'
+  const H1 =
+  /*#__PURE__*/
+  styled(\\"h1\\", {
+    target: \\"e1u6ll0g0\\"
   })(_ref, props => ({
     display: props.display
   }), _ref2);
@@ -172,17 +185,18 @@ const Profile = () => {
 `;
 
 exports[`styled extract babel 6 interpolation in different places 1`] = `
-"
-const H1 = /*#__PURE__*/styled('h1', {
-  target: 'e8nbyc50'
-})('font-size:', fontSize + 'px', ';height:20px;transform:translateX(', props => props.translateX, ');height1:', something, 'wow;width:w', something, 'ow;transform:translateX(', props => props.translateX, ') translateY(', props => props.translateX, ');transform1:translateX(', props => props.translateX, ') translateY(', props => props.translateX, ');transform2:translateX(', props => props.translateX, ') ', props => props.translateX, ';');"
+"const H1 =
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
+})(\\"font-size:\\", fontSize + 'px', \\";height:20px;transform:translateX(\\", props => props.translateX, \\");height1:\\", something, \\"wow;width:w\\", something, \\"ow;transform:translateX(\\", props => props.translateX, \\") translateY(\\", props => props.translateX, \\");transform1:translateX(\\", props => props.translateX, \\") translateY(\\", props => props.translateX, \\");transform2:translateX(\\", props => props.translateX, \\") \\", props => props.translateX, \\";\\");"
 `;
 
 exports[`styled extract babel 6 media query 1`] = `
 "import \\"./emotion.emotion.css\\";
 const H1 = styled(\\"h1\\", {
   e: \\"css-6skbg5\\",
-  target: \\"e8nbyc50\\"
+  target: \\"e1u6ll0g0\\"
 })();
 
 
@@ -191,22 +205,26 @@ emotion.emotion.css
 `;
 
 exports[`styled extract babel 6 more than 10 dynamic values 1`] = `
-"const H1 = /*#__PURE__*/styled('h1', {
-    target: 'e8nbyc50'
-})('text-decoration:', 'underline', ';border-right:solid blue ', 54, 'px;background:', 'white', ';color:', 'black', ';display:', 'block', ';border-radius:', '3px', ';padding:', '25px', ';width:', '500px', ';z-index:', 100, ';font-size:', '18px', ';text-align:', 'center', ';border-left:', p => p.theme.blue, ';');"
+"const H1 =
+/*#__PURE__*/
+styled('h1', {
+  target: \\"e1u6ll0g0\\"
+})(\\"text-decoration:\\", 'underline', \\";border-right:solid blue \\", 54, \\"px;background:\\", 'white', \\";color:\\", 'black', \\";display:\\", 'block', \\";border-radius:\\", '3px', \\";padding:\\", '25px', \\";width:\\", '500px', \\";z-index:\\", 100, \\";font-size:\\", '18px', \\";text-align:\\", 'center', \\";border-left:\\", p => p.theme.blue, \\";\\");"
 `;
 
 exports[`styled extract babel 6 nested 1`] = `
-"const H1 = /*#__PURE__*/styled('h1', {
-  target: 'e8nbyc50'
-})('font-size:', fontSize + 'px', ';& div{color:blue;& span{color:red}}');"
+"const H1 =
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
+})(\\"font-size:\\", fontSize + 'px', \\";& div{color:blue;& span{color:red}}\\");"
 `;
 
 exports[`styled extract babel 6 no dynamic 1`] = `
 "import \\"./emotion.emotion.css\\";
 styled(\\"h1\\", {
   e: \\"css-14ksm7b\\",
-  target: \\"e8nbyc50\\"
+  target: \\"e1u6ll0g0\\"
 })();
 
 
@@ -218,42 +236,47 @@ exports[`styled extract babel 6 no use 1`] = `
 "import \\"./emotion.emotion.css\\";
 styled(\\"h1\\", {
   e: \\"css-0\\",
-  target: \\"e8nbyc50\\"
+  target: \\"e1u6ll0g0\\"
 })();"
 `;
 
 exports[`styled extract babel 6 objects based on props 1`] = `
-"
-const H1 = /*#__PURE__*/styled('h1', {
-  target: 'e8nbyc50'
-})({ padding: 10 }, props => ({
+"const H1 =
+/*#__PURE__*/
+styled('h1', {
+  target: \\"e1u6ll0g0\\"
+})({
+  padding: 10
+}, props => ({
   display: props.display
 }));"
 `;
 
 exports[`styled extract babel 6 objects fn call 1`] = `
-"
-const H1 = /*#__PURE__*/styled('h1', {
-  target: 'e8nbyc50'
+"const H1 =
+/*#__PURE__*/
+styled('h1', {
+  target: \\"e1u6ll0g0\\"
 })({
   display: 'flex'
 });"
 `;
 
 exports[`styled extract babel 6 objects prefixed 1`] = `
-"
-const H1 = /*#__PURE__*/styled('h1', {
-    target: 'e8nbyc50'
+"const H1 =
+/*#__PURE__*/
+styled('h1', {
+  target: \\"e1u6ll0g0\\"
 })({
-    borderRadius: '50%',
-    transition: 'transform 400ms ease-in-out',
-    boxSizing: 'border-box',
-    display: 'flex',
-    ':hover': {
-        transform: 'scale(1.2)'
-    }
+  borderRadius: '50%',
+  transition: 'transform 400ms ease-in-out',
+  boxSizing: 'border-box',
+  display: 'flex',
+  ':hover': {
+    transform: 'scale(1.2)'
+  }
 }, props => {
-    padding: props.padding;
+  padding: props.padding;
 });"
 `;
 
@@ -261,9 +284,13 @@ exports[`styled extract babel 6 random expressions 1`] = `
 "import \\"./emotion.emotion.css\\";
 
 const a = () => \\"css-a-1cvrkk1\\";
-/*#__PURE__*/styled(\\"h1\\", {
-  target: \\"e8nbyc50\\"
-})(\\"margin:12px 48px;\\", \\"css-143zpy6\\", \\";color:#ffffff;& .profile{\\", props => props.prop && a(), \\"}\\", { backgroundColor: \\"hotpink\\" }, \\";\\");
+
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
+})(\\"margin:12px 48px;\\", \\"css-143zpy6\\", \\";color:#ffffff;& .profile{\\", props => props.prop && a(), \\"}\\", {
+  backgroundColor: \\"hotpink\\"
+}, \\";\\");
 
 
 emotion.emotion.css
@@ -272,15 +299,20 @@ emotion.emotion.css
 `;
 
 exports[`styled extract babel 6 shorthand property 1`] = `
-"const H1 = /*#__PURE__*/styled(\\"h1\\", {
-  target: \\"e8nbyc50\\"
-})({ fontSize });"
+"const H1 =
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
+})({
+  fontSize
+});"
 `;
 
 exports[`styled extract babel 6 styled objects prefixed 1`] = `
-"
-const H1 = /*#__PURE__*/styled('h1', {
-  target: 'e8nbyc50'
+"const H1 =
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
 })({
   borderRadius: '50%',
   transition: 'transform 400ms ease-in-out',
@@ -295,32 +327,39 @@ const H1 = /*#__PURE__*/styled('h1', {
 `;
 
 exports[`styled extract babel 6 styled. objects 1`] = `
-"
-const H1 = /*#__PURE__*/styled(\\"h1\\", {
-  target: \\"e8nbyc50\\"
-})({ padding: 10 }, props => ({
+"const H1 =
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
+})({
+  padding: 10
+}, props => ({
   display: props.display
 }));"
 `;
 
 exports[`styled extract babel 6 styled. objects with a multiple spread properties 1`] = `
-"
-const defaultText = { fontSize: 20 };
-const Figure = /*#__PURE__*/styled(\\"figure\\", {
-  target: \\"e8nbyc50\\"
-})({
-  ...defaultText,
+"const defaultText = {
+  fontSize: 20
+};
+const Figure =
+/*#__PURE__*/
+styled(\\"figure\\", {
+  target: \\"e1u6ll0g0\\"
+})({ ...defaultText,
   ...defaultFigure
 });"
 `;
 
 exports[`styled extract babel 6 styled. objects with a multiple spread properties and other keys 1`] = `
-"
-const defaultText = { fontSize: 20 };
-const Figure = /*#__PURE__*/styled('figure', {
-  target: 'e8nbyc50'
-})({
-  ...defaultText,
+"const defaultText = {
+  fontSize: 20
+};
+const Figure =
+/*#__PURE__*/
+styled(\\"figure\\", {
+  target: \\"e1u6ll0g0\\"
+})({ ...defaultText,
   fontSize: '20px',
   ...defaultFigure,
   ...defaultText2
@@ -328,20 +367,23 @@ const Figure = /*#__PURE__*/styled('figure', {
 `;
 
 exports[`styled extract babel 6 styled. objects with a single spread property 1`] = `
-"
-const defaultText = { fontSize: 20 };
-const Figure = /*#__PURE__*/styled(\\"figure\\", {
-  target: \\"e8nbyc50\\"
-})({
-  ...defaultText
+"const defaultText = {
+  fontSize: 20
+};
+const Figure =
+/*#__PURE__*/
+styled(\\"figure\\", {
+  target: \\"e1u6ll0g0\\"
+})({ ...defaultText
 });"
 `;
 
 exports[`styled extract babel 6 variable import: no dynamic 1`] = `
-"import './emotion.emotion.css';
-import what from 'emotion';what('h1', {
-  e: 'css-14ksm7b',
-  target: 'e8nbyc50'
+"import \\"./emotion.emotion.css\\";
+import what from 'emotion';
+what(\\"h1\\", {
+  e: \\"css-14ksm7b\\",
+  target: \\"e1u6ll0g0\\"
 })();
 
 
@@ -741,11 +783,12 @@ emotion.emotion.css
 `;
 
 exports[`styled inline babel 6 autoLabel object styles 1`] = `
-"
-const Profile = () => {
-  const H1 = /*#__PURE__*/styled('h1', {
-    target: 'e8nbyc50',
-    label: 'H1'
+"const Profile = () => {
+  const H1 =
+  /*#__PURE__*/
+  styled(\\"h1\\", {
+    target: \\"e1u6ll0g0\\",
+    label: \\"H1\\"
   })({
     borderRadius: '50%',
     transition: 'transform 400ms ease-in-out',
@@ -759,95 +802,113 @@ const Profile = () => {
 `;
 
 exports[`styled inline babel 6 autoLabel string styles 1`] = `
-"
-const Profile = () => {
-  const ProfileH1 = /*#__PURE__*/styled('h1', {
-    label: 'ProfileH1',
-    target: 'e8nbyc50'
-  })('color:blue;');
-
+"const Profile = () => {
+  const ProfileH1 =
+  /*#__PURE__*/
+  styled('h1', {
+    label: \\"ProfileH1\\",
+    target: \\"e1u6ll0g0\\"
+  })(\\"color:blue;\\");
   return <H1>Hello</H1>;
 };"
 `;
 
 exports[`styled inline babel 6 basic 1`] = `
-"const H1 = /*#__PURE__*/styled('h1', {
-  target: 'e8nbyc50'
-})('font-size:', fontSize + 'px', ';');"
+"const H1 =
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
+})(\\"font-size:\\", fontSize + 'px', \\";\\");"
 `;
 
 exports[`styled inline babel 6 comments 1`] = `
-"
-/*#__PURE__*/styled(\\"div\\", {
-    target: \\"e8nbyc50\\"
+"/*#__PURE__*/
+styled(\\"div\\", {
+  target: \\"e1u6ll0g0\\"
 })(\\"color:hotpink;\\");"
 `;
 
 exports[`styled inline babel 6 component selector 1`] = `
-"
-const Child = /*#__PURE__*/styled('div', {
-  target: 'e8nbyc50'
-})('color:red;');
-
+"const Child =
+/*#__PURE__*/
+styled(\\"div\\", {
+  target: \\"e1u6ll0g0\\"
+})(\\"color:red;\\");
 const SecondChild = Child.withComponent('span', {
-  target: 'e8nbyc51'
+  target: \\"e1u6ll0g1\\"
 });
-
-const Parent = /*#__PURE__*/styled('div', {
-  target: 'e8nbyc52'
-})(Child, '{color:blue;}', SecondChild, '{color:pink;}');"
+const Parent =
+/*#__PURE__*/
+styled(\\"div\\", {
+  target: \\"e1u6ll0g2\\"
+})(Child, \\"{color:blue;}\\", SecondChild, \\"{color:pink;}\\");"
 `;
 
 exports[`styled inline babel 6 composition based on props 1`] = `
-"const cls1 = /*#__PURE__*/css('width:20px;');
-const H1 = /*#__PURE__*/styled('h1', {
-  target: 'e8nbyc50'
+"const cls1 =
+/*#__PURE__*/
+css(\\"width:20px;\\");
+const H1 =
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
 })(props => {
   return props.a ? cssA : cssB;
-}, ';font-size:', fontSize + 'px', ';height:20px;transform:translateX(', props => props.translateX, ');');"
+}, \\";font-size:\\", fontSize + 'px', \\";height:20px;transform:translateX(\\", props => props.translateX, \\");\\");"
 `;
 
 exports[`styled inline babel 6 config rename 1`] = `
-"/*#__PURE__*/what(\\"h1\\", {
-  target: \\"e8nbyc50\\"
+"/*#__PURE__*/
+what(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
 })(\\"color:blue;\\");"
 `;
 
 exports[`styled inline babel 6 dynamic fns 1`] = `
-"const Avatar = /*#__PURE__*/styled('img', {
-  target: 'e8nbyc50'
-})('width:96px;height:96px;border-radius:', props => props.theme.borderRadius, ';border:1px solid ', props => props.theme.borderColor, ';');"
+"const Avatar =
+/*#__PURE__*/
+styled('img', {
+  target: \\"e1u6ll0g0\\"
+})(\\"width:96px;height:96px;border-radius:\\", props => props.theme.borderRadius, \\";border:1px solid \\", props => props.theme.borderColor, \\";\\");"
 `;
 
 exports[`styled inline babel 6 existing options 1`] = `
-"
-const Button = /*#__PURE__*/styled('button', {
+"const Button =
+/*#__PURE__*/
+styled('button', {
   existing: true,
-  label: 'Button',
-  target: 'e8nbyc50'
-}, otherArg, 'test', { anotherArg: 1 })('color:blue;');"
+  label: \\"Button\\",
+  target: \\"e1u6ll0g0\\"
+}, otherArg, 'test', {
+  anotherArg: 1
+})(\\"color:blue;\\");"
 `;
 
 exports[`styled inline babel 6 existing options object 1`] = `
-"
-const Button = /*#__PURE__*/styled('button', {
+"const Button =
+/*#__PURE__*/
+styled('button', {
   existing: true,
-  target: 'e8nbyc50',
-  label: 'Button'
-}, otherArg, 'test', { anotherArg: 1 })({
+  target: \\"e1u6ll0g0\\",
+  label: \\"Button\\"
+}, otherArg, 'test', {
+  anotherArg: 1
+})({
   color: 'blue'
 });"
 `;
 
 exports[`styled inline babel 6 function call 1`] = `
-"/*#__PURE__*/styled(MyComponent, {
-  target: 'e8nbyc50'
-})('font-size:', fontSize + 'px', ';');"
+"/*#__PURE__*/
+styled(MyComponent, {
+  target: \\"e1u6ll0g0\\"
+})(\\"font-size:\\", fontSize + 'px', \\";\\");"
 `;
 
 exports[`styled inline babel 6 hash generation no file system 1`] = `
-"/*#__PURE__*/styled(\\"h1\\", {
-  target: \\"ezpcgkn0\\"
+"/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1kqw4hu0\\"
 })(\\"color:blue;\\");"
 `;
 
@@ -861,11 +922,15 @@ exports[`styled inline babel 6 hoisting 1`] = `
     transform: 'scale(1.2)'
   }
 };
-var _ref2 = [{ color: 'blue' }];
+var _ref2 = [{
+  color: 'blue'
+}];
 
 const Profile = () => {
-  const H1 = /*#__PURE__*/styled('h1', {
-    target: 'e8nbyc50'
+  const H1 =
+  /*#__PURE__*/
+  styled(\\"h1\\", {
+    target: \\"e1u6ll0g0\\"
   })(_ref, props => ({
     display: props.display
   }), _ref2);
@@ -873,95 +938,121 @@ const Profile = () => {
 `;
 
 exports[`styled inline babel 6 interpolation in different places 1`] = `
-"
-const H1 = /*#__PURE__*/styled('h1', {
-  target: 'e8nbyc50'
-})('font-size:', fontSize + 'px', ';height:20px;transform:translateX(', props => props.translateX, ');height1:', something, 'wow;width:w', something, 'ow;transform:translateX(', props => props.translateX, ') translateY(', props => props.translateX, ');transform1:translateX(', props => props.translateX, ') translateY(', props => props.translateX, ');transform2:translateX(', props => props.translateX, ') ', props => props.translateX, ';');"
+"const H1 =
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
+})(\\"font-size:\\", fontSize + 'px', \\";height:20px;transform:translateX(\\", props => props.translateX, \\");height1:\\", something, \\"wow;width:w\\", something, \\"ow;transform:translateX(\\", props => props.translateX, \\") translateY(\\", props => props.translateX, \\");transform1:translateX(\\", props => props.translateX, \\") translateY(\\", props => props.translateX, \\");transform2:translateX(\\", props => props.translateX, \\") \\", props => props.translateX, \\";\\");"
 `;
 
 exports[`styled inline babel 6 media query 1`] = `
-"const H1 = /*#__PURE__*/styled(\\"h1\\", {
-  target: \\"e8nbyc50\\"
+"const H1 =
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
 })(\\"@media print{font-size:10pt}@media screen{.child-selector{font-size:13px}}@media screen,print{&:hover + &{line-height:1.2}}@media only screen   and (min-device-width:320px)   and (max-device-width:480px)  and (-webkit-min-device-pixel-ratio:2){.child-selector{line-height:1.4}}\\");"
 `;
 
 exports[`styled inline babel 6 more than 10 dynamic values 1`] = `
-"const H1 = /*#__PURE__*/styled('h1', {
-    target: 'e8nbyc50'
-})('text-decoration:', 'underline', ';border-right:solid blue ', 54, 'px;background:', 'white', ';color:', 'black', ';display:', 'block', ';border-radius:', '3px', ';padding:', '25px', ';width:', '500px', ';z-index:', 100, ';font-size:', '18px', ';text-align:', 'center', ';border-left:', p => p.theme.blue, ';');"
+"const H1 =
+/*#__PURE__*/
+styled('h1', {
+  target: \\"e1u6ll0g0\\"
+})(\\"text-decoration:\\", 'underline', \\";border-right:solid blue \\", 54, \\"px;background:\\", 'white', \\";color:\\", 'black', \\";display:\\", 'block', \\";border-radius:\\", '3px', \\";padding:\\", '25px', \\";width:\\", '500px', \\";z-index:\\", 100, \\";font-size:\\", '18px', \\";text-align:\\", 'center', \\";border-left:\\", p => p.theme.blue, \\";\\");"
 `;
 
 exports[`styled inline babel 6 nested 1`] = `
-"const H1 = /*#__PURE__*/styled('h1', {
-  target: 'e8nbyc50'
-})('font-size:', fontSize + 'px', ';& div{color:blue;& span{color:red}}');"
+"const H1 =
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
+})(\\"font-size:\\", fontSize + 'px', \\";& div{color:blue;& span{color:red}}\\");"
 `;
 
 exports[`styled inline babel 6 no dynamic 1`] = `
-"/*#__PURE__*/styled(\\"h1\\", {
-  target: \\"e8nbyc50\\"
+"/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
 })(\\"color:blue;\\");"
 `;
 
 exports[`styled inline babel 6 no use 1`] = `
-"/*#__PURE__*/styled(\\"h1\\", {
-  target: \\"e8nbyc50\\"
+"/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
 })();"
 `;
 
 exports[`styled inline babel 6 objects based on props 1`] = `
-"
-const H1 = /*#__PURE__*/styled('h1', {
-  target: 'e8nbyc50'
-})({ padding: 10 }, props => ({
+"const H1 =
+/*#__PURE__*/
+styled('h1', {
+  target: \\"e1u6ll0g0\\"
+})({
+  padding: 10
+}, props => ({
   display: props.display
 }));"
 `;
 
 exports[`styled inline babel 6 objects fn call 1`] = `
-"
-const H1 = /*#__PURE__*/styled('h1', {
-  target: 'e8nbyc50'
+"const H1 =
+/*#__PURE__*/
+styled('h1', {
+  target: \\"e1u6ll0g0\\"
 })({
   display: 'flex'
 });"
 `;
 
 exports[`styled inline babel 6 objects prefixed 1`] = `
-"
-const H1 = /*#__PURE__*/styled('h1', {
-    target: 'e8nbyc50'
+"const H1 =
+/*#__PURE__*/
+styled('h1', {
+  target: \\"e1u6ll0g0\\"
 })({
-    borderRadius: '50%',
-    transition: 'transform 400ms ease-in-out',
-    boxSizing: 'border-box',
-    display: 'flex',
-    ':hover': {
-        transform: 'scale(1.2)'
-    }
+  borderRadius: '50%',
+  transition: 'transform 400ms ease-in-out',
+  boxSizing: 'border-box',
+  display: 'flex',
+  ':hover': {
+    transform: 'scale(1.2)'
+  }
 }, props => {
-    padding: props.padding;
+  padding: props.padding;
 });"
 `;
 
 exports[`styled inline babel 6 random expressions 1`] = `
-"
-const a = () => /*#__PURE__*/css(\\"font-size:1rem\\");
-/*#__PURE__*/styled(\\"h1\\", {
-  target: \\"e8nbyc50\\"
-})(\\"margin:12px 48px;\\", /*#__PURE__*/css(\\"font-size:32px\\"), \\";color:#ffffff;& .profile{\\", props => props.prop && a(), \\"}\\", { backgroundColor: \\"hotpink\\" }, \\";\\");"
+"const a = () =>
+/*#__PURE__*/
+css(\\"font-size:1rem\\");
+
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
+})(\\"margin:12px 48px;\\",
+/*#__PURE__*/
+css(\\"font-size:32px\\"), \\";color:#ffffff;& .profile{\\", props => props.prop && a(), \\"}\\", {
+  backgroundColor: \\"hotpink\\"
+}, \\";\\");"
 `;
 
 exports[`styled inline babel 6 shorthand property 1`] = `
-"const H1 = /*#__PURE__*/styled(\\"h1\\", {
-  target: \\"e8nbyc50\\"
-})({ fontSize });"
+"const H1 =
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
+})({
+  fontSize
+});"
 `;
 
 exports[`styled inline babel 6 styled objects prefixed 1`] = `
-"
-const H1 = /*#__PURE__*/styled('h1', {
-  target: 'e8nbyc50'
+"const H1 =
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
 })({
   borderRadius: '50%',
   transition: 'transform 400ms ease-in-out',
@@ -976,32 +1067,39 @@ const H1 = /*#__PURE__*/styled('h1', {
 `;
 
 exports[`styled inline babel 6 styled. objects 1`] = `
-"
-const H1 = /*#__PURE__*/styled(\\"h1\\", {
-  target: \\"e8nbyc50\\"
-})({ padding: 10 }, props => ({
+"const H1 =
+/*#__PURE__*/
+styled(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
+})({
+  padding: 10
+}, props => ({
   display: props.display
 }));"
 `;
 
 exports[`styled inline babel 6 styled. objects with a multiple spread properties 1`] = `
-"
-const defaultText = { fontSize: 20 };
-const Figure = /*#__PURE__*/styled(\\"figure\\", {
-  target: \\"e8nbyc50\\"
-})({
-  ...defaultText,
+"const defaultText = {
+  fontSize: 20
+};
+const Figure =
+/*#__PURE__*/
+styled(\\"figure\\", {
+  target: \\"e1u6ll0g0\\"
+})({ ...defaultText,
   ...defaultFigure
 });"
 `;
 
 exports[`styled inline babel 6 styled. objects with a multiple spread properties and other keys 1`] = `
-"
-const defaultText = { fontSize: 20 };
-const Figure = /*#__PURE__*/styled('figure', {
-  target: 'e8nbyc50'
-})({
-  ...defaultText,
+"const defaultText = {
+  fontSize: 20
+};
+const Figure =
+/*#__PURE__*/
+styled(\\"figure\\", {
+  target: \\"e1u6ll0g0\\"
+})({ ...defaultText,
   fontSize: '20px',
   ...defaultFigure,
   ...defaultText2
@@ -1009,19 +1107,24 @@ const Figure = /*#__PURE__*/styled('figure', {
 `;
 
 exports[`styled inline babel 6 styled. objects with a single spread property 1`] = `
-"
-const defaultText = { fontSize: 20 };
-const Figure = /*#__PURE__*/styled(\\"figure\\", {
-  target: \\"e8nbyc50\\"
-})({
-  ...defaultText
+"const defaultText = {
+  fontSize: 20
+};
+const Figure =
+/*#__PURE__*/
+styled(\\"figure\\", {
+  target: \\"e1u6ll0g0\\"
+})({ ...defaultText
 });"
 `;
 
 exports[`styled inline babel 6 variable import: no dynamic 1`] = `
-"import what from 'emotion'; /*#__PURE__*/what('h1', {
-  target: 'e8nbyc50'
-})('color:blue;');"
+"import what from 'emotion';
+
+/*#__PURE__*/
+what(\\"h1\\", {
+  target: \\"e1u6ll0g0\\"
+})(\\"color:blue;\\");"
 `;
 
 exports[`styled inline babel 7 autoLabel object styles 1`] = `


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Upgrade `babel-core` to use `@babel/core` v7

<!-- Why are these changes necessary? -->
**Why**:

To avoid multiple version of installer when using the plugin. This kind of disagrement:

```
Requires Babel "^7.0.0-0", but was loaded with "6.26.3". If you are sure you have a compatible version of @babel/core, it is likely that something in your build process is loading the wrong version. Inspect the stack trace of this error to look for the first entry that doesn't mention "@babel/core" or "babel-core" to see what is calling Babel.
```

This lead to a lot of change in the snapshot: mainly some formatting that change. There is also some generated that change (in the `styled.test.js.snap` file for exemple). 
It seems to be a change of hash algorithm: each hashs are changed everywhere 

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [ ] Code complete

<!-- feel free to add additional comments -->

<!-- Please add a `Tag:` prefixed label from the labels so that this PR shows up in the changelog -->
