### PR TITLE
Enable labels by default in vanilla macro

### DIFF
--- a/packages/babel-plugin-emotion/__tests__/__snapshots__/vanilla-emotion.js.snap
+++ b/packages/babel-plugin-emotion/__tests__/__snapshots__/vanilla-emotion.js.snap
@@ -69,7 +69,7 @@ let someCls =
 /*#__PURE__*/
 _css({
   color: window.whatever
-}, process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNzcy1vYmplY3QuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBRWMiLCJmaWxlIjoiY3NzLW9iamVjdC5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmxldCBzb21lQ2xzID0gY3NzKHtcbiAgY29sb3I6IHdpbmRvdy53aGF0ZXZlclxufSlcbiJdfQ== */\\");"
+}, \\"label:someCls;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNzcy1vYmplY3QuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBRWMiLCJmaWxlIjoiY3NzLW9iamVjdC5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmxldCBzb21lQ2xzID0gY3NzKHtcbiAgY29sb3I6IHdpbmRvdy53aGF0ZXZlclxufSlcbiJdfQ== */\\"));"
 `;
 
 exports[`vanilla emotion does-not-minify-inside-content-property 1`] = `
@@ -91,11 +91,11 @@ import { css as _css } from \\"emotion\\";
 const cls1 =
 /*#__PURE__*/
 _css(process.env.NODE_ENV === \\"production\\" ? {
-  name: \\"hh44ja\\",
-  styles: \\"content:'  {  }  ';\\"
+  name: \\"19tqhve-cls1\\",
+  styles: \\"content:'  {  }  ';label:cls1;\\"
 } : {
-  name: \\"hh44ja\\",
-  styles: \\"content:'  {  }  ';\\",
+  name: \\"19tqhve-cls1\\",
+  styles: \\"content:'  {  }  ';label:cls1;\\",
   map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImRvZXMtbm90LW1pbmlmeS1pbnNpZGUtY29udGVudC1wcm9wZXJ0eS5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFFZ0IiLCJmaWxlIjoiZG9lcy1ub3QtbWluaWZ5LWluc2lkZS1jb250ZW50LXByb3BlcnR5LmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbidcblxuY29uc3QgY2xzMSA9IGNzc2BcbiAgY29udGVudDogJyAgeyAgfSAgJztcbmBcbi8vIHByZXR0aWVyLWlnbm9yZVxuY29uc3QgY2xzMiA9IGNzc2BcbiAgY29udGVudDogXCIgIHsgIH0gIFwiO1xuYFxuIl19 */\\"
 }); // prettier-ignore
 
