### PR TITLE
Allow `innerRef` prop to be passed down to composite components

### DIFF
--- a/packages/styled-base/src/index.js
+++ b/packages/styled-base/src/index.js
@@ -142,11 +142,6 @@ let createStyled: CreateStyled = (tag: any, options?: StyledOptions) => {
               }
             } else {
               newProps.ref = ref
-              if (process.env.NODE_ENV !== 'production' && props.innerRef) {
-                console.error(
-                  '`innerRef` is no longer allowed, please use the `ref` prop instead'
-                )
-              }
             }
 
             const ele = React.createElement(baseTag, newProps)

--- a/packages/styled-base/src/utils.js
+++ b/packages/styled-base/src/utils.js
@@ -5,8 +5,9 @@ import isPropValid from '@emotion/is-prop-valid'
 export type Interpolations = Array<any>
 
 export const testOmitPropsOnStringTag: (key: string) => boolean = isPropValid
-export const testOmitPropsOnComponent = (key: string) =>
-  key !== 'theme' && key !== 'innerRef'
+export const testOmitPropsOnComponent = process.env.PREACT
+  ? (key: string) => key !== 'theme' && key !== 'innerRef'
+  : (key: string) => key !== 'theme'
 
 export type StyledOptions = {
   label?: string,


### PR DESCRIPTION
Ref forwarding make the innerRef just a regular prop and this should be forwarded to the wrapped component