### PR TITLE
Docs: Typed tagged templates literals are now supported

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -111,6 +111,12 @@ const Image1 = styled('div')({
 
 // Or with a generic type
 
+const Image1 = styled.div<ImageProps>`
+  width: ${(props: ImageProps) => props.width};
+  background: url(${(props: ImageProps) => props.src}) center center;
+  background-size: contain;
+`
+
 const Image1 = styled('div')<ImageProps>({
   backgroundSize: 'contain',
 }, props => ({
@@ -118,8 +124,6 @@ const Image1 = styled('div')<ImageProps>({
   background: `url(${props.src}) center center`,
 }));
 ```
-
-* The generic type version only works with object styles due to https://github.com/Microsoft/TypeScript/issues/11947.
 
 ### React Components
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -111,19 +111,22 @@ const Image1 = styled('div')({
 
 // Or with a generic type
 
-const Image1 = styled.div<ImageProps>`
-  width: ${(props: ImageProps) => props.width};
-  background: url(${(props: ImageProps) => props.src}) center center;
-  background-size: contain;
-`
-
-const Image1 = styled('div')<ImageProps>({
+const Image2 = styled('div')<ImageProps>({
   backgroundSize: 'contain',
 }, props => ({
   width: props.width;
   background: `url(${props.src}) center center`,
 }));
+
+// TS 2.9+ only
+const Image3 = styled.div<ImageProps>`
+  width: ${(props: ImageProps) => props.width};
+  background: url(${(props: ImageProps) => props.src}) center center;
+  background-size: contain;
+`
 ```
+
+* For Typescript <2.9, the generic type version only works with object styles due to https://github.com/Microsoft/TypeScript/issues/11947.
 
 ### React Components
 


### PR DESCRIPTION
The aforementioned limitation about tagged template literals is now removed.
See this issue: https://github.com/Microsoft/TypeScript/pull/23430

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Documentation update

<!-- Why are these changes necessary? -->
**Why**:
Typescript now supports Generic typed template literals.
see https://github.com/Microsoft/TypeScript/pull/23430

<!-- How were these changes implemented? -->
**How**:

Edited the doc to reflect the change with an example and warning for TS <2.9 users.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests
- [ ] Code complete

<!-- feel free to add additional comments -->

<!-- Please add a `Tag:` prefixed label from the labels so that this PR shows up in the changelog -->