@@ -103,11 +103,11 @@ _css(process.env.NODE_ENV === \\"production\\" ? {
 const cls2 =
 /*#__PURE__*/
 _css(process.env.NODE_ENV === \\"production\\" ? {
-  name: \\"1rr8elb\\",
-  styles: \\"content:\\\\\\"  {  }  \\\\\\";\\"
+  name: \\"16r822g-cls2\\",
+  styles: \\"content:\\\\\\"  {  }  \\\\\\";label:cls2;\\"
 } : {
-  name: \\"1rr8elb\\",
-  styles: \\"content:\\\\\\"  {  }  \\\\\\";\\",
+  name: \\"16r822g-cls2\\",
+  styles: \\"content:\\\\\\"  {  }  \\\\\\";label:cls2;\\",
   map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImRvZXMtbm90LW1pbmlmeS1pbnNpZGUtY29udGVudC1wcm9wZXJ0eS5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFNZ0IiLCJmaWxlIjoiZG9lcy1ub3QtbWluaWZ5LWluc2lkZS1jb250ZW50LXByb3BlcnR5LmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbidcblxuY29uc3QgY2xzMSA9IGNzc2BcbiAgY29udGVudDogJyAgeyAgfSAgJztcbmBcbi8vIHByZXR0aWVyLWlnbm9yZVxuY29uc3QgY2xzMiA9IGNzc2BcbiAgY29udGVudDogXCIgIHsgIH0gIFwiO1xuYFxuIl19 */\\"
 });"
 `;
@@ -172,33 +172,33 @@ function test() {
   _css(\\"font-size:20px;@media (min-width:420px){color:blue;\\",
   /*#__PURE__*/
   _css(process.env.NODE_ENV === \\"production\\" ? {
-    name: \\"15xbpqr\\",
-    styles: \\"width:96px;height:96px;\\"
+    name: \\"1ylk12k-cls1\\",
+    styles: \\"width:96px;height:96px;label:cls1;\\"
   } : {
-    name: \\"15xbpqr\\",
-    styles: \\"width:96px;height:96px;\\",
+    name: \\"1ylk12k-cls1\\",
+    styles: \\"width:96px;height:96px;label:cls1;\\",
     map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQU9XIiwiZmlsZSI6ImhvaXN0aW5nLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbidcblxuZnVuY3Rpb24gdGVzdCgpIHtcbiAgY29uc3QgY2xzMSA9IGNzc2BcbiAgICBmb250LXNpemU6IDIwcHg7XG4gICAgQG1lZGlhIChtaW4td2lkdGg6IDQyMHB4KSB7XG4gICAgICBjb2xvcjogYmx1ZTtcbiAgICAgICR7Y3NzYFxuICAgICAgICB3aWR0aDogOTZweDtcbiAgICAgICAgaGVpZ2h0OiA5NnB4O1xuICAgICAgYH07XG4gICAgICBsaW5lLWhlaWdodDogMjZweDtcbiAgICB9XG4gICAgYmFja2dyb3VuZDogZ3JlZW47XG4gICAgJHt7IGJhY2tncm91bmRDb2xvcjogJ2hvdHBpbmsnIH19O1xuICBgXG5cbiAgY29uc3QgY2xzMiA9IGNzc2BcbiAgICAke3sgY29sb3I6ICdibHVlJyB9fTtcbiAgYFxuXG4gIGNvbnN0IGNsczMgPSBjc3NgXG4gICAgZGlzcGxheTogZmxleDtcbiAgICAmOmhvdmVyIHtcbiAgICAgIGNvbG9yOiBob3RwaW5rO1xuICAgIH1cbiAgYFxuICBsZXQgb3V0ZXJWYXIgPSAnc29tZXRoaW5nJ1xuICBmdW5jdGlvbiBpbm5lcigpIHtcbiAgICBjb25zdCBzdHlsZXMgPSB7IGNvbG9yOiAnZGFya29yY2hpZCcgfVxuICAgIGNvbnN0IGNvbG9yID0gJ2FxdWFtYXJpbmUnXG5cbiAgICBjb25zdCBjbHM0ID0gY3NzYFxuICAgICAgJHtjbHMzfTtcbiAgICAgICR7Y2xzMX07XG4gICAgICAke3sgY29sb3I6ICdkYXJrb3JjaGlkJyB9fTtcbiAgICAgICR7eyBjb2xvciB9fTtcbiAgICAgICR7Y3NzYFxuICAgICAgICBoZWlnaHQ6IDQyMHB4O1xuICAgICAgICB3aWR0aDogJHtzdHlsZXN9O1xuICAgICAgYH07XG4gICAgYFxuICAgIGxldCBzb21lQ2xzID0gY3NzYFxuICAgICAgY29sb3I6ICR7b3V0ZXJWYXJ9O1xuICAgIGBcbiAgfVxufVxuIl19 */\\"
-  }), \\";line-height:26px;}background:green;background-color:hotpink;;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUdrQiIsImZpbGUiOiJob2lzdGluZy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmZ1bmN0aW9uIHRlc3QoKSB7XG4gIGNvbnN0IGNsczEgPSBjc3NgXG4gICAgZm9udC1zaXplOiAyMHB4O1xuICAgIEBtZWRpYSAobWluLXdpZHRoOiA0MjBweCkge1xuICAgICAgY29sb3I6IGJsdWU7XG4gICAgICAke2Nzc2BcbiAgICAgICAgd2lkdGg6IDk2cHg7XG4gICAgICAgIGhlaWdodDogOTZweDtcbiAgICAgIGB9O1xuICAgICAgbGluZS1oZWlnaHQ6IDI2cHg7XG4gICAgfVxuICAgIGJhY2tncm91bmQ6IGdyZWVuO1xuICAgICR7eyBiYWNrZ3JvdW5kQ29sb3I6ICdob3RwaW5rJyB9fTtcbiAgYFxuXG4gIGNvbnN0IGNsczIgPSBjc3NgXG4gICAgJHt7IGNvbG9yOiAnYmx1ZScgfX07XG4gIGBcblxuICBjb25zdCBjbHMzID0gY3NzYFxuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgJjpob3ZlciB7XG4gICAgICBjb2xvcjogaG90cGluaztcbiAgICB9XG4gIGBcbiAgbGV0IG91dGVyVmFyID0gJ3NvbWV0aGluZydcbiAgZnVuY3Rpb24gaW5uZXIoKSB7XG4gICAgY29uc3Qgc3R5bGVzID0geyBjb2xvcjogJ2RhcmtvcmNoaWQnIH1cbiAgICBjb25zdCBjb2xvciA9ICdhcXVhbWFyaW5lJ1xuXG4gICAgY29uc3QgY2xzNCA9IGNzc2BcbiAgICAgICR7Y2xzM307XG4gICAgICAke2NsczF9O1xuICAgICAgJHt7IGNvbG9yOiAnZGFya29yY2hpZCcgfX07XG4gICAgICAke3sgY29sb3IgfX07XG4gICAgICAke2Nzc2BcbiAgICAgICAgaGVpZ2h0OiA0MjBweDtcbiAgICAgICAgd2lkdGg6ICR7c3R5bGVzfTtcbiAgICAgIGB9O1xuICAgIGBcbiAgICBsZXQgc29tZUNscyA9IGNzc2BcbiAgICAgIGNvbG9yOiAke291dGVyVmFyfTtcbiAgICBgXG4gIH1cbn1cbiJdfQ== */\\"));
+  }), \\";line-height:26px;}background:green;background-color:hotpink;;label:cls1;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUdrQiIsImZpbGUiOiJob2lzdGluZy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmZ1bmN0aW9uIHRlc3QoKSB7XG4gIGNvbnN0IGNsczEgPSBjc3NgXG4gICAgZm9udC1zaXplOiAyMHB4O1xuICAgIEBtZWRpYSAobWluLXdpZHRoOiA0MjBweCkge1xuICAgICAgY29sb3I6IGJsdWU7XG4gICAgICAke2Nzc2BcbiAgICAgICAgd2lkdGg6IDk2cHg7XG4gICAgICAgIGhlaWdodDogOTZweDtcbiAgICAgIGB9O1xuICAgICAgbGluZS1oZWlnaHQ6IDI2cHg7XG4gICAgfVxuICAgIGJhY2tncm91bmQ6IGdyZWVuO1xuICAgICR7eyBiYWNrZ3JvdW5kQ29sb3I6ICdob3RwaW5rJyB9fTtcbiAgYFxuXG4gIGNvbnN0IGNsczIgPSBjc3NgXG4gICAgJHt7IGNvbG9yOiAnYmx1ZScgfX07XG4gIGBcblxuICBjb25zdCBjbHMzID0gY3NzYFxuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgJjpob3ZlciB7XG4gICAgICBjb2xvcjogaG90cGluaztcbiAgICB9XG4gIGBcbiAgbGV0IG91dGVyVmFyID0gJ3NvbWV0aGluZydcbiAgZnVuY3Rpb24gaW5uZXIoKSB7XG4gICAgY29uc3Qgc3R5bGVzID0geyBjb2xvcjogJ2RhcmtvcmNoaWQnIH1cbiAgICBjb25zdCBjb2xvciA9ICdhcXVhbWFyaW5lJ1xuXG4gICAgY29uc3QgY2xzNCA9IGNzc2BcbiAgICAgICR7Y2xzM307XG4gICAgICAke2NsczF9O1xuICAgICAgJHt7IGNvbG9yOiAnZGFya29yY2hpZCcgfX07XG4gICAgICAke3sgY29sb3IgfX07XG4gICAgICAke2Nzc2BcbiAgICAgICAgaGVpZ2h0OiA0MjBweDtcbiAgICAgICAgd2lkdGg6ICR7c3R5bGVzfTtcbiAgICAgIGB9O1xuICAgIGBcbiAgICBsZXQgc29tZUNscyA9IGNzc2BcbiAgICAgIGNvbG9yOiAke291dGVyVmFyfTtcbiAgICBgXG4gIH1cbn1cbiJdfQ== */\\"));
 
   const cls2 =
   /*#__PURE__*/
   _css(process.env.NODE_ENV === \\"production\\" ? {
-    name: \\"1rdr7a4\\",
-    styles: \\"color:blue;;\\"
+    name: \\"ca17a1-cls2\\",
+    styles: \\"color:blue;;label:cls2;\\"
   } : {
-    name: \\"1rdr7a4\\",
-    styles: \\"color:blue;;\\",
+    name: \\"ca17a1-cls2\\",
+    styles: \\"color:blue;;label:cls2;\\",
     map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQWlCa0IiLCJmaWxlIjoiaG9pc3RpbmcuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uJ1xuXG5mdW5jdGlvbiB0ZXN0KCkge1xuICBjb25zdCBjbHMxID0gY3NzYFxuICAgIGZvbnQtc2l6ZTogMjBweDtcbiAgICBAbWVkaWEgKG1pbi13aWR0aDogNDIwcHgpIHtcbiAgICAgIGNvbG9yOiBibHVlO1xuICAgICAgJHtjc3NgXG4gICAgICAgIHdpZHRoOiA5NnB4O1xuICAgICAgICBoZWlnaHQ6IDk2cHg7XG4gICAgICBgfTtcbiAgICAgIGxpbmUtaGVpZ2h0OiAyNnB4O1xuICAgIH1cbiAgICBiYWNrZ3JvdW5kOiBncmVlbjtcbiAgICAke3sgYmFja2dyb3VuZENvbG9yOiAnaG90cGluaycgfX07XG4gIGBcblxuICBjb25zdCBjbHMyID0gY3NzYFxuICAgICR7eyBjb2xvcjogJ2JsdWUnIH19O1xuICBgXG5cbiAgY29uc3QgY2xzMyA9IGNzc2BcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgICY6aG92ZXIge1xuICAgICAgY29sb3I6IGhvdHBpbms7XG4gICAgfVxuICBgXG4gIGxldCBvdXRlclZhciA9ICdzb21ldGhpbmcnXG4gIGZ1bmN0aW9uIGlubmVyKCkge1xuICAgIGNvbnN0IHN0eWxlcyA9IHsgY29sb3I6ICdkYXJrb3JjaGlkJyB9XG4gICAgY29uc3QgY29sb3IgPSAnYXF1YW1hcmluZSdcblxuICAgIGNvbnN0IGNsczQgPSBjc3NgXG4gICAgICAke2NsczN9O1xuICAgICAgJHtjbHMxfTtcbiAgICAgICR7eyBjb2xvcjogJ2RhcmtvcmNoaWQnIH19O1xuICAgICAgJHt7IGNvbG9yIH19O1xuICAgICAgJHtjc3NgXG4gICAgICAgIGhlaWdodDogNDIwcHg7XG4gICAgICAgIHdpZHRoOiAke3N0eWxlc307XG4gICAgICBgfTtcbiAgICBgXG4gICAgbGV0IHNvbWVDbHMgPSBjc3NgXG4gICAgICBjb2xvcjogJHtvdXRlclZhcn07XG4gICAgYFxuICB9XG59XG4iXX0= */\\"
   });
 
   const cls3 =
   /*#__PURE__*/
   _css(process.env.NODE_ENV === \\"production\\" ? {
-    name: \\"a21n9o\\",
-    styles: \\"display:flex;&:hover{color:hotpink;}\\"
+    name: \\"zyzn0f-cls3\\",
+    styles: \\"display:flex;&:hover{color:hotpink;}label:cls3;\\"
   } : {
-    name: \\"a21n9o\\",
-    styles: \\"display:flex;&:hover{color:hotpink;}\\",
+    name: \\"zyzn0f-cls3\\",
+    styles: \\"display:flex;&:hover{color:hotpink;}label:cls3;\\",
     map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQXFCa0IiLCJmaWxlIjoiaG9pc3RpbmcuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uJ1xuXG5mdW5jdGlvbiB0ZXN0KCkge1xuICBjb25zdCBjbHMxID0gY3NzYFxuICAgIGZvbnQtc2l6ZTogMjBweDtcbiAgICBAbWVkaWEgKG1pbi13aWR0aDogNDIwcHgpIHtcbiAgICAgIGNvbG9yOiBibHVlO1xuICAgICAgJHtjc3NgXG4gICAgICAgIHdpZHRoOiA5NnB4O1xuICAgICAgICBoZWlnaHQ6IDk2cHg7XG4gICAgICBgfTtcbiAgICAgIGxpbmUtaGVpZ2h0OiAyNnB4O1xuICAgIH1cbiAgICBiYWNrZ3JvdW5kOiBncmVlbjtcbiAgICAke3sgYmFja2dyb3VuZENvbG9yOiAnaG90cGluaycgfX07XG4gIGBcblxuICBjb25zdCBjbHMyID0gY3NzYFxuICAgICR7eyBjb2xvcjogJ2JsdWUnIH19O1xuICBgXG5cbiAgY29uc3QgY2xzMyA9IGNzc2BcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgICY6aG92ZXIge1xuICAgICAgY29sb3I6IGhvdHBpbms7XG4gICAgfVxuICBgXG4gIGxldCBvdXRlclZhciA9ICdzb21ldGhpbmcnXG4gIGZ1bmN0aW9uIGlubmVyKCkge1xuICAgIGNvbnN0IHN0eWxlcyA9IHsgY29sb3I6ICdkYXJrb3JjaGlkJyB9XG4gICAgY29uc3QgY29sb3IgPSAnYXF1YW1hcmluZSdcblxuICAgIGNvbnN0IGNsczQgPSBjc3NgXG4gICAgICAke2NsczN9O1xuICAgICAgJHtjbHMxfTtcbiAgICAgICR7eyBjb2xvcjogJ2RhcmtvcmNoaWQnIH19O1xuICAgICAgJHt7IGNvbG9yIH19O1xuICAgICAgJHtjc3NgXG4gICAgICAgIGhlaWdodDogNDIwcHg7XG4gICAgICAgIHdpZHRoOiAke3N0eWxlc307XG4gICAgICBgfTtcbiAgICBgXG4gICAgbGV0IHNvbWVDbHMgPSBjc3NgXG4gICAgICBjb2xvcjogJHtvdXRlclZhcn07XG4gICAgYFxuICB9XG59XG4iXX0= */\\"
   });
 
@@ -216,11 +216,11 @@ function test() {
       color
     }, \\";\\",
     /*#__PURE__*/
-    _css(\\"height:420px;width:\\", styles, \\";\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQXFDVyIsImZpbGUiOiJob2lzdGluZy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmZ1bmN0aW9uIHRlc3QoKSB7XG4gIGNvbnN0IGNsczEgPSBjc3NgXG4gICAgZm9udC1zaXplOiAyMHB4O1xuICAgIEBtZWRpYSAobWluLXdpZHRoOiA0MjBweCkge1xuICAgICAgY29sb3I6IGJsdWU7XG4gICAgICAke2Nzc2BcbiAgICAgICAgd2lkdGg6IDk2cHg7XG4gICAgICAgIGhlaWdodDogOTZweDtcbiAgICAgIGB9O1xuICAgICAgbGluZS1oZWlnaHQ6IDI2cHg7XG4gICAgfVxuICAgIGJhY2tncm91bmQ6IGdyZWVuO1xuICAgICR7eyBiYWNrZ3JvdW5kQ29sb3I6ICdob3RwaW5rJyB9fTtcbiAgYFxuXG4gIGNvbnN0IGNsczIgPSBjc3NgXG4gICAgJHt7IGNvbG9yOiAnYmx1ZScgfX07XG4gIGBcblxuICBjb25zdCBjbHMzID0gY3NzYFxuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgJjpob3ZlciB7XG4gICAgICBjb2xvcjogaG90cGluaztcbiAgICB9XG4gIGBcbiAgbGV0IG91dGVyVmFyID0gJ3NvbWV0aGluZydcbiAgZnVuY3Rpb24gaW5uZXIoKSB7XG4gICAgY29uc3Qgc3R5bGVzID0geyBjb2xvcjogJ2RhcmtvcmNoaWQnIH1cbiAgICBjb25zdCBjb2xvciA9ICdhcXVhbWFyaW5lJ1xuXG4gICAgY29uc3QgY2xzNCA9IGNzc2BcbiAgICAgICR7Y2xzM307XG4gICAgICAke2NsczF9O1xuICAgICAgJHt7IGNvbG9yOiAnZGFya29yY2hpZCcgfX07XG4gICAgICAke3sgY29sb3IgfX07XG4gICAgICAke2Nzc2BcbiAgICAgICAgaGVpZ2h0OiA0MjBweDtcbiAgICAgICAgd2lkdGg6ICR7c3R5bGVzfTtcbiAgICAgIGB9O1xuICAgIGBcbiAgICBsZXQgc29tZUNscyA9IGNzc2BcbiAgICAgIGNvbG9yOiAke291dGVyVmFyfTtcbiAgICBgXG4gIH1cbn1cbiJdfQ== */\\")), \\";\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQWdDb0IiLCJmaWxlIjoiaG9pc3RpbmcuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uJ1xuXG5mdW5jdGlvbiB0ZXN0KCkge1xuICBjb25zdCBjbHMxID0gY3NzYFxuICAgIGZvbnQtc2l6ZTogMjBweDtcbiAgICBAbWVkaWEgKG1pbi13aWR0aDogNDIwcHgpIHtcbiAgICAgIGNvbG9yOiBibHVlO1xuICAgICAgJHtjc3NgXG4gICAgICAgIHdpZHRoOiA5NnB4O1xuICAgICAgICBoZWlnaHQ6IDk2cHg7XG4gICAgICBgfTtcbiAgICAgIGxpbmUtaGVpZ2h0OiAyNnB4O1xuICAgIH1cbiAgICBiYWNrZ3JvdW5kOiBncmVlbjtcbiAgICAke3sgYmFja2dyb3VuZENvbG9yOiAnaG90cGluaycgfX07XG4gIGBcblxuICBjb25zdCBjbHMyID0gY3NzYFxuICAgICR7eyBjb2xvcjogJ2JsdWUnIH19O1xuICBgXG5cbiAgY29uc3QgY2xzMyA9IGNzc2BcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgICY6aG92ZXIge1xuICAgICAgY29sb3I6IGhvdHBpbms7XG4gICAgfVxuICBgXG4gIGxldCBvdXRlclZhciA9ICdzb21ldGhpbmcnXG4gIGZ1bmN0aW9uIGlubmVyKCkge1xuICAgIGNvbnN0IHN0eWxlcyA9IHsgY29sb3I6ICdkYXJrb3JjaGlkJyB9XG4gICAgY29uc3QgY29sb3IgPSAnYXF1YW1hcmluZSdcblxuICAgIGNvbnN0IGNsczQgPSBjc3NgXG4gICAgICAke2NsczN9O1xuICAgICAgJHtjbHMxfTtcbiAgICAgICR7eyBjb2xvcjogJ2RhcmtvcmNoaWQnIH19O1xuICAgICAgJHt7IGNvbG9yIH19O1xuICAgICAgJHtjc3NgXG4gICAgICAgIGhlaWdodDogNDIwcHg7XG4gICAgICAgIHdpZHRoOiAke3N0eWxlc307XG4gICAgICBgfTtcbiAgICBgXG4gICAgbGV0IHNvbWVDbHMgPSBjc3NgXG4gICAgICBjb2xvcjogJHtvdXRlclZhcn07XG4gICAgYFxuICB9XG59XG4iXX0= */\\"));
+    _css(\\"height:420px;width:\\", styles, \\";label:cls4;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQXFDVyIsImZpbGUiOiJob2lzdGluZy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmZ1bmN0aW9uIHRlc3QoKSB7XG4gIGNvbnN0IGNsczEgPSBjc3NgXG4gICAgZm9udC1zaXplOiAyMHB4O1xuICAgIEBtZWRpYSAobWluLXdpZHRoOiA0MjBweCkge1xuICAgICAgY29sb3I6IGJsdWU7XG4gICAgICAke2Nzc2BcbiAgICAgICAgd2lkdGg6IDk2cHg7XG4gICAgICAgIGhlaWdodDogOTZweDtcbiAgICAgIGB9O1xuICAgICAgbGluZS1oZWlnaHQ6IDI2cHg7XG4gICAgfVxuICAgIGJhY2tncm91bmQ6IGdyZWVuO1xuICAgICR7eyBiYWNrZ3JvdW5kQ29sb3I6ICdob3RwaW5rJyB9fTtcbiAgYFxuXG4gIGNvbnN0IGNsczIgPSBjc3NgXG4gICAgJHt7IGNvbG9yOiAnYmx1ZScgfX07XG4gIGBcblxuICBjb25zdCBjbHMzID0gY3NzYFxuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgJjpob3ZlciB7XG4gICAgICBjb2xvcjogaG90cGluaztcbiAgICB9XG4gIGBcbiAgbGV0IG91dGVyVmFyID0gJ3NvbWV0aGluZydcbiAgZnVuY3Rpb24gaW5uZXIoKSB7XG4gICAgY29uc3Qgc3R5bGVzID0geyBjb2xvcjogJ2RhcmtvcmNoaWQnIH1cbiAgICBjb25zdCBjb2xvciA9ICdhcXVhbWFyaW5lJ1xuXG4gICAgY29uc3QgY2xzNCA9IGNzc2BcbiAgICAgICR7Y2xzM307XG4gICAgICAke2NsczF9O1xuICAgICAgJHt7IGNvbG9yOiAnZGFya29yY2hpZCcgfX07XG4gICAgICAke3sgY29sb3IgfX07XG4gICAgICAke2Nzc2BcbiAgICAgICAgaGVpZ2h0OiA0MjBweDtcbiAgICAgICAgd2lkdGg6ICR7c3R5bGVzfTtcbiAgICAgIGB9O1xuICAgIGBcbiAgICBsZXQgc29tZUNscyA9IGNzc2BcbiAgICAgIGNvbG9yOiAke291dGVyVmFyfTtcbiAgICBgXG4gIH1cbn1cbiJdfQ== */\\")), \\";label:cls4;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQWdDb0IiLCJmaWxlIjoiaG9pc3RpbmcuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uJ1xuXG5mdW5jdGlvbiB0ZXN0KCkge1xuICBjb25zdCBjbHMxID0gY3NzYFxuICAgIGZvbnQtc2l6ZTogMjBweDtcbiAgICBAbWVkaWEgKG1pbi13aWR0aDogNDIwcHgpIHtcbiAgICAgIGNvbG9yOiBibHVlO1xuICAgICAgJHtjc3NgXG4gICAgICAgIHdpZHRoOiA5NnB4O1xuICAgICAgICBoZWlnaHQ6IDk2cHg7XG4gICAgICBgfTtcbiAgICAgIGxpbmUtaGVpZ2h0OiAyNnB4O1xuICAgIH1cbiAgICBiYWNrZ3JvdW5kOiBncmVlbjtcbiAgICAke3sgYmFja2dyb3VuZENvbG9yOiAnaG90cGluaycgfX07XG4gIGBcblxuICBjb25zdCBjbHMyID0gY3NzYFxuICAgICR7eyBjb2xvcjogJ2JsdWUnIH19O1xuICBgXG5cbiAgY29uc3QgY2xzMyA9IGNzc2BcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgICY6aG92ZXIge1xuICAgICAgY29sb3I6IGhvdHBpbms7XG4gICAgfVxuICBgXG4gIGxldCBvdXRlclZhciA9ICdzb21ldGhpbmcnXG4gIGZ1bmN0aW9uIGlubmVyKCkge1xuICAgIGNvbnN0IHN0eWxlcyA9IHsgY29sb3I6ICdkYXJrb3JjaGlkJyB9XG4gICAgY29uc3QgY29sb3IgPSAnYXF1YW1hcmluZSdcblxuICAgIGNvbnN0IGNsczQgPSBjc3NgXG4gICAgICAke2NsczN9O1xuICAgICAgJHtjbHMxfTtcbiAgICAgICR7eyBjb2xvcjogJ2RhcmtvcmNoaWQnIH19O1xuICAgICAgJHt7IGNvbG9yIH19O1xuICAgICAgJHtjc3NgXG4gICAgICAgIGhlaWdodDogNDIwcHg7XG4gICAgICAgIHdpZHRoOiAke3N0eWxlc307XG4gICAgICBgfTtcbiAgICBgXG4gICAgbGV0IHNvbWVDbHMgPSBjc3NgXG4gICAgICBjb2xvcjogJHtvdXRlclZhcn07XG4gICAgYFxuICB9XG59XG4iXX0= */\\"));
 
     let someCls =
     /*#__PURE__*/
-    _css(\\"color:\\", outerVar, \\";\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQTBDcUIiLCJmaWxlIjoiaG9pc3RpbmcuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uJ1xuXG5mdW5jdGlvbiB0ZXN0KCkge1xuICBjb25zdCBjbHMxID0gY3NzYFxuICAgIGZvbnQtc2l6ZTogMjBweDtcbiAgICBAbWVkaWEgKG1pbi13aWR0aDogNDIwcHgpIHtcbiAgICAgIGNvbG9yOiBibHVlO1xuICAgICAgJHtjc3NgXG4gICAgICAgIHdpZHRoOiA5NnB4O1xuICAgICAgICBoZWlnaHQ6IDk2cHg7XG4gICAgICBgfTtcbiAgICAgIGxpbmUtaGVpZ2h0OiAyNnB4O1xuICAgIH1cbiAgICBiYWNrZ3JvdW5kOiBncmVlbjtcbiAgICAke3sgYmFja2dyb3VuZENvbG9yOiAnaG90cGluaycgfX07XG4gIGBcblxuICBjb25zdCBjbHMyID0gY3NzYFxuICAgICR7eyBjb2xvcjogJ2JsdWUnIH19O1xuICBgXG5cbiAgY29uc3QgY2xzMyA9IGNzc2BcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgICY6aG92ZXIge1xuICAgICAgY29sb3I6IGhvdHBpbms7XG4gICAgfVxuICBgXG4gIGxldCBvdXRlclZhciA9ICdzb21ldGhpbmcnXG4gIGZ1bmN0aW9uIGlubmVyKCkge1xuICAgIGNvbnN0IHN0eWxlcyA9IHsgY29sb3I6ICdkYXJrb3JjaGlkJyB9XG4gICAgY29uc3QgY29sb3IgPSAnYXF1YW1hcmluZSdcblxuICAgIGNvbnN0IGNsczQgPSBjc3NgXG4gICAgICAke2NsczN9O1xuICAgICAgJHtjbHMxfTtcbiAgICAgICR7eyBjb2xvcjogJ2RhcmtvcmNoaWQnIH19O1xuICAgICAgJHt7IGNvbG9yIH19O1xuICAgICAgJHtjc3NgXG4gICAgICAgIGhlaWdodDogNDIwcHg7XG4gICAgICAgIHdpZHRoOiAke3N0eWxlc307XG4gICAgICBgfTtcbiAgICBgXG4gICAgbGV0IHNvbWVDbHMgPSBjc3NgXG4gICAgICBjb2xvcjogJHtvdXRlclZhcn07XG4gICAgYFxuICB9XG59XG4iXX0= */\\"));
+    _css(\\"color:\\", outerVar, \\";label:someCls;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQTBDcUIiLCJmaWxlIjoiaG9pc3RpbmcuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uJ1xuXG5mdW5jdGlvbiB0ZXN0KCkge1xuICBjb25zdCBjbHMxID0gY3NzYFxuICAgIGZvbnQtc2l6ZTogMjBweDtcbiAgICBAbWVkaWEgKG1pbi13aWR0aDogNDIwcHgpIHtcbiAgICAgIGNvbG9yOiBibHVlO1xuICAgICAgJHtjc3NgXG4gICAgICAgIHdpZHRoOiA5NnB4O1xuICAgICAgICBoZWlnaHQ6IDk2cHg7XG4gICAgICBgfTtcbiAgICAgIGxpbmUtaGVpZ2h0OiAyNnB4O1xuICAgIH1cbiAgICBiYWNrZ3JvdW5kOiBncmVlbjtcbiAgICAke3sgYmFja2dyb3VuZENvbG9yOiAnaG90cGluaycgfX07XG4gIGBcblxuICBjb25zdCBjbHMyID0gY3NzYFxuICAgICR7eyBjb2xvcjogJ2JsdWUnIH19O1xuICBgXG5cbiAgY29uc3QgY2xzMyA9IGNzc2BcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgICY6aG92ZXIge1xuICAgICAgY29sb3I6IGhvdHBpbms7XG4gICAgfVxuICBgXG4gIGxldCBvdXRlclZhciA9ICdzb21ldGhpbmcnXG4gIGZ1bmN0aW9uIGlubmVyKCkge1xuICAgIGNvbnN0IHN0eWxlcyA9IHsgY29sb3I6ICdkYXJrb3JjaGlkJyB9XG4gICAgY29uc3QgY29sb3IgPSAnYXF1YW1hcmluZSdcblxuICAgIGNvbnN0IGNsczQgPSBjc3NgXG4gICAgICAke2NsczN9O1xuICAgICAgJHtjbHMxfTtcbiAgICAgICR7eyBjb2xvcjogJ2RhcmtvcmNoaWQnIH19O1xuICAgICAgJHt7IGNvbG9yIH19O1xuICAgICAgJHtjc3NgXG4gICAgICAgIGhlaWdodDogNDIwcHg7XG4gICAgICAgIHdpZHRoOiAke3N0eWxlc307XG4gICAgICBgfTtcbiAgICBgXG4gICAgbGV0IHNvbWVDbHMgPSBjc3NgXG4gICAgICBjb2xvcjogJHtvdXRlclZhcn07XG4gICAgYFxuICB9XG59XG4iXX0= */\\"));
   }
 }"
 `;
@@ -395,11 +395,11 @@ import { keyframes as _keyframes } from \\"emotion\\";
 const rotate360 =
 /*#__PURE__*/
 _keyframes(process.env.NODE_ENV === \\"production\\" ? {
-  name: \\"1q8eu9e\\",
-  styles: \\"from{transform:rotate(0deg);}to{transform:rotate(360deg);}\\"
+  name: \\"1lprnvq-rotate360\\",
+  styles: \\"from{transform:rotate(0deg);}to{transform:rotate(360deg);}label:rotate360;\\"
 } : {
-  name: \\"1q8eu9e\\",
-  styles: \\"from{transform:rotate(0deg);}to{transform:rotate(360deg);}\\",
+  name: \\"1lprnvq-rotate360\\",
+  styles: \\"from{transform:rotate(0deg);}to{transform:rotate(360deg);}label:rotate360;\\",
   map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImtleWZyYW1lcy1iYXNpYy5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFFMkIiLCJmaWxlIjoia2V5ZnJhbWVzLWJhc2ljLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsga2V5ZnJhbWVzIH0gZnJvbSAnZW1vdGlvbidcblxuY29uc3Qgcm90YXRlMzYwID0ga2V5ZnJhbWVzYFxuICBmcm9tIHtcbiAgICB0cmFuc2Zvcm06IHJvdGF0ZSgwZGVnKTtcbiAgfVxuICB0byB7XG4gICAgdHJhbnNmb3JtOiByb3RhdGUoMzYwZGVnKTtcbiAgfVxuYFxuIl19 */\\"
 });"
 `;
@@ -426,7 +426,7 @@ let endingRotation = window.whatever;
 
 const rotate360 =
 /*#__PURE__*/
-_keyframes(\\"from{transform:rotate(0deg);}to{transform:rotate(\\", endingRotation, \\");}\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImtleWZyYW1lcy13aXRoLWludGVycG9sYXRpb24uanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBSTJCIiwiZmlsZSI6ImtleWZyYW1lcy13aXRoLWludGVycG9sYXRpb24uanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBrZXlmcmFtZXMgfSBmcm9tICdlbW90aW9uJ1xuXG5sZXQgZW5kaW5nUm90YXRpb24gPSB3aW5kb3cud2hhdGV2ZXJcblxuY29uc3Qgcm90YXRlMzYwID0ga2V5ZnJhbWVzYFxuICBmcm9tIHtcbiAgICB0cmFuc2Zvcm06IHJvdGF0ZSgwZGVnKTtcbiAgfVxuICB0byB7XG4gICAgdHJhbnNmb3JtOiByb3RhdGUoJHtlbmRpbmdSb3RhdGlvbn0pO1xuICB9XG5gXG4iXX0= */\\"));"
+_keyframes(\\"from{transform:rotate(0deg);}to{transform:rotate(\\", endingRotation, \\");}label:rotate360;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImtleWZyYW1lcy13aXRoLWludGVycG9sYXRpb24uanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBSTJCIiwiZmlsZSI6ImtleWZyYW1lcy13aXRoLWludGVycG9sYXRpb24uanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBrZXlmcmFtZXMgfSBmcm9tICdlbW90aW9uJ1xuXG5sZXQgZW5kaW5nUm90YXRpb24gPSB3aW5kb3cud2hhdGV2ZXJcblxuY29uc3Qgcm90YXRlMzYwID0ga2V5ZnJhbWVzYFxuICBmcm9tIHtcbiAgICB0cmFuc2Zvcm06IHJvdGF0ZSgwZGVnKTtcbiAgfVxuICB0byB7XG4gICAgdHJhbnNmb3JtOiByb3RhdGUoJHtlbmRpbmdSb3RhdGlvbn0pO1xuICB9XG5gXG4iXX0= */\\"));"
 `;
 
 exports[`vanilla emotion object-label 1`] = `
@@ -449,21 +449,21 @@ let obj = {
   someProp:
   /*#__PURE__*/
   _css(process.env.NODE_ENV === \\"production\\" ? {
-    name: \\"bjcoli\\",
-    styles: \\"color:green;\\"
+    name: \\"cw3a48-someProp\\",
+    styles: \\"color:green;label:someProp;\\"
   } : {
-    name: \\"bjcoli\\",
-    styles: \\"color:green;\\",
+    name: \\"cw3a48-someProp\\",
+    styles: \\"color:green;label:someProp;\\",
     map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm9iamVjdC1sYWJlbC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFHWSIsImZpbGUiOiJvYmplY3QtbGFiZWwuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uJ1xuXG5sZXQgb2JqID0ge1xuICBzb21lUHJvcDogY3NzKHsgY29sb3I6ICdncmVlbicgfSksXG4gIGFub3RoZXJQcm9wOiBjc3MoeyBjb2xvcjogJ2hvdHBpbmsnIH0pXG59XG5jbGFzcyBUaGluZyB7XG4gIHN0YXRpYyBQcm9wID0gY3NzKHsgY29sb3I6ICd5ZWxsb3cnIH0pXG4gIEJhZElkZWEgPSBjc3MoeyBjb2xvcjogJ3JlZCcgfSlcbn1cbiJdfQ== */\\"
   }),
   anotherProp:
   /*#__PURE__*/
   _css(process.env.NODE_ENV === \\"production\\" ? {
-    name: \\"1lrxbo5\\",
-    styles: \\"color:hotpink;\\"
+    name: \\"1oocabw-anotherProp\\",
+    styles: \\"color:hotpink;label:anotherProp;\\"
   } : {
-    name: \\"1lrxbo5\\",
-    styles: \\"color:hotpink;\\",
+    name: \\"1oocabw-anotherProp\\",
+    styles: \\"color:hotpink;label:anotherProp;\\",
     map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm9iamVjdC1sYWJlbC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFJZSIsImZpbGUiOiJvYmplY3QtbGFiZWwuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uJ1xuXG5sZXQgb2JqID0ge1xuICBzb21lUHJvcDogY3NzKHsgY29sb3I6ICdncmVlbicgfSksXG4gIGFub3RoZXJQcm9wOiBjc3MoeyBjb2xvcjogJ2hvdHBpbmsnIH0pXG59XG5jbGFzcyBUaGluZyB7XG4gIHN0YXRpYyBQcm9wID0gY3NzKHsgY29sb3I6ICd5ZWxsb3cnIH0pXG4gIEJhZElkZWEgPSBjc3MoeyBjb2xvcjogJ3JlZCcgfSlcbn1cbiJdfQ== */\\"
   })
 };
@@ -472,21 +472,21 @@ class Thing {
   static Prop =
   /*#__PURE__*/
   _css(process.env.NODE_ENV === \\"production\\" ? {
-    name: \\"fsfbn2\\",
-    styles: \\"color:yellow;\\"
+    name: \\"1p4vs6c-Prop\\",
+    styles: \\"color:yellow;label:Prop;\\"
   } : {
-    name: \\"fsfbn2\\",
-    styles: \\"color:yellow;\\",
+    name: \\"1p4vs6c-Prop\\",
+    styles: \\"color:yellow;label:Prop;\\",
     map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm9iamVjdC1sYWJlbC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFPZ0IiLCJmaWxlIjoib2JqZWN0LWxhYmVsLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbidcblxubGV0IG9iaiA9IHtcbiAgc29tZVByb3A6IGNzcyh7IGNvbG9yOiAnZ3JlZW4nIH0pLFxuICBhbm90aGVyUHJvcDogY3NzKHsgY29sb3I6ICdob3RwaW5rJyB9KVxufVxuY2xhc3MgVGhpbmcge1xuICBzdGF0aWMgUHJvcCA9IGNzcyh7IGNvbG9yOiAneWVsbG93JyB9KVxuICBCYWRJZGVhID0gY3NzKHsgY29sb3I6ICdyZWQnIH0pXG59XG4iXX0= */\\"
   });
   BadIdea =
   /*#__PURE__*/
   _css(process.env.NODE_ENV === \\"production\\" ? {
-    name: \\"tokvmb\\",
-    styles: \\"color:red;\\"
+    name: \\"1htwp0n-BadIdea\\",
+    styles: \\"color:red;label:BadIdea;\\"
   } : {
-    name: \\"tokvmb\\",
-    styles: \\"color:red;\\",
+    name: \\"1htwp0n-BadIdea\\",
+    styles: \\"color:red;label:BadIdea;\\",
     map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm9iamVjdC1sYWJlbC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFRWSIsImZpbGUiOiJvYmplY3QtbGFiZWwuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uJ1xuXG5sZXQgb2JqID0ge1xuICBzb21lUHJvcDogY3NzKHsgY29sb3I6ICdncmVlbicgfSksXG4gIGFub3RoZXJQcm9wOiBjc3MoeyBjb2xvcjogJ2hvdHBpbmsnIH0pXG59XG5jbGFzcyBUaGluZyB7XG4gIHN0YXRpYyBQcm9wID0gY3NzKHsgY29sb3I6ICd5ZWxsb3cnIH0pXG4gIEJhZElkZWEgPSBjc3MoeyBjb2xvcjogJ3JlZCcgfSlcbn1cbiJdfQ== */\\"
   });
 }"

--- a/packages/babel-plugin-emotion/__tests__/vanilla-emotion-macro/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-emotion/__tests__/vanilla-emotion-macro/__snapshots__/index.js.snap
@@ -69,7 +69,7 @@ let someCls =
 /*#__PURE__*/
 _css({
   color: window.whatever
-}, process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNzcy1vYmplY3QuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBRWMiLCJmaWxlIjoiY3NzLW9iamVjdC5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmxldCBzb21lQ2xzID0gY3NzKHtcbiAgY29sb3I6IHdpbmRvdy53aGF0ZXZlclxufSlcbiJdfQ== */\\");"
+}, \\"label:someCls;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNzcy1vYmplY3QuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBRWMiLCJmaWxlIjoiY3NzLW9iamVjdC5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmxldCBzb21lQ2xzID0gY3NzKHtcbiAgY29sb3I6IHdpbmRvdy53aGF0ZXZlclxufSlcbiJdfQ== */\\"));"
 `;
 
 exports[`vanilla emotion does-not-minify-inside-content-property 1`] = `
@@ -91,11 +91,11 @@ import { css as _css } from \\"emotion\\";
 const cls1 =
 /*#__PURE__*/
 _css(process.env.NODE_ENV === \\"production\\" ? {
-  name: \\"hh44ja\\",
-  styles: \\"content:'  {  }  ';\\"
+  name: \\"19tqhve-cls1\\",
+  styles: \\"content:'  {  }  ';label:cls1;\\"
 } : {
-  name: \\"hh44ja\\",
-  styles: \\"content:'  {  }  ';\\",
+  name: \\"19tqhve-cls1\\",
+  styles: \\"content:'  {  }  ';label:cls1;\\",
   map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImRvZXMtbm90LW1pbmlmeS1pbnNpZGUtY29udGVudC1wcm9wZXJ0eS5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFFZ0IiLCJmaWxlIjoiZG9lcy1ub3QtbWluaWZ5LWluc2lkZS1jb250ZW50LXByb3BlcnR5LmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbi9tYWNybydcblxuY29uc3QgY2xzMSA9IGNzc2BcbiAgY29udGVudDogJyAgeyAgfSAgJztcbmBcbi8vIHByZXR0aWVyLWlnbm9yZVxuY29uc3QgY2xzMiA9IGNzc2BcbiAgY29udGVudDogXCIgIHsgIH0gIFwiO1xuYFxuIl19 */\\"
 }); // prettier-ignore
 
@@ -103,11 +103,11 @@ _css(process.env.NODE_ENV === \\"production\\" ? {
 const cls2 =
 /*#__PURE__*/
 _css(process.env.NODE_ENV === \\"production\\" ? {
-  name: \\"1rr8elb\\",
-  styles: \\"content:\\\\\\"  {  }  \\\\\\";\\"
+  name: \\"16r822g-cls2\\",
+  styles: \\"content:\\\\\\"  {  }  \\\\\\";label:cls2;\\"
 } : {
-  name: \\"1rr8elb\\",
-  styles: \\"content:\\\\\\"  {  }  \\\\\\";\\",
+  name: \\"16r822g-cls2\\",
+  styles: \\"content:\\\\\\"  {  }  \\\\\\";label:cls2;\\",
   map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImRvZXMtbm90LW1pbmlmeS1pbnNpZGUtY29udGVudC1wcm9wZXJ0eS5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFNZ0IiLCJmaWxlIjoiZG9lcy1ub3QtbWluaWZ5LWluc2lkZS1jb250ZW50LXByb3BlcnR5LmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbi9tYWNybydcblxuY29uc3QgY2xzMSA9IGNzc2BcbiAgY29udGVudDogJyAgeyAgfSAgJztcbmBcbi8vIHByZXR0aWVyLWlnbm9yZVxuY29uc3QgY2xzMiA9IGNzc2BcbiAgY29udGVudDogXCIgIHsgIH0gIFwiO1xuYFxuIl19 */\\"
 });"
 `;
@@ -172,33 +172,33 @@ function test() {
   _css(\\"font-size:20px;@media (min-width:420px){color:blue;\\",
   /*#__PURE__*/
   _css(process.env.NODE_ENV === \\"production\\" ? {
-    name: \\"15xbpqr\\",
-    styles: \\"width:96px;height:96px;\\"
+    name: \\"1ylk12k-cls1\\",
+    styles: \\"width:96px;height:96px;label:cls1;\\"
   } : {
-    name: \\"15xbpqr\\",
-    styles: \\"width:96px;height:96px;\\",
+    name: \\"1ylk12k-cls1\\",
+    styles: \\"width:96px;height:96px;label:cls1;\\",
     map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQU9XIiwiZmlsZSI6ImhvaXN0aW5nLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbi9tYWNybydcblxuZnVuY3Rpb24gdGVzdCgpIHtcbiAgY29uc3QgY2xzMSA9IGNzc2BcbiAgICBmb250LXNpemU6IDIwcHg7XG4gICAgQG1lZGlhIChtaW4td2lkdGg6IDQyMHB4KSB7XG4gICAgICBjb2xvcjogYmx1ZTtcbiAgICAgICR7Y3NzYFxuICAgICAgICB3aWR0aDogOTZweDtcbiAgICAgICAgaGVpZ2h0OiA5NnB4O1xuICAgICAgYH07XG4gICAgICBsaW5lLWhlaWdodDogMjZweDtcbiAgICB9XG4gICAgYmFja2dyb3VuZDogZ3JlZW47XG4gICAgJHt7IGJhY2tncm91bmRDb2xvcjogJ2hvdHBpbmsnIH19O1xuICBgXG5cbiAgY29uc3QgY2xzMiA9IGNzc2BcbiAgICAke3sgY29sb3I6ICdibHVlJyB9fTtcbiAgYFxuXG4gIGNvbnN0IGNsczMgPSBjc3NgXG4gICAgZGlzcGxheTogZmxleDtcbiAgICAmOmhvdmVyIHtcbiAgICAgIGNvbG9yOiBob3RwaW5rO1xuICAgIH1cbiAgYFxuICBsZXQgb3V0ZXJWYXIgPSAnc29tZXRoaW5nJ1xuICBmdW5jdGlvbiBpbm5lcigpIHtcbiAgICBjb25zdCBzdHlsZXMgPSB7IGNvbG9yOiAnZGFya29yY2hpZCcgfVxuICAgIGNvbnN0IGNvbG9yID0gJ2FxdWFtYXJpbmUnXG5cbiAgICBjb25zdCBjbHM0ID0gY3NzYFxuICAgICAgJHtjbHMzfTtcbiAgICAgICR7Y2xzMX07XG4gICAgICAke3sgY29sb3I6ICdkYXJrb3JjaGlkJyB9fTtcbiAgICAgICR7eyBjb2xvciB9fTtcbiAgICAgICR7Y3NzYFxuICAgICAgICBoZWlnaHQ6IDQyMHB4O1xuICAgICAgICB3aWR0aDogJHtzdHlsZXN9O1xuICAgICAgYH07XG4gICAgYFxuICAgIGxldCBzb21lQ2xzID0gY3NzYFxuICAgICAgY29sb3I6ICR7b3V0ZXJWYXJ9O1xuICAgIGBcbiAgfVxufVxuIl19 */\\"
-  }), \\";line-height:26px;}background:green;background-color:hotpink;;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUdrQiIsImZpbGUiOiJob2lzdGluZy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmZ1bmN0aW9uIHRlc3QoKSB7XG4gIGNvbnN0IGNsczEgPSBjc3NgXG4gICAgZm9udC1zaXplOiAyMHB4O1xuICAgIEBtZWRpYSAobWluLXdpZHRoOiA0MjBweCkge1xuICAgICAgY29sb3I6IGJsdWU7XG4gICAgICAke2Nzc2BcbiAgICAgICAgd2lkdGg6IDk2cHg7XG4gICAgICAgIGhlaWdodDogOTZweDtcbiAgICAgIGB9O1xuICAgICAgbGluZS1oZWlnaHQ6IDI2cHg7XG4gICAgfVxuICAgIGJhY2tncm91bmQ6IGdyZWVuO1xuICAgICR7eyBiYWNrZ3JvdW5kQ29sb3I6ICdob3RwaW5rJyB9fTtcbiAgYFxuXG4gIGNvbnN0IGNsczIgPSBjc3NgXG4gICAgJHt7IGNvbG9yOiAnYmx1ZScgfX07XG4gIGBcblxuICBjb25zdCBjbHMzID0gY3NzYFxuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgJjpob3ZlciB7XG4gICAgICBjb2xvcjogaG90cGluaztcbiAgICB9XG4gIGBcbiAgbGV0IG91dGVyVmFyID0gJ3NvbWV0aGluZydcbiAgZnVuY3Rpb24gaW5uZXIoKSB7XG4gICAgY29uc3Qgc3R5bGVzID0geyBjb2xvcjogJ2RhcmtvcmNoaWQnIH1cbiAgICBjb25zdCBjb2xvciA9ICdhcXVhbWFyaW5lJ1xuXG4gICAgY29uc3QgY2xzNCA9IGNzc2BcbiAgICAgICR7Y2xzM307XG4gICAgICAke2NsczF9O1xuICAgICAgJHt7IGNvbG9yOiAnZGFya29yY2hpZCcgfX07XG4gICAgICAke3sgY29sb3IgfX07XG4gICAgICAke2Nzc2BcbiAgICAgICAgaGVpZ2h0OiA0MjBweDtcbiAgICAgICAgd2lkdGg6ICR7c3R5bGVzfTtcbiAgICAgIGB9O1xuICAgIGBcbiAgICBsZXQgc29tZUNscyA9IGNzc2BcbiAgICAgIGNvbG9yOiAke291dGVyVmFyfTtcbiAgICBgXG4gIH1cbn1cbiJdfQ== */\\"));
+  }), \\";line-height:26px;}background:green;background-color:hotpink;;label:cls1;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUdrQiIsImZpbGUiOiJob2lzdGluZy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmZ1bmN0aW9uIHRlc3QoKSB7XG4gIGNvbnN0IGNsczEgPSBjc3NgXG4gICAgZm9udC1zaXplOiAyMHB4O1xuICAgIEBtZWRpYSAobWluLXdpZHRoOiA0MjBweCkge1xuICAgICAgY29sb3I6IGJsdWU7XG4gICAgICAke2Nzc2BcbiAgICAgICAgd2lkdGg6IDk2cHg7XG4gICAgICAgIGhlaWdodDogOTZweDtcbiAgICAgIGB9O1xuICAgICAgbGluZS1oZWlnaHQ6IDI2cHg7XG4gICAgfVxuICAgIGJhY2tncm91bmQ6IGdyZWVuO1xuICAgICR7eyBiYWNrZ3JvdW5kQ29sb3I6ICdob3RwaW5rJyB9fTtcbiAgYFxuXG4gIGNvbnN0IGNsczIgPSBjc3NgXG4gICAgJHt7IGNvbG9yOiAnYmx1ZScgfX07XG4gIGBcblxuICBjb25zdCBjbHMzID0gY3NzYFxuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgJjpob3ZlciB7XG4gICAgICBjb2xvcjogaG90cGluaztcbiAgICB9XG4gIGBcbiAgbGV0IG91dGVyVmFyID0gJ3NvbWV0aGluZydcbiAgZnVuY3Rpb24gaW5uZXIoKSB7XG4gICAgY29uc3Qgc3R5bGVzID0geyBjb2xvcjogJ2RhcmtvcmNoaWQnIH1cbiAgICBjb25zdCBjb2xvciA9ICdhcXVhbWFyaW5lJ1xuXG4gICAgY29uc3QgY2xzNCA9IGNzc2BcbiAgICAgICR7Y2xzM307XG4gICAgICAke2NsczF9O1xuICAgICAgJHt7IGNvbG9yOiAnZGFya29yY2hpZCcgfX07XG4gICAgICAke3sgY29sb3IgfX07XG4gICAgICAke2Nzc2BcbiAgICAgICAgaGVpZ2h0OiA0MjBweDtcbiAgICAgICAgd2lkdGg6ICR7c3R5bGVzfTtcbiAgICAgIGB9O1xuICAgIGBcbiAgICBsZXQgc29tZUNscyA9IGNzc2BcbiAgICAgIGNvbG9yOiAke291dGVyVmFyfTtcbiAgICBgXG4gIH1cbn1cbiJdfQ== */\\"));
 
   const cls2 =
   /*#__PURE__*/
   _css(process.env.NODE_ENV === \\"production\\" ? {
-    name: \\"1rdr7a4\\",
-    styles: \\"color:blue;;\\"
+    name: \\"ca17a1-cls2\\",
+    styles: \\"color:blue;;label:cls2;\\"
   } : {
-    name: \\"1rdr7a4\\",
-    styles: \\"color:blue;;\\",
+    name: \\"ca17a1-cls2\\",
+    styles: \\"color:blue;;label:cls2;\\",
     map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQWlCa0IiLCJmaWxlIjoiaG9pc3RpbmcuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uL21hY3JvJ1xuXG5mdW5jdGlvbiB0ZXN0KCkge1xuICBjb25zdCBjbHMxID0gY3NzYFxuICAgIGZvbnQtc2l6ZTogMjBweDtcbiAgICBAbWVkaWEgKG1pbi13aWR0aDogNDIwcHgpIHtcbiAgICAgIGNvbG9yOiBibHVlO1xuICAgICAgJHtjc3NgXG4gICAgICAgIHdpZHRoOiA5NnB4O1xuICAgICAgICBoZWlnaHQ6IDk2cHg7XG4gICAgICBgfTtcbiAgICAgIGxpbmUtaGVpZ2h0OiAyNnB4O1xuICAgIH1cbiAgICBiYWNrZ3JvdW5kOiBncmVlbjtcbiAgICAke3sgYmFja2dyb3VuZENvbG9yOiAnaG90cGluaycgfX07XG4gIGBcblxuICBjb25zdCBjbHMyID0gY3NzYFxuICAgICR7eyBjb2xvcjogJ2JsdWUnIH19O1xuICBgXG5cbiAgY29uc3QgY2xzMyA9IGNzc2BcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgICY6aG92ZXIge1xuICAgICAgY29sb3I6IGhvdHBpbms7XG4gICAgfVxuICBgXG4gIGxldCBvdXRlclZhciA9ICdzb21ldGhpbmcnXG4gIGZ1bmN0aW9uIGlubmVyKCkge1xuICAgIGNvbnN0IHN0eWxlcyA9IHsgY29sb3I6ICdkYXJrb3JjaGlkJyB9XG4gICAgY29uc3QgY29sb3IgPSAnYXF1YW1hcmluZSdcblxuICAgIGNvbnN0IGNsczQgPSBjc3NgXG4gICAgICAke2NsczN9O1xuICAgICAgJHtjbHMxfTtcbiAgICAgICR7eyBjb2xvcjogJ2RhcmtvcmNoaWQnIH19O1xuICAgICAgJHt7IGNvbG9yIH19O1xuICAgICAgJHtjc3NgXG4gICAgICAgIGhlaWdodDogNDIwcHg7XG4gICAgICAgIHdpZHRoOiAke3N0eWxlc307XG4gICAgICBgfTtcbiAgICBgXG4gICAgbGV0IHNvbWVDbHMgPSBjc3NgXG4gICAgICBjb2xvcjogJHtvdXRlclZhcn07XG4gICAgYFxuICB9XG59XG4iXX0= */\\"
   });
 
   const cls3 =
   /*#__PURE__*/
   _css(process.env.NODE_ENV === \\"production\\" ? {
-    name: \\"a21n9o\\",
-    styles: \\"display:flex;&:hover{color:hotpink;}\\"
+    name: \\"zyzn0f-cls3\\",
+    styles: \\"display:flex;&:hover{color:hotpink;}label:cls3;\\"
   } : {
-    name: \\"a21n9o\\",
-    styles: \\"display:flex;&:hover{color:hotpink;}\\",
+    name: \\"zyzn0f-cls3\\",
+    styles: \\"display:flex;&:hover{color:hotpink;}label:cls3;\\",
     map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQXFCa0IiLCJmaWxlIjoiaG9pc3RpbmcuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uL21hY3JvJ1xuXG5mdW5jdGlvbiB0ZXN0KCkge1xuICBjb25zdCBjbHMxID0gY3NzYFxuICAgIGZvbnQtc2l6ZTogMjBweDtcbiAgICBAbWVkaWEgKG1pbi13aWR0aDogNDIwcHgpIHtcbiAgICAgIGNvbG9yOiBibHVlO1xuICAgICAgJHtjc3NgXG4gICAgICAgIHdpZHRoOiA5NnB4O1xuICAgICAgICBoZWlnaHQ6IDk2cHg7XG4gICAgICBgfTtcbiAgICAgIGxpbmUtaGVpZ2h0OiAyNnB4O1xuICAgIH1cbiAgICBiYWNrZ3JvdW5kOiBncmVlbjtcbiAgICAke3sgYmFja2dyb3VuZENvbG9yOiAnaG90cGluaycgfX07XG4gIGBcblxuICBjb25zdCBjbHMyID0gY3NzYFxuICAgICR7eyBjb2xvcjogJ2JsdWUnIH19O1xuICBgXG5cbiAgY29uc3QgY2xzMyA9IGNzc2BcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgICY6aG92ZXIge1xuICAgICAgY29sb3I6IGhvdHBpbms7XG4gICAgfVxuICBgXG4gIGxldCBvdXRlclZhciA9ICdzb21ldGhpbmcnXG4gIGZ1bmN0aW9uIGlubmVyKCkge1xuICAgIGNvbnN0IHN0eWxlcyA9IHsgY29sb3I6ICdkYXJrb3JjaGlkJyB9XG4gICAgY29uc3QgY29sb3IgPSAnYXF1YW1hcmluZSdcblxuICAgIGNvbnN0IGNsczQgPSBjc3NgXG4gICAgICAke2NsczN9O1xuICAgICAgJHtjbHMxfTtcbiAgICAgICR7eyBjb2xvcjogJ2RhcmtvcmNoaWQnIH19O1xuICAgICAgJHt7IGNvbG9yIH19O1xuICAgICAgJHtjc3NgXG4gICAgICAgIGhlaWdodDogNDIwcHg7XG4gICAgICAgIHdpZHRoOiAke3N0eWxlc307XG4gICAgICBgfTtcbiAgICBgXG4gICAgbGV0IHNvbWVDbHMgPSBjc3NgXG4gICAgICBjb2xvcjogJHtvdXRlclZhcn07XG4gICAgYFxuICB9XG59XG4iXX0= */\\"
   });
 
