### PR TITLE
Readd test:typescript check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ jobs:
             - v1-dependencies-
       - run: yarn install --pure-lockfile
       - run: yarn lint:check
+      - run: yarn test:typescript
 
 workflows:
   version: 2

--- a/packages/create-emotion-server/package.json
+++ b/packages/create-emotion-server/package.json
@@ -18,7 +18,7 @@
     "through": "^2.3.8"
   },
   "devDependencies": {
-    "@types/node": "*",
+    "@types/node": "^10.11.4",
     "dtslint": "^0.3.0",
     "emotion": "^10.0.0-really-unsafe-please-do-not-use.2",
     "react-emotion": "^10.0.0-really-unsafe-please-do-not-use.2"

--- a/packages/emotion-server/package.json
+++ b/packages/emotion-server/package.json
@@ -19,7 +19,7 @@
     "emotion": "^9.1.3"
   },
   "devDependencies": {
-    "@types/react-dom": "16.0.5",
+    "@types/node": "^10.11.4",
     "babel-plugin-emotion": "^10.0.0-really-unsafe-please-do-not-use.2",
     "dtslint": "^0.3.0",
     "emotion": "^10.0.0-really-unsafe-please-do-not-use.2",

--- a/packages/emotion-server/types/tests.tsx
+++ b/packages/emotion-server/types/tests.tsx
@@ -1,11 +1,10 @@
-import * as React from 'react';
-import { renderToNodeStream, renderToString } from 'react-dom/server';
 import { extractCritical, renderStylesToNodeStream, renderStylesToString } from '../';
 
-declare const element: React.ReactElement<any>;
+declare const renderedString: string;
+declare const renderedNodeStream: NodeJS.ReadableStream;
 
-const { html, css, ids } = extractCritical(renderToString(element));
+const { html, css, ids } = extractCritical(renderedString);
 
-renderStylesToString(renderToString(element));
+renderStylesToString(renderedString);
 
-renderToNodeStream(element).pipe(renderStylesToNodeStream());
+renderedNodeStream.pipe(renderStylesToNodeStream());

--- a/yarn.lock
+++ b/yarn.lock
@@ -1624,6 +1624,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
   integrity sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw==
 
+"@types/node@^10.11.4":
+  version "10.11.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.4.tgz#e8bd933c3f78795d580ae41d86590bfc1f4f389d"
+  integrity sha512-ojnbBiKkZFYRfQpmtnnWTMw+rzGp/JiystjluW9jgN3VzRwilXddJ6aGQ9V/7iuDG06SBgn7ozW9k3zcAnYjYQ==
+
 "@types/node@^7.0.11":
   version "7.0.70"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.70.tgz#688aaeb6e6d374ed016c4dc2c46de695859d6887"
@@ -1647,14 +1652,6 @@
   integrity sha512-i2bswRNBtAxtxEThrYBTCnDtMPosywAJVBT05JsJaczhaIRMbjqmlZ5wUDde1cUl7OJs9WfM3FUkZE9NRF3pMQ==
   dependencies:
     "@types/history" "*"
-    "@types/react" "*"
-
-"@types/react-dom@16.0.5":
-  version "16.0.5"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.5.tgz#a757457662e3819409229e8f86795ff37b371f96"
-  integrity sha512-ony2hEYlGXCLWNAWWgbsHR7qVvDbeMRFc5b43+7dhj3n+zXzxz81HV9Yjpc3JD8vLCiwYoSLqFCI6bD0+0zG2Q==
-  dependencies:
-    "@types/node" "*"
     "@types/react" "*"
 
 "@types/react@*":


### PR DESCRIPTION
**What**: Fix emotion-server typing tests and readd test:typescript to CI.

**Why**: To check typescript in CI

**How**: Removing `@types/react-dom` dev dependency from `emotion-server`.

**Checklist**:
- [N/A] Documentation
- [x] Tests
- [x] Code complete
