### PR TITLE
Add typings of @emotion/is-prop-valid package

### DIFF
--- a/packages/is-prop-valid/package.json
+++ b/packages/is-prop-valid/package.json
@@ -4,17 +4,25 @@
   "description": "A function to check whether a prop is valid for HTML and SVG elements",
   "main": "dist/is-prop-valid.cjs.js",
   "module": "dist/is-prop-valid.esm.js",
+  "types": "types/index.d.ts",
   "license": "MIT",
   "repository": "https://github.com/emotion-js/emotion/tree/master/packages/is-prop-valid",
+  "scripts": {
+    "test:typescript": "dtslint types"
+  },
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
     "@emotion/memoize": "^10.0.0-really-unsafe-please-do-not-use.2"
   },
+  "devDependencies": {
+    "dtslint": "^0.3.0"
+  },
   "files": [
     "src",
-    "dist"
+    "dist",
+    "types"
   ],
   "umd:main": "./dist/index.min.js",
   "browser": {

--- a/packages/is-prop-valid/types/index.d.ts
+++ b/packages/is-prop-valid/types/index.d.ts
@@ -1,0 +1,5 @@
+// Definitions by: Junyoung Clare Jang <https://github.com/Ailrun>
+// TypeScript Version: 2.1
+
+declare function isPropValid(string: string): boolean
+export default isPropValid

--- a/packages/is-prop-valid/types/tests.ts
+++ b/packages/is-prop-valid/types/tests.ts
@@ -1,0 +1,12 @@
+import isPropValid from '@emotion/is-prop-valid'
+
+isPropValid('ref')
+
+// $ExpectError
+isPropValid()
+// $ExpectError
+isPropValid(5)
+// $ExpectError
+isPropValid({})
+// $ExpectError
+isPropValid('ref', 'def')

--- a/packages/is-prop-valid/types/tsconfig.json
+++ b/packages/is-prop-valid/types/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "baseUrl": "../",
+    "forceConsistentCasingInFileNames": true,
+    "lib": [
+      "es6",
+      "dom"
+    ],
+    "module": "commonjs",
+    "noEmit": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "target": "es5",
+    "typeRoots": [
+      "../"
+    ],
+    "types": []
+  },
+  "include": [
+    "./*.ts",
+    "./*.tsx"
+  ]
+}

--- a/packages/is-prop-valid/types/tslint.json
+++ b/packages/is-prop-valid/types/tslint.json
@@ -1,0 +1,25 @@
+{
+    "extends": "dtslint/dtslint.json",
+    "rules": {
+        "array-type": [
+            true,
+            "generic"
+        ],
+        "import-spacing": false,
+        "semicolon": false,
+        "whitespace": [
+            true,
+            "check-branch",
+            "check-decl",
+            "check-operator",
+            "check-module",
+            "check-rest-spread",
+            "check-type",
+            "check-typecast",
+            "check-type-operator",
+            "check-preblock"
+        ],
+
+        "no-unnecessary-generics": false
+    }
+}


### PR DESCRIPTION
**What**: Adding typings of `@emotion/is-prop-valid` package

**Why**: Since there are users who use `@emotion/is-prop-valid` in their app like https://github.com/emotion-js/emotion/issues/900

**How**:

**Checklist**:
- [N/A] Documentation
- [x] Tests
- [x] Code complete