@@ -216,11 +216,11 @@ function test() {
       color
     }, \\";\\",
     /*#__PURE__*/
-    _css(\\"height:420px;width:\\", styles, \\";\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQXFDVyIsImZpbGUiOiJob2lzdGluZy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmZ1bmN0aW9uIHRlc3QoKSB7XG4gIGNvbnN0IGNsczEgPSBjc3NgXG4gICAgZm9udC1zaXplOiAyMHB4O1xuICAgIEBtZWRpYSAobWluLXdpZHRoOiA0MjBweCkge1xuICAgICAgY29sb3I6IGJsdWU7XG4gICAgICAke2Nzc2BcbiAgICAgICAgd2lkdGg6IDk2cHg7XG4gICAgICAgIGhlaWdodDogOTZweDtcbiAgICAgIGB9O1xuICAgICAgbGluZS1oZWlnaHQ6IDI2cHg7XG4gICAgfVxuICAgIGJhY2tncm91bmQ6IGdyZWVuO1xuICAgICR7eyBiYWNrZ3JvdW5kQ29sb3I6ICdob3RwaW5rJyB9fTtcbiAgYFxuXG4gIGNvbnN0IGNsczIgPSBjc3NgXG4gICAgJHt7IGNvbG9yOiAnYmx1ZScgfX07XG4gIGBcblxuICBjb25zdCBjbHMzID0gY3NzYFxuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgJjpob3ZlciB7XG4gICAgICBjb2xvcjogaG90cGluaztcbiAgICB9XG4gIGBcbiAgbGV0IG91dGVyVmFyID0gJ3NvbWV0aGluZydcbiAgZnVuY3Rpb24gaW5uZXIoKSB7XG4gICAgY29uc3Qgc3R5bGVzID0geyBjb2xvcjogJ2RhcmtvcmNoaWQnIH1cbiAgICBjb25zdCBjb2xvciA9ICdhcXVhbWFyaW5lJ1xuXG4gICAgY29uc3QgY2xzNCA9IGNzc2BcbiAgICAgICR7Y2xzM307XG4gICAgICAke2NsczF9O1xuICAgICAgJHt7IGNvbG9yOiAnZGFya29yY2hpZCcgfX07XG4gICAgICAke3sgY29sb3IgfX07XG4gICAgICAke2Nzc2BcbiAgICAgICAgaGVpZ2h0OiA0MjBweDtcbiAgICAgICAgd2lkdGg6ICR7c3R5bGVzfTtcbiAgICAgIGB9O1xuICAgIGBcbiAgICBsZXQgc29tZUNscyA9IGNzc2BcbiAgICAgIGNvbG9yOiAke291dGVyVmFyfTtcbiAgICBgXG4gIH1cbn1cbiJdfQ== */\\")), \\";\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQWdDb0IiLCJmaWxlIjoiaG9pc3RpbmcuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uL21hY3JvJ1xuXG5mdW5jdGlvbiB0ZXN0KCkge1xuICBjb25zdCBjbHMxID0gY3NzYFxuICAgIGZvbnQtc2l6ZTogMjBweDtcbiAgICBAbWVkaWEgKG1pbi13aWR0aDogNDIwcHgpIHtcbiAgICAgIGNvbG9yOiBibHVlO1xuICAgICAgJHtjc3NgXG4gICAgICAgIHdpZHRoOiA5NnB4O1xuICAgICAgICBoZWlnaHQ6IDk2cHg7XG4gICAgICBgfTtcbiAgICAgIGxpbmUtaGVpZ2h0OiAyNnB4O1xuICAgIH1cbiAgICBiYWNrZ3JvdW5kOiBncmVlbjtcbiAgICAke3sgYmFja2dyb3VuZENvbG9yOiAnaG90cGluaycgfX07XG4gIGBcblxuICBjb25zdCBjbHMyID0gY3NzYFxuICAgICR7eyBjb2xvcjogJ2JsdWUnIH19O1xuICBgXG5cbiAgY29uc3QgY2xzMyA9IGNzc2BcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgICY6aG92ZXIge1xuICAgICAgY29sb3I6IGhvdHBpbms7XG4gICAgfVxuICBgXG4gIGxldCBvdXRlclZhciA9ICdzb21ldGhpbmcnXG4gIGZ1bmN0aW9uIGlubmVyKCkge1xuICAgIGNvbnN0IHN0eWxlcyA9IHsgY29sb3I6ICdkYXJrb3JjaGlkJyB9XG4gICAgY29uc3QgY29sb3IgPSAnYXF1YW1hcmluZSdcblxuICAgIGNvbnN0IGNsczQgPSBjc3NgXG4gICAgICAke2NsczN9O1xuICAgICAgJHtjbHMxfTtcbiAgICAgICR7eyBjb2xvcjogJ2RhcmtvcmNoaWQnIH19O1xuICAgICAgJHt7IGNvbG9yIH19O1xuICAgICAgJHtjc3NgXG4gICAgICAgIGhlaWdodDogNDIwcHg7XG4gICAgICAgIHdpZHRoOiAke3N0eWxlc307XG4gICAgICBgfTtcbiAgICBgXG4gICAgbGV0IHNvbWVDbHMgPSBjc3NgXG4gICAgICBjb2xvcjogJHtvdXRlclZhcn07XG4gICAgYFxuICB9XG59XG4iXX0= */\\"));
+    _css(\\"height:420px;width:\\", styles, \\";label:cls4;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQXFDVyIsImZpbGUiOiJob2lzdGluZy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmZ1bmN0aW9uIHRlc3QoKSB7XG4gIGNvbnN0IGNsczEgPSBjc3NgXG4gICAgZm9udC1zaXplOiAyMHB4O1xuICAgIEBtZWRpYSAobWluLXdpZHRoOiA0MjBweCkge1xuICAgICAgY29sb3I6IGJsdWU7XG4gICAgICAke2Nzc2BcbiAgICAgICAgd2lkdGg6IDk2cHg7XG4gICAgICAgIGhlaWdodDogOTZweDtcbiAgICAgIGB9O1xuICAgICAgbGluZS1oZWlnaHQ6IDI2cHg7XG4gICAgfVxuICAgIGJhY2tncm91bmQ6IGdyZWVuO1xuICAgICR7eyBiYWNrZ3JvdW5kQ29sb3I6ICdob3RwaW5rJyB9fTtcbiAgYFxuXG4gIGNvbnN0IGNsczIgPSBjc3NgXG4gICAgJHt7IGNvbG9yOiAnYmx1ZScgfX07XG4gIGBcblxuICBjb25zdCBjbHMzID0gY3NzYFxuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgJjpob3ZlciB7XG4gICAgICBjb2xvcjogaG90cGluaztcbiAgICB9XG4gIGBcbiAgbGV0IG91dGVyVmFyID0gJ3NvbWV0aGluZydcbiAgZnVuY3Rpb24gaW5uZXIoKSB7XG4gICAgY29uc3Qgc3R5bGVzID0geyBjb2xvcjogJ2RhcmtvcmNoaWQnIH1cbiAgICBjb25zdCBjb2xvciA9ICdhcXVhbWFyaW5lJ1xuXG4gICAgY29uc3QgY2xzNCA9IGNzc2BcbiAgICAgICR7Y2xzM307XG4gICAgICAke2NsczF9O1xuICAgICAgJHt7IGNvbG9yOiAnZGFya29yY2hpZCcgfX07XG4gICAgICAke3sgY29sb3IgfX07XG4gICAgICAke2Nzc2BcbiAgICAgICAgaGVpZ2h0OiA0MjBweDtcbiAgICAgICAgd2lkdGg6ICR7c3R5bGVzfTtcbiAgICAgIGB9O1xuICAgIGBcbiAgICBsZXQgc29tZUNscyA9IGNzc2BcbiAgICAgIGNvbG9yOiAke291dGVyVmFyfTtcbiAgICBgXG4gIH1cbn1cbiJdfQ== */\\")), \\";label:cls4;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQWdDb0IiLCJmaWxlIjoiaG9pc3RpbmcuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uL21hY3JvJ1xuXG5mdW5jdGlvbiB0ZXN0KCkge1xuICBjb25zdCBjbHMxID0gY3NzYFxuICAgIGZvbnQtc2l6ZTogMjBweDtcbiAgICBAbWVkaWEgKG1pbi13aWR0aDogNDIwcHgpIHtcbiAgICAgIGNvbG9yOiBibHVlO1xuICAgICAgJHtjc3NgXG4gICAgICAgIHdpZHRoOiA5NnB4O1xuICAgICAgICBoZWlnaHQ6IDk2cHg7XG4gICAgICBgfTtcbiAgICAgIGxpbmUtaGVpZ2h0OiAyNnB4O1xuICAgIH1cbiAgICBiYWNrZ3JvdW5kOiBncmVlbjtcbiAgICAke3sgYmFja2dyb3VuZENvbG9yOiAnaG90cGluaycgfX07XG4gIGBcblxuICBjb25zdCBjbHMyID0gY3NzYFxuICAgICR7eyBjb2xvcjogJ2JsdWUnIH19O1xuICBgXG5cbiAgY29uc3QgY2xzMyA9IGNzc2BcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgICY6aG92ZXIge1xuICAgICAgY29sb3I6IGhvdHBpbms7XG4gICAgfVxuICBgXG4gIGxldCBvdXRlclZhciA9ICdzb21ldGhpbmcnXG4gIGZ1bmN0aW9uIGlubmVyKCkge1xuICAgIGNvbnN0IHN0eWxlcyA9IHsgY29sb3I6ICdkYXJrb3JjaGlkJyB9XG4gICAgY29uc3QgY29sb3IgPSAnYXF1YW1hcmluZSdcblxuICAgIGNvbnN0IGNsczQgPSBjc3NgXG4gICAgICAke2NsczN9O1xuICAgICAgJHtjbHMxfTtcbiAgICAgICR7eyBjb2xvcjogJ2RhcmtvcmNoaWQnIH19O1xuICAgICAgJHt7IGNvbG9yIH19O1xuICAgICAgJHtjc3NgXG4gICAgICAgIGhlaWdodDogNDIwcHg7XG4gICAgICAgIHdpZHRoOiAke3N0eWxlc307XG4gICAgICBgfTtcbiAgICBgXG4gICAgbGV0IHNvbWVDbHMgPSBjc3NgXG4gICAgICBjb2xvcjogJHtvdXRlclZhcn07XG4gICAgYFxuICB9XG59XG4iXX0= */\\"));
 
     let someCls =
     /*#__PURE__*/
