### PR TITLE
Make is-prop-valid check case sensitive

### DIFF
--- a/packages/is-prop-valid/src/props.js
+++ b/packages/is-prop-valid/src/props.js
@@ -465,4 +465,4 @@ const props = {
 // eslint-disable-next-line import/no-commonjs
 module.exports = `/^((${Object.keys(props).join(
   '|'
-)})|(on[A-Z].*)|((data|aria|x)-.*))$/i`
+)})|(on[A-Z].*)|((data|aria|x)-.*))$/`

--- a/packages/is-prop-valid/src/props.js
+++ b/packages/is-prop-valid/src/props.js
@@ -31,7 +31,7 @@ const props = {
   async: true,
   autoComplete: true,
   // autoFocus is polyfilled/normalized by AutoFocusUtils
-  autoFocus: true,
+  // autoFocus: true,
   autoPlay: true,
   capture: true,
   cellPadding: true,

--- a/packages/is-prop-valid/src/props.js
+++ b/packages/is-prop-valid/src/props.js
@@ -31,7 +31,7 @@ const props = {
   async: true,
   autoComplete: true,
   // autoFocus is polyfilled/normalized by AutoFocusUtils
-  // autoFocus: true,
+  autoFocus: true,
   autoPlay: true,
   capture: true,
   cellPadding: true,
@@ -460,7 +460,8 @@ const props = {
   zoomAndPan: true,
   // preact
   for: true,
-  class: true
+  class: true,
+  autofocus: true
 }
 // eslint-disable-next-line import/no-commonjs
 module.exports = `/^((${Object.keys(props).join(


### PR DESCRIPTION
See https://github.com/styled-components/styled-components/issues/1969#issuecomment-426943214 for the reasoning. Basically this is currently letting props such as `onboarding` or `onlineSize` through even though those are obviously not event handlers.

By making this check case sensitive it should work as expected.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete
