### PR TITLE
Make local development & babel plugin hashing compatible with Windows

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 let pkgsThatNeedBabelPluginEmotion = [
   'emotion',
   'create-emotion',
@@ -10,7 +12,7 @@ let pkgsThatNeedBabelPluginEmotion = [
 
 let needsBabelPluginEmotion = filename =>
   pkgsThatNeedBabelPluginEmotion.some(pkg =>
-    filename.includes(`packages/${pkg}/test`)
+    filename.includes(path.join('packages', pkg, 'test'))
   )
 
 module.exports = api => {

--- a/packages/babel-plugin-emotion/package.json
+++ b/packages/babel-plugin-emotion/package.json
@@ -17,6 +17,7 @@
     "babel-plugin-macros": "^2.0.0",
     "babel-plugin-syntax-jsx": "^6.18.0",
     "convert-source-map": "^1.5.0",
+    "escape-string-regexp": "^1.0.5",
     "find-root": "^1.1.0",
     "source-map": "^0.5.7"
   },

--- a/packages/babel-plugin-emotion/src/utils/get-target-class-name.js
+++ b/packages/babel-plugin-emotion/src/utils/get-target-class-name.js
@@ -3,12 +3,17 @@ import findRoot from 'find-root'
 import memoize from '@emotion/memoize'
 import nodePath from 'path'
 import hashString from '@emotion/hash'
+import escapeRegexp from 'escape-string-regexp'
 
 let hashArray = (arr: Array<string>) => hashString(arr.join(''))
 
 const unsafeRequire = require
 
 const getPackageRootPath = memoize(filename => findRoot(filename))
+
+const separator = new RegExp(escapeRegexp(nodePath.sep), 'g')
+
+const normalizePath = path => nodePath.normalize(path).replace(separator, '/')
 
 export function getTargetClassName(state: *, t: *) {
   if (state.emotionTargetClassNameCount === undefined) {
@@ -34,7 +39,7 @@ export function getTargetClassName(state: *, t: *) {
   const stuffToHash = [moduleName]
 
   if (finalPath) {
-    stuffToHash.push(nodePath.normalize(finalPath))
+    stuffToHash.push(normalizePath(finalPath))
   } else {
     stuffToHash.push(state.file.code)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8000,7 +8000,7 @@ escape-html@~1.0.3:
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.3, escape-string-regexp@^1.0.5:
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
 escodegen@^1.6.1, escodegen@^1.8.1:
@@ -18517,7 +18517,7 @@ react-devtools-core@3.3.4:
 
 react-dom@16.4.2, react-dom@16.5.0, "react-dom@^15 || ^16", react-dom@^16.2.0, react-dom@^16.3.0, react-dom@^16.3.2, react-dom@^16.4.2, react-dom@^16.5.0:
   version "16.4.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.2.tgz#4afed569689f2c561d2b8da0b819669c38a0bda4"
+  resolved "https://registry.npmjs.org/react-dom/-/react-dom-16.4.2.tgz#4afed569689f2c561d2b8da0b819669c38a0bda4"
   integrity sha512-Usl73nQqzvmJN+89r97zmeUpQDKDlh58eX6Hbs/ERdDHzeBzWy+ENk7fsGQ+5KxArV1iOFPT46/VneklK9zoWw==
   dependencies:
     fbjs "^0.8.16"
@@ -18921,7 +18921,7 @@ react-vis@^1.10.4:
 
 react@16.4.2, react@16.5.0, "react@^15 || ^16", react@^16.2.0, react@^16.3.0, react@^16.3.2, react@^16.4.2, react@^16.5.0:
   version "16.4.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.4.2.tgz#2cd90154e3a9d9dd8da2991149fdca3c260e129f"
+  resolved "https://registry.npmjs.org/react/-/react-16.4.2.tgz#2cd90154e3a9d9dd8da2991149fdca3c260e129f"
   integrity sha512-dMv7YrbxO4y2aqnvA7f/ik9ibeLSHQJTI6TrYAenPSaQ6OXfb+Oti+oJiy8WBxgRzlKatYqtCjphTgDSCEiWFg==
   dependencies:
     fbjs "^0.8.16"


### PR DESCRIPTION
Extracted from https://github.com/emotion-js/emotion/pull/886

This is more important than setting up AppVeyor to test compat automatically and we have perf concerns about that CI, so I'll try to experiment with speeding things up there in that other PR.

Let's merge this independently though :)

Resolves #881.