-    _css(\\"color:\\", outerVar, \\";\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQTBDcUIiLCJmaWxlIjoiaG9pc3RpbmcuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uL21hY3JvJ1xuXG5mdW5jdGlvbiB0ZXN0KCkge1xuICBjb25zdCBjbHMxID0gY3NzYFxuICAgIGZvbnQtc2l6ZTogMjBweDtcbiAgICBAbWVkaWEgKG1pbi13aWR0aDogNDIwcHgpIHtcbiAgICAgIGNvbG9yOiBibHVlO1xuICAgICAgJHtjc3NgXG4gICAgICAgIHdpZHRoOiA5NnB4O1xuICAgICAgICBoZWlnaHQ6IDk2cHg7XG4gICAgICBgfTtcbiAgICAgIGxpbmUtaGVpZ2h0OiAyNnB4O1xuICAgIH1cbiAgICBiYWNrZ3JvdW5kOiBncmVlbjtcbiAgICAke3sgYmFja2dyb3VuZENvbG9yOiAnaG90cGluaycgfX07XG4gIGBcblxuICBjb25zdCBjbHMyID0gY3NzYFxuICAgICR7eyBjb2xvcjogJ2JsdWUnIH19O1xuICBgXG5cbiAgY29uc3QgY2xzMyA9IGNzc2BcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgICY6aG92ZXIge1xuICAgICAgY29sb3I6IGhvdHBpbms7XG4gICAgfVxuICBgXG4gIGxldCBvdXRlclZhciA9ICdzb21ldGhpbmcnXG4gIGZ1bmN0aW9uIGlubmVyKCkge1xuICAgIGNvbnN0IHN0eWxlcyA9IHsgY29sb3I6ICdkYXJrb3JjaGlkJyB9XG4gICAgY29uc3QgY29sb3IgPSAnYXF1YW1hcmluZSdcblxuICAgIGNvbnN0IGNsczQgPSBjc3NgXG4gICAgICAke2NsczN9O1xuICAgICAgJHtjbHMxfTtcbiAgICAgICR7eyBjb2xvcjogJ2RhcmtvcmNoaWQnIH19O1xuICAgICAgJHt7IGNvbG9yIH19O1xuICAgICAgJHtjc3NgXG4gICAgICAgIGhlaWdodDogNDIwcHg7XG4gICAgICAgIHdpZHRoOiAke3N0eWxlc307XG4gICAgICBgfTtcbiAgICBgXG4gICAgbGV0IHNvbWVDbHMgPSBjc3NgXG4gICAgICBjb2xvcjogJHtvdXRlclZhcn07XG4gICAgYFxuICB9XG59XG4iXX0= */\\"));
+    _css(\\"color:\\", outerVar, \\";label:someCls;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImhvaXN0aW5nLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQTBDcUIiLCJmaWxlIjoiaG9pc3RpbmcuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uL21hY3JvJ1xuXG5mdW5jdGlvbiB0ZXN0KCkge1xuICBjb25zdCBjbHMxID0gY3NzYFxuICAgIGZvbnQtc2l6ZTogMjBweDtcbiAgICBAbWVkaWEgKG1pbi13aWR0aDogNDIwcHgpIHtcbiAgICAgIGNvbG9yOiBibHVlO1xuICAgICAgJHtjc3NgXG4gICAgICAgIHdpZHRoOiA5NnB4O1xuICAgICAgICBoZWlnaHQ6IDk2cHg7XG4gICAgICBgfTtcbiAgICAgIGxpbmUtaGVpZ2h0OiAyNnB4O1xuICAgIH1cbiAgICBiYWNrZ3JvdW5kOiBncmVlbjtcbiAgICAke3sgYmFja2dyb3VuZENvbG9yOiAnaG90cGluaycgfX07XG4gIGBcblxuICBjb25zdCBjbHMyID0gY3NzYFxuICAgICR7eyBjb2xvcjogJ2JsdWUnIH19O1xuICBgXG5cbiAgY29uc3QgY2xzMyA9IGNzc2BcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgICY6aG92ZXIge1xuICAgICAgY29sb3I6IGhvdHBpbms7XG4gICAgfVxuICBgXG4gIGxldCBvdXRlclZhciA9ICdzb21ldGhpbmcnXG4gIGZ1bmN0aW9uIGlubmVyKCkge1xuICAgIGNvbnN0IHN0eWxlcyA9IHsgY29sb3I6ICdkYXJrb3JjaGlkJyB9XG4gICAgY29uc3QgY29sb3IgPSAnYXF1YW1hcmluZSdcblxuICAgIGNvbnN0IGNsczQgPSBjc3NgXG4gICAgICAke2NsczN9O1xuICAgICAgJHtjbHMxfTtcbiAgICAgICR7eyBjb2xvcjogJ2RhcmtvcmNoaWQnIH19O1xuICAgICAgJHt7IGNvbG9yIH19O1xuICAgICAgJHtjc3NgXG4gICAgICAgIGhlaWdodDogNDIwcHg7XG4gICAgICAgIHdpZHRoOiAke3N0eWxlc307XG4gICAgICBgfTtcbiAgICBgXG4gICAgbGV0IHNvbWVDbHMgPSBjc3NgXG4gICAgICBjb2xvcjogJHtvdXRlclZhcn07XG4gICAgYFxuICB9XG59XG4iXX0= */\\"));
   }
 }"
 `;
@@ -395,11 +395,11 @@ import { keyframes as _keyframes } from \\"emotion\\";
 const rotate360 =
 /*#__PURE__*/
 _keyframes(process.env.NODE_ENV === \\"production\\" ? {
-  name: \\"1q8eu9e\\",
-  styles: \\"from{transform:rotate(0deg);}to{transform:rotate(360deg);}\\"
+  name: \\"1lprnvq-rotate360\\",
+  styles: \\"from{transform:rotate(0deg);}to{transform:rotate(360deg);}label:rotate360;\\"
 } : {
-  name: \\"1q8eu9e\\",
-  styles: \\"from{transform:rotate(0deg);}to{transform:rotate(360deg);}\\",
+  name: \\"1lprnvq-rotate360\\",
+  styles: \\"from{transform:rotate(0deg);}to{transform:rotate(360deg);}label:rotate360;\\",
   map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImtleWZyYW1lcy1iYXNpYy5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFFMkIiLCJmaWxlIjoia2V5ZnJhbWVzLWJhc2ljLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsga2V5ZnJhbWVzIH0gZnJvbSAnZW1vdGlvbi9tYWNybydcblxuY29uc3Qgcm90YXRlMzYwID0ga2V5ZnJhbWVzYFxuICBmcm9tIHtcbiAgICB0cmFuc2Zvcm06IHJvdGF0ZSgwZGVnKTtcbiAgfVxuICB0byB7XG4gICAgdHJhbnNmb3JtOiByb3RhdGUoMzYwZGVnKTtcbiAgfVxuYFxuIl19 */\\"
 });"
 `;
@@ -426,7 +426,7 @@ let endingRotation = window.whatever;
 
 const rotate360 =
 /*#__PURE__*/
-_keyframes(\\"from{transform:rotate(0deg);}to{transform:rotate(\\", endingRotation, \\");}\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImtleWZyYW1lcy13aXRoLWludGVycG9sYXRpb24uanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBSTJCIiwiZmlsZSI6ImtleWZyYW1lcy13aXRoLWludGVycG9sYXRpb24uanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBrZXlmcmFtZXMgfSBmcm9tICdlbW90aW9uL21hY3JvJ1xuXG5sZXQgZW5kaW5nUm90YXRpb24gPSB3aW5kb3cud2hhdGV2ZXJcblxuY29uc3Qgcm90YXRlMzYwID0ga2V5ZnJhbWVzYFxuICBmcm9tIHtcbiAgICB0cmFuc2Zvcm06IHJvdGF0ZSgwZGVnKTtcbiAgfVxuICB0byB7XG4gICAgdHJhbnNmb3JtOiByb3RhdGUoJHtlbmRpbmdSb3RhdGlvbn0pO1xuICB9XG5gXG4iXX0= */\\"));"
+_keyframes(\\"from{transform:rotate(0deg);}to{transform:rotate(\\", endingRotation, \\");}label:rotate360;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImtleWZyYW1lcy13aXRoLWludGVycG9sYXRpb24uanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBSTJCIiwiZmlsZSI6ImtleWZyYW1lcy13aXRoLWludGVycG9sYXRpb24uanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBrZXlmcmFtZXMgfSBmcm9tICdlbW90aW9uL21hY3JvJ1xuXG5sZXQgZW5kaW5nUm90YXRpb24gPSB3aW5kb3cud2hhdGV2ZXJcblxuY29uc3Qgcm90YXRlMzYwID0ga2V5ZnJhbWVzYFxuICBmcm9tIHtcbiAgICB0cmFuc2Zvcm06IHJvdGF0ZSgwZGVnKTtcbiAgfVxuICB0byB7XG4gICAgdHJhbnNmb3JtOiByb3RhdGUoJHtlbmRpbmdSb3RhdGlvbn0pO1xuICB9XG5gXG4iXX0= */\\"));"
 `;
 
 exports[`vanilla emotion object-label 1`] = `
