### PR TITLE
Refine exports from TS definitions

### DIFF
--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -2,7 +2,7 @@
 // TypeScript Version: 2.8
 
 import { EmotionCache } from '@emotion/cache'
-import css, { Interpolation } from '@emotion/css'
+import css, { Interpolation, SerializedStyles } from '@emotion/css'
 import { Keyframes } from '@emotion/serialize'
 import {
   ClassAttributes,
@@ -16,7 +16,14 @@ import {
   createElement
 } from 'react'
 
-export { Interpolation, css }
+export {
+  ArrayInterpolation,
+  ComponentSelector,
+  FunctionInterpolation,
+  ObjectInterpolation
+} from '@emotion/css'
+
+export { EmotionCache, Interpolation, SerializedStyles, css }
 
 export const ThemeContext: Context<object>
 export const CacheProvider: Provider<EmotionCache>

--- a/packages/create-emotion/types/index.d.ts
+++ b/packages/create-emotion/types/index.d.ts
@@ -4,7 +4,6 @@
 import { EmotionCache, Options } from '@emotion/cache'
 import { Interpolation } from '@emotion/serialize'
 import { StyleSheet } from '@emotion/sheet'
-import { RegisteredCache, getRegisteredStyles } from '@emotion/utils'
 
 export {
   ArrayInterpolation,
@@ -13,7 +12,7 @@ export {
   ObjectInterpolation
 } from '@emotion/serialize'
 
-export { EmotionCache, Interpolation, Options, RegisteredCache, StyleSheet }
+export { EmotionCache, Interpolation, Options, StyleSheet }
 
 export interface ArrayClassNamesArg extends Array<ClassNamesArg> {}
 export type ClassNamesArg =

--- a/packages/css/types/index.d.ts
+++ b/packages/css/types/index.d.ts
@@ -2,6 +2,13 @@
 // TypeScript Version: 2.8
 import { Interpolation, SerializedStyles } from '@emotion/serialize'
 
+export {
+  ArrayInterpolation,
+  ComponentSelector,
+  FunctionInterpolation,
+  ObjectInterpolation
+} from '@emotion/serialize'
+
 export { Interpolation, SerializedStyles }
 
 export default function css(

--- a/packages/emotion/types/index.d.ts
+++ b/packages/emotion/types/index.d.ts
@@ -4,15 +4,14 @@
 import { Emotion } from 'create-emotion'
 
 export {
+  ArrayClassNamesArg,
   ArrayInterpolation,
   ClassNamesArg,
   ComponentSelector,
-  Emotion,
   EmotionCache,
   FunctionInterpolation,
   Interpolation,
   ObjectInterpolation,
-  RegisteredCache,
   StyleSheet
 } from 'create-emotion'
 

--- a/packages/styled-base/types/index.d.ts
+++ b/packages/styled-base/types/index.d.ts
@@ -17,7 +17,13 @@ import * as React from 'react'
 
 import { Omit, Overwrapped, PropsOf } from './helper'
 
-export { Interpolation }
+export {
+  ArrayInterpolation,
+  FunctionInterpolation,
+  ObjectInterpolation
+} from '@emotion/serialize'
+
+export { ComponentSelector, Interpolation }
 
 type JSXInEl = JSX.IntrinsicElements
 

--- a/packages/styled/types/index.d.ts
+++ b/packages/styled/types/index.d.ts
@@ -7,10 +7,14 @@ import {
 } from '@emotion/styled-base'
 
 export {
+  ArrayInterpolation,
+  ComponentSelector,
   CreateStyledComponentBase,
   CreateStyledComponentExtrinsic,
   CreateStyledComponentIntrinsic,
+  FunctionInterpolation,
   Interpolation,
+  ObjectInterpolation,
   StyledComponent,
   StyledOptions,
   WithTheme


### PR DESCRIPTION
**What**:
1. Some result types are not exported.
2. Some types are exported in one package and not exported in other packages.

**Why**:
Without result type, it's hard for users to make HOC/utility function.

**How**:
Export types more uniformly.

**Checklist**:
- [N/A] Documentation
- [x] Tests
- [x] Code complete
