### PR TITLE
Allow extract critical without globals

### DIFF
--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -1,5 +1,5 @@
 ---
-title: "Server Side Rendering"
+title: 'Server Side Rendering'
 ---
 
 Server side rendering works out of the box in emotion 10 and above
@@ -63,7 +63,7 @@ const stream = renderToNodeStream(<App />).pipe(
 
 ### extractCritical
 
-This returns an object with the properties `html`, `ids` and `css`. It removes unused rules that were created with emotion(it still includes rules that were inserted with `injectGlobal`).
+This returns an object with the properties `html`, `ids` and `css`. It removes unused rules that were created with emotion. You may choose whether or not to include rules that were inserted with `injectGlobal`, by setting the second `includeGobals` parameter; by default globals **are** included.
 
 ```jsx
 import { renderToString } from 'react-dom/server'
@@ -73,6 +73,12 @@ import App from './App'
 const { html, ids, css } = extractCritical(
   renderToString(<App />)
 )
+
+const {
+  html: htmlNotInclGlobals,
+  ids: idsNotInclGlobals,
+  css: cssNotInclGlobals
+} = extractCritical(renderToString(<App />), false)
 ```
 
 #### hydrate

--- a/packages/create-emotion-server/src/extract-critical.js
+++ b/packages/create-emotion-server/src/extract-critical.js
@@ -8,23 +8,27 @@ const createExtractCritical = (cache: EmotionCache) => (html: string) => {
 
   let o = { html, ids: [], css: '' }
   let match
-  let ids = {}
+  let idsInHtml = {}
   while ((match = RGX.exec(html)) !== null) {
     // $FlowFixMe
-    if (ids[match[1]] === undefined) {
+    if (idsInHtml[match[1]] === undefined) {
       // $FlowFixMe
-      ids[match[1]] = true
+      idsInHtml[match[1]] = true
     }
   }
 
   o.ids = Object.keys(cache.inserted).filter(id => {
-    if (
-      (ids[id] !== undefined ||
-        cache.registered[`${cache.key}-${id}`] === undefined) &&
-      cache.inserted[id] !== true
-    ) {
-      o.css += cache.inserted[id]
-      return true
+    const idIsDirectlyInHtml = idsInHtml[id] !== undefined
+    const idIsGlobal = cache.registered[`${cache.key}-${id}`] === undefined
+
+    if (idIsDirectlyInHtml || idIsGlobal) {
+      // cache.inserted contains either strings or 'true'.
+      // The latter should be ignored, and the type system requires this check to be inline.
+      const valueToInsert = cache.inserted[id]
+      if (valueToInsert !== true) {
+        o.css += valueToInsert
+        return true
+      }
     }
   })
 

--- a/packages/create-emotion-server/src/extract-critical.js
+++ b/packages/create-emotion-server/src/extract-critical.js
@@ -4,11 +4,11 @@ import type { EmotionCache } from '@emotion/utils'
 const createExtractCritical = (cache: EmotionCache) => (html: string) => {
   // parse out ids from html
   // reconstruct css/rules/cache to pass
-  let RGX = new RegExp(`${cache.key}-([a-zA-Z0-9-_]+)`, 'gm')
+  const RGX = new RegExp(`${cache.key}-([a-zA-Z0-9-_]+)`, 'gm')
 
-  let o = { html, ids: [], css: '' }
+  const o = { html, ids: [], css: '' }
   let match
-  let idsInHtml = {}
+  const idsInHtml = {}
   while ((match = RGX.exec(html)) !== null) {
     // $FlowFixMe
     if (idsInHtml[match[1]] === undefined) {
@@ -18,8 +18,9 @@ const createExtractCritical = (cache: EmotionCache) => (html: string) => {
   }
 
   o.ids = Object.keys(cache.inserted).filter(id => {
-    const idIsDirectlyInHtml = idsInHtml[id] !== undefined
-    const idIsGlobal = cache.registered[`${cache.key}-${id}`] === undefined
+    const idIsDirectlyInHtml = typeof idsInHtml[id] !== 'undefined'
+    const idIsGlobal =
+      typeof cache.registered[`${cache.key}-${id}`] === 'undefined'
 
     if (idIsDirectlyInHtml || idIsGlobal) {
       // cache.inserted contains either strings or 'true'.

--- a/packages/create-emotion-server/src/extract-critical.js
+++ b/packages/create-emotion-server/src/extract-critical.js
@@ -1,7 +1,10 @@
 // @flow
 import type { EmotionCache } from '@emotion/utils'
 
-const createExtractCritical = (cache: EmotionCache) => (html: string) => {
+const createExtractCritical = (cache: EmotionCache) => (
+  html: string,
+  includeGlobals: boolean = true
+) => {
   // parse out ids from html
   // reconstruct css/rules/cache to pass
   const RGX = new RegExp(`${cache.key}-([a-zA-Z0-9-_]+)`, 'gm')
@@ -22,7 +25,7 @@ const createExtractCritical = (cache: EmotionCache) => (html: string) => {
     const idIsGlobal =
       typeof cache.registered[`${cache.key}-${id}`] === 'undefined'
 
-    if (idIsDirectlyInHtml || idIsGlobal) {
+    if (idIsDirectlyInHtml || (idIsGlobal && includeGlobals)) {
       // cache.inserted contains either strings or 'true'.
       // The latter should be ignored, and the type system requires this check to be inline.
       const valueToInsert = cache.inserted[id]

--- a/packages/create-emotion-server/types/index.d.ts
+++ b/packages/create-emotion-server/types/index.d.ts
@@ -4,7 +4,7 @@
 import { Emotion } from 'create-emotion';
 
 export interface EmotionServer {
-  extractCritical(html: string): { html: string; ids: string[]; css: string; };
+  extractCritical(html: string, includeGlobals?: boolean): { html: string; ids: string[]; css: string; };
   renderStylesToString(html: string): string;
   renderStylesToNodeStream(): NodeJS.ReadWriteStream;
 }

--- a/packages/emotion-server/test/__snapshots__/index.test.js.snap
+++ b/packages/emotion-server/test/__snapshots__/index.test.js.snap
@@ -244,6 +244,78 @@ Object {
 }
 `;
 
+exports[`extractCritical returns static css without globals if requested 1`] = `
+Object {
+  "css": ".css-14e1j2p-hoverStyles-Something_Main {
+  color: hotpink;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.css-14e1j2p-hoverStyles-Something_Main:hover {
+  color: white;
+  background-color: lightgray;
+  border-color: aqua;
+  box-shadow: -15px -15px 0 0 aqua,-30px -30px 0 0 cornflowerblue;
+}
+
+.css-1h1w8ez-Image {
+  -webkit-animation: animation-i9f7qw-bounce;
+  animation: animation-i9f7qw-bounce;
+  border-radius: 50%;
+  height: 50px;
+  width: 50px;
+  background-color: red;
+}",
+  "html": 
+<main class="css-14e1j2p-hoverStyles-Something_Main">
+  <img size="30"
+       class="css-1h1w8ez-Image"
+  >
+  <img size="100"
+       class="css-1h1w8ez-Image"
+  >
+  <img class="css-1h1w8ez-Image">
+</main>
+,
+  "ids": Array [
+    "14e1j2p-hoverStyles-Something_Main",
+    "1h1w8ez-Image",
+  ],
+}
+`;
+
+exports[`extractCritical returns static css without globals if requested 2`] = `
+Object {
+  "css": ".css-14e1j2p-hoverStyles-Something_Main {
+  color: hotpink;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.css-14e1j2p-hoverStyles-Something_Main:hover {
+  color: white;
+  background-color: lightgray;
+  border-color: aqua;
+  box-shadow: -15px -15px 0 0 aqua,-30px -30px 0 0 cornflowerblue;
+}",
+  "html": 
+<main class="css-14e1j2p-hoverStyles-Something_Main">
+  <div>
+    Hello
+  </div>
+</main>
+,
+  "ids": Array [
+    "14e1j2p-hoverStyles-Something_Main",
+  ],
+}
+`;
+
 exports[`hydration only rules that are not in the critical css are inserted 1`] = `
 Object {
   "css": "@font-face {

--- a/packages/emotion-server/test/index.test.js
+++ b/packages/emotion-server/test/index.test.js
@@ -26,7 +26,37 @@ describe('extractCritical', () => {
       )
     ).toMatchSnapshot()
   })
+
+  test('returns static css without globals if requested', () => {
+    const { Page1, Page2 } = getComponents(emotion, reactEmotion)
+    expect(
+      prettyifyCritical(
+        emotionServer.extractCritical(renderToString(<Page1 />), false)
+      )
+    ).toMatchSnapshot()
+    expect(
+      prettyifyCritical(
+        emotionServer.extractCritical(renderToString(<Page2 />), false)
+      )
+    ).toMatchSnapshot()
+  })
+
+  test('includes globals by default', () => {
+    const { Page1, Page2 } = getComponents(emotion, reactEmotion)
+    const page1String = renderToString(<Page1 />)
+    const page2String = renderToString(<Page2 />)
+    const defaultCritical = string => emotionServer.extractCritical(string)
+    const explicitIncludeCritical = string =>
+      emotionServer.extractCritical(string, true)
+    expect(defaultCritical(page1String)).toEqual(
+      explicitIncludeCritical(page1String)
+    )
+    expect(defaultCritical(page2String)).toEqual(
+      explicitIncludeCritical(page2String)
+    )
+  })
 })
+
 describe('hydration', () => {
   test('only rules that are not in the critical css are inserted', () => {
     const { Page1 } = getComponents(emotion, reactEmotion)


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Add ability to fetch only the specific emotion css rules attached to a block of HTML, excluding any global rules.

Whilst making the change, I did some boy-scouting. Trivial variable renaming for greater clarity, and fix let => const and typof foo = 'undefined' JS best practices.
(Separate commits for each step.)

<!-- Why are these changes necessary? -->
**Why**:
I have a use case where I needed that subset of the rules.
I imagine other may need it as well, and adding it has no impact on anyone who doesn't care.

<!-- How were these changes implemented? -->
**How**:
Current code very explicitly returns css if either:
a) the id is in the HTML.
b) the css is a global rule.
I added an optional boolean parameter to allow exclusion of the second case (defaulting to false, i.e. include Globals, i.e. the current behaviour).

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->

<!-- Please add a `Tag:` prefixed label from the labels so that this PR shows up in the changelog -->
I'm afraid I don't know how to: `Please add a `Tag:` prefixed label from the labels so that this PR shows up in the changelog`. Please advise.