@@ -449,21 +449,21 @@ let obj = {
   someProp:
   /*#__PURE__*/
   _css(process.env.NODE_ENV === \\"production\\" ? {
-    name: \\"bjcoli\\",
-    styles: \\"color:green;\\"
+    name: \\"cw3a48-someProp\\",
+    styles: \\"color:green;label:someProp;\\"
   } : {
-    name: \\"bjcoli\\",
-    styles: \\"color:green;\\",
+    name: \\"cw3a48-someProp\\",
+    styles: \\"color:green;label:someProp;\\",
     map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm9iamVjdC1sYWJlbC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFHWSIsImZpbGUiOiJvYmplY3QtbGFiZWwuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uL21hY3JvJ1xuXG5sZXQgb2JqID0ge1xuICBzb21lUHJvcDogY3NzKHsgY29sb3I6ICdncmVlbicgfSksXG4gIGFub3RoZXJQcm9wOiBjc3MoeyBjb2xvcjogJ2hvdHBpbmsnIH0pXG59XG5jbGFzcyBUaGluZyB7XG4gIHN0YXRpYyBQcm9wID0gY3NzKHsgY29sb3I6ICd5ZWxsb3cnIH0pXG4gIEJhZElkZWEgPSBjc3MoeyBjb2xvcjogJ3JlZCcgfSlcbn1cbiJdfQ== */\\"
   }),
   anotherProp:
   /*#__PURE__*/
   _css(process.env.NODE_ENV === \\"production\\" ? {
-    name: \\"1lrxbo5\\",
-    styles: \\"color:hotpink;\\"
+    name: \\"1oocabw-anotherProp\\",
+    styles: \\"color:hotpink;label:anotherProp;\\"
   } : {
-    name: \\"1lrxbo5\\",
-    styles: \\"color:hotpink;\\",
+    name: \\"1oocabw-anotherProp\\",
+    styles: \\"color:hotpink;label:anotherProp;\\",
     map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm9iamVjdC1sYWJlbC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFJZSIsImZpbGUiOiJvYmplY3QtbGFiZWwuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uL21hY3JvJ1xuXG5sZXQgb2JqID0ge1xuICBzb21lUHJvcDogY3NzKHsgY29sb3I6ICdncmVlbicgfSksXG4gIGFub3RoZXJQcm9wOiBjc3MoeyBjb2xvcjogJ2hvdHBpbmsnIH0pXG59XG5jbGFzcyBUaGluZyB7XG4gIHN0YXRpYyBQcm9wID0gY3NzKHsgY29sb3I6ICd5ZWxsb3cnIH0pXG4gIEJhZElkZWEgPSBjc3MoeyBjb2xvcjogJ3JlZCcgfSlcbn1cbiJdfQ== */\\"
   })
 };
