### PR TITLE
Fix typo in class-names.md

### DIFF
--- a/docs/class-names.md
+++ b/docs/class-names.md
@@ -2,7 +2,7 @@
 title: 'Class Names'
 ---
 
-It can be useful to create to create a className that is not passed to a component, for example if a component accepts a `wrapperClassName` prop or similar. To do this, Emotion exposes a render prop component which you can pass a function which accepts `css` and `cx`. If you have used versions of Emotion prior to Emotion 10 or used vanilla Emotion, the `css` and `cx` functions work exactly like they do in versions.
+It can be useful to create a className that is not passed to a component, for example if a component accepts a `wrapperClassName` prop or similar. To do this, Emotion exposes a render prop component which you can pass a function which accepts `css` and `cx`. If you have used versions of Emotion prior to Emotion 10 or used vanilla Emotion, the `css` and `cx` functions work exactly like they do in versions.
 
 ```jsx
 // @live


### PR DESCRIPTION
"to create" was written twice