### PR TITLE
Add warning for interpolating a class name from `css`

### DIFF
--- a/packages/emotion/test/warnings.test.js
+++ b/packages/emotion/test/warnings.test.js
@@ -55,7 +55,7 @@ it('does warn when functions are passed to css calls', () => {
   )
 })
 
-it('does warn when functions are passed to css calls', () => {
+it('warns when class names from css are interpolated', () => {
   let cls = css`
     color: green;
   `

--- a/packages/emotion/test/warnings.test.js
+++ b/packages/emotion/test/warnings.test.js
@@ -54,3 +54,20 @@ it('does warn when functions are passed to css calls', () => {
     "Functions that are interpolated in css calls will be stringified.\nIf you want to have a css call based on props, create a function that returns a css call like this\nlet dynamicStyle = (props) => css`color: ${props.color}`\nIt can be called directly with props or interpolated in a styled call like this\nlet SomeComponent = styled('div')`${dynamicStyle}`"
   )
 })
+
+it('does warn when functions are passed to css calls', () => {
+  let cls = css`
+    color: green;
+  `
+  css`
+    .${cls} {
+      color: hotpink;
+    }
+  `
+  expect(console.error.mock.calls[0]).toMatchInlineSnapshot(`
+Array [
+  "Interpolating a className from css\`\` is not recommended and will cause problems with composition.
+Interpolating a className from css\`\` will be completely unsupported in the next major version of Emotion",
+]
+`)
+})

--- a/packages/serialize/src/index.js
+++ b/packages/serialize/src/index.js
@@ -154,6 +154,16 @@ function handleInterpolation(
     // eslint-disable-next-line no-fallthrough
     default: {
       const cached = registered[interpolation]
+      if (
+        process.env.NODE_ENV !== 'production' &&
+        couldBeSelectorInterpolation &&
+        cached !== undefined
+      ) {
+        console.error(
+          'Interpolating a className from css`` is not recommended and will cause problems with composition.\n' +
+            'Interpolating a className from css`` will be completely unsupported in the next major version of Emotion'
+        )
+      }
       return cached !== undefined && !couldBeSelectorInterpolation
         ? cached
         : interpolation

--- a/packages/serialize/src/index.js
+++ b/packages/serialize/src/index.js
@@ -79,6 +79,8 @@ if (process.env.NODE_ENV !== 'production') {
   }
 }
 
+let shouldWarnAboutInterpolatingClassNameFromCss = true
+
 function handleInterpolation(
   mergedProps: void | Object,
   registered: RegisteredCache,
@@ -157,12 +159,14 @@ function handleInterpolation(
       if (
         process.env.NODE_ENV !== 'production' &&
         couldBeSelectorInterpolation &&
+        shouldWarnAboutInterpolatingClassNameFromCss &&
         cached !== undefined
       ) {
         console.error(
           'Interpolating a className from css`` is not recommended and will cause problems with composition.\n' +
             'Interpolating a className from css`` will be completely unsupported in the next major version of Emotion'
         )
+        shouldWarnAboutInterpolatingClassNameFromCss = false
       }
       return cached !== undefined && !couldBeSelectorInterpolation
         ? cached


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Add warning for interpolating a class name from css
<!-- Why are these changes necessary? -->
**Why**:

To make it clear how unsupported this is. #875 

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->

<!-- Please add a `Tag:` prefixed label from the labels so that this PR shows up in the changelog -->