@@ -472,21 +472,21 @@ class Thing {
   static Prop =
   /*#__PURE__*/
   _css(process.env.NODE_ENV === \\"production\\" ? {
-    name: \\"fsfbn2\\",
-    styles: \\"color:yellow;\\"
+    name: \\"1p4vs6c-Prop\\",
+    styles: \\"color:yellow;label:Prop;\\"
   } : {
-    name: \\"fsfbn2\\",
-    styles: \\"color:yellow;\\",
+    name: \\"1p4vs6c-Prop\\",
+    styles: \\"color:yellow;label:Prop;\\",
     map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm9iamVjdC1sYWJlbC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFPZ0IiLCJmaWxlIjoib2JqZWN0LWxhYmVsLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbi9tYWNybydcblxubGV0IG9iaiA9IHtcbiAgc29tZVByb3A6IGNzcyh7IGNvbG9yOiAnZ3JlZW4nIH0pLFxuICBhbm90aGVyUHJvcDogY3NzKHsgY29sb3I6ICdob3RwaW5rJyB9KVxufVxuY2xhc3MgVGhpbmcge1xuICBzdGF0aWMgUHJvcCA9IGNzcyh7IGNvbG9yOiAneWVsbG93JyB9KVxuICBCYWRJZGVhID0gY3NzKHsgY29sb3I6ICdyZWQnIH0pXG59XG4iXX0= */\\"
   });
   BadIdea =
   /*#__PURE__*/
   _css(process.env.NODE_ENV === \\"production\\" ? {
-    name: \\"tokvmb\\",
-    styles: \\"color:red;\\"
+    name: \\"1htwp0n-BadIdea\\",
+    styles: \\"color:red;label:BadIdea;\\"
   } : {
-    name: \\"tokvmb\\",
-    styles: \\"color:red;\\",
+    name: \\"1htwp0n-BadIdea\\",
+    styles: \\"color:red;label:BadIdea;\\",
     map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm9iamVjdC1sYWJlbC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFRWSIsImZpbGUiOiJvYmplY3QtbGFiZWwuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBjc3MgfSBmcm9tICdlbW90aW9uL21hY3JvJ1xuXG5sZXQgb2JqID0ge1xuICBzb21lUHJvcDogY3NzKHsgY29sb3I6ICdncmVlbicgfSksXG4gIGFub3RoZXJQcm9wOiBjc3MoeyBjb2xvcjogJ2hvdHBpbmsnIH0pXG59XG5jbGFzcyBUaGluZyB7XG4gIHN0YXRpYyBQcm9wID0gY3NzKHsgY29sb3I6ICd5ZWxsb3cnIH0pXG4gIEJhZElkZWEgPSBjc3MoeyBjb2xvcjogJ3JlZCcgfSlcbn1cbiJdfQ== */\\"
   });
 }"

--- a/packages/babel-plugin-emotion/src/macro.js
+++ b/packages/babel-plugin-emotion/src/macro.js
@@ -30,7 +30,7 @@ export let createEmotionMacro = (instancePath: string) =>
               babel,
               state,
               path,
-              shouldLabel: state.opts.autoLabel
+              shouldLabel: true
             })
             if (node) {
               path.node.arguments[0] = node

--- a/packages/emotion/test/__snapshots__/css.test.js.snap
+++ b/packages/emotion/test/__snapshots__/css.test.js.snap
@@ -176,7 +176,7 @@ exports[`css explicit & 1`] = `
 `;
 
 exports[`css explicit & 2`] = `
-".css-16ooeb3.another-class {
+".css-1iccnl4-cls1.another-class {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -238,7 +238,7 @@ exports[`css flushes correctly 1`] = `
 
 exports[`css flushes correctly 2`] = `
 <div
-  className="css-k008qs"
+  className="css-15gpprc-cls1"
 />
 `;
 
@@ -303,20 +303,20 @@ exports[`css manually use label property 1`] = `
 `;
 
 exports[`css manually use label property 2`] = `
-".css-1t6hm03-wow {
+".css-3uek40-wow-cls1 {
   color: hotpink;
 }"
 `;
 
 exports[`css media query specificity 1`] = `
-".css-mfslnr {
+".css-eeq86y-cls {
   width: 32px;
   height: 32px;
   border-radius: 50%;
 }
 
 @media (min-width:420px) {
-  .css-mfslnr {
+  .css-eeq86y-cls {
     width: 96px;
     height: 96px;
   }

--- a/packages/emotion/test/__snapshots__/inject-global.test.js.snap
+++ b/packages/emotion/test/__snapshots__/inject-global.test.js.snap
@@ -30,7 +30,7 @@ exports[`injectGlobal nested interpolated media query 1`] = `
 `;
 
 exports[`injectGlobal random interpolation 1`] = `
-".css-k008qs {
+".css-1002tid-cls {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/packages/emotion/test/__snapshots__/keyframes.test.js.snap
+++ b/packages/emotion/test/__snapshots__/keyframes.test.js.snap
@@ -27,41 +27,6 @@ exports[`keyframes keyframes with interpolation 1`] = `
 </h1>
 `;
 
-exports[`keyframes keyframes with interpolation 2`] = `
-"@-webkit-keyframes animation-1q8eu9e {
-  from {
-    -webkit-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-
-  to {
-    -webkit-transform: rotate(360deg);
-    -ms-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
-}
-
-@keyframes animation-1q8eu9e {
-  from {
-    -webkit-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-
-  to {
-    -webkit-transform: rotate(360deg);
-    -ms-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
-}
-
-.css-l8b5qg {
-  -webkit-animation: animation-1q8eu9e 2s linear infinite;
-  animation: animation-1q8eu9e 2s linear infinite;
-}"
-`;
-
 exports[`keyframes renders 1`] = `
 @keyframes animation-0 {
   from, 20%, 53%, 80%, to {
@@ -105,75 +70,4 @@ exports[`keyframes renders 1`] = `
 >
   hello world
 </h1>
-`;
-
-exports[`keyframes renders 2`] = `
-"@-webkit-keyframes animation-16qlhaj {
-  from, 20%, 53%, 80%, to {
-    -webkit-animation-timing-function: cubic-bezier(0.215,0.610,0.355,1.000);
-    animation-timing-function: cubic-bezier(0.215,0.610,0.355,1.000);
-    -webkit-transform: translate3d(0,0,0);
-    -ms-transform: translate3d(0,0,0);
-    transform: translate3d(0,0,0);
-  }
-
-  40%, 43% {
-    -webkit-animation-timing-function: cubic-bezier(0.755,0.050,0.855,0.060);
-    animation-timing-function: cubic-bezier(0.755,0.050,0.855,0.060);
-    -webkit-transform: translate3d(0,-30px,0);
-    -ms-transform: translate3d(0,-30px,0);
-    transform: translate3d(0,-30px,0);
-  }
-
-  70% {
-    -webkit-animation-timing-function: cubic-bezier(0.755,0.050,0.855,0.060);
-    animation-timing-function: cubic-bezier(0.755,0.050,0.855,0.060);
-    -webkit-transform: translate3d(0,-15px,0);
-    -ms-transform: translate3d(0,-15px,0);
-    transform: translate3d(0,-15px,0);
-  }
-
-  90% {
-    -webkit-transform: translate3d(0,-4px,0);
-    -ms-transform: translate3d(0,-4px,0);
-    transform: translate3d(0,-4px,0);
-  }
-}
-
-@keyframes animation-16qlhaj {
-  from, 20%, 53%, 80%, to {
-    -webkit-animation-timing-function: cubic-bezier(0.215,0.610,0.355,1.000);
-    animation-timing-function: cubic-bezier(0.215,0.610,0.355,1.000);
-    -webkit-transform: translate3d(0,0,0);
-    -ms-transform: translate3d(0,0,0);
-    transform: translate3d(0,0,0);
-  }
-
-  40%, 43% {
-    -webkit-animation-timing-function: cubic-bezier(0.755,0.050,0.855,0.060);
-    animation-timing-function: cubic-bezier(0.755,0.050,0.855,0.060);
-    -webkit-transform: translate3d(0,-30px,0);
-    -ms-transform: translate3d(0,-30px,0);
-    transform: translate3d(0,-30px,0);
-  }
-
-  70% {
-    -webkit-animation-timing-function: cubic-bezier(0.755,0.050,0.855,0.060);
-    animation-timing-function: cubic-bezier(0.755,0.050,0.855,0.060);
-    -webkit-transform: translate3d(0,-15px,0);
-    -ms-transform: translate3d(0,-15px,0);
-    transform: translate3d(0,-15px,0);
-  }
-
-  90% {
-    -webkit-transform: translate3d(0,-4px,0);
-    -ms-transform: translate3d(0,-4px,0);
-    transform: translate3d(0,-4px,0);
-  }
-}
-
-.css-1qpx6jr {
-  -webkit-animation: animation-16qlhaj 2s linear infinite;
-  animation: animation-16qlhaj 2s linear infinite;
-}"
 `;

--- a/packages/emotion/test/keyframes.test.js
+++ b/packages/emotion/test/keyframes.test.js
@@ -2,7 +2,7 @@
 import 'test-utils/legacy-env'
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { keyframes, sheet, flush, css } from 'emotion'
+import { keyframes, flush, css } from 'emotion'
 
 describe('keyframes', () => {
   afterEach(() => {
@@ -43,7 +43,6 @@ describe('keyframes', () => {
       .toJSON()
 
     expect(tree).toMatchSnapshot()
-    expect(sheet).toMatchSnapshot()
   })
   test('keyframes with interpolation', () => {
     const endingRotation = '360deg'
@@ -69,7 +68,5 @@ describe('keyframes', () => {
       .toJSON()
 
     expect(tree).toMatchSnapshot()
-
-    expect(sheet).toMatchSnapshot()
   })
 })

--- a/packages/emotion/test/source-map/__snapshots__/source-map.test.js.snap
+++ b/packages/emotion/test/source-map/__snapshots__/source-map.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`css css without newline or semicolon 1`] = `
-".css-1lrxbo5 {
+".css-6kh100-cls {
   color: hotpink;
 }
 

--- a/packages/emotion/test/warnings.test.js
+++ b/packages/emotion/test/warnings.test.js
@@ -67,7 +67,7 @@ it('warns when class names from css are interpolated', () => {
   expect(console.error.mock.calls[0]).toMatchInlineSnapshot(`
 Array [
   "Interpolating a className from css\`\` is not recommended and will cause problems with composition.
-Interpolating a className from css\`\` will be completely unsupported in the next major version of Emotion",
+Interpolating a className from css\`\` will be completely unsupported in a future major version of Emotion",
 ]
 `)
 })

--- a/packages/jest-emotion/test/__snapshots__/printer.test.js.snap
+++ b/packages/jest-emotion/test/__snapshots__/printer.test.js.snap
@@ -12,10 +12,10 @@ exports[`does not replace class names that are not from emotion 1`] = `
 
 exports[`jest-emotion with DOM elements disabled does not replace class names or insert styles into DOM element snapshots 1`] = `
 "<div
-  class=\\"css-tokvmb\\"
+  class=\\"css-q1yspt-divStyle\\"
 >
   <svg
-    class=\\"css-8atqhb\\"
+    class=\\"css-18ku24t-svgStyle\\"
   />
 </div>"
 `;
@@ -74,4 +74,4 @@ exports[`jest-emotion with dom elements replaces class names and inserts styles 
 </div>"
 `;
 
-exports[`throws nice error for invalid css 1`] = `"There was an error parsing the following css: \\".css-11cntgz{jnnjvhjevhevhb;}\\""`;
+exports[`throws nice error for invalid css 1`] = `"There was an error parsing the following css: \\".css-d1550g-tree{jnnjvh@'jevhevhblabel:tree;}\\""`;

--- a/packages/jest-emotion/test/printer.test.js
+++ b/packages/jest-emotion/test/printer.test.js
@@ -142,7 +142,9 @@ header .emotion-0 {
 })
 
 test('throws nice error for invalid css', () => {
-  const tree = renderer.create(<div className={css`jnnjvhjevhevhb`} />).toJSON()
+  const tree = renderer
+    .create(<div className={css`jnnjvh@'jevhevhb`} />)
+    .toJSON()
 
   expect(() => {
     ignoreConsoleErrors(() => {

--- a/packages/serialize/src/index.js
+++ b/packages/serialize/src/index.js
@@ -188,7 +188,7 @@ function handleInterpolation(
       ) {
         console.error(
           'Interpolating a className from css`` is not recommended and will cause problems with composition.\n' +
-            'Interpolating a className from css`` will be completely unsupported in the next major version of Emotion'
+            'Interpolating a className from css`` will be completely unsupported in a future major version of Emotion'
         )
         shouldWarnAboutInterpolatingClassNameFromCss = false
       }


### PR DESCRIPTION
This is already how it is for the other babel things, so just add it to this one as well.

There's also a small warning message change in this.