### PR TITLE
Fix css prop style overwriting

### DIFF
--- a/packages/core/__tests__/__snapshots__/css.js.snap
+++ b/packages/core/__tests__/__snapshots__/css.js.snap
@@ -73,6 +73,18 @@ exports[`object with false 1`] = `
 </div>
 `;
 
+exports[`overwrite styles from parent 1`] = `
+.emotion-0 {
+  color: green;
+  background-color: yellow;
+  color: hotpink;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
 exports[`string as css prop throws 1`] = `
 "Strings are not allowed as css prop values, please wrap it in a css template literal from '@emotion/css' like this: css\`
             color: hotpink;

--- a/packages/core/__tests__/css.js
+++ b/packages/core/__tests__/css.js
@@ -155,3 +155,24 @@ test('autoLabel without babel', () => {
 
   expect(tree.toJSON().props.className.endsWith('-SomeComp')).toBe(true)
 })
+
+test('overwrite styles from parent', () => {
+  let SomeComponent = (props: Object) => (
+    <div
+      css={{
+        color: 'green',
+        backgroundColor: 'yellow'
+      }}
+      {...props}
+    />
+  )
+  const tree = renderer.create(
+    <SomeComponent
+      css={{
+        color: 'hotpink'
+      }}
+    />
+  )
+
+  expect(tree.toJSON()).toMatchSnapshot()
+})

--- a/packages/core/src/jsx.js
+++ b/packages/core/src/jsx.js
@@ -15,6 +15,9 @@ let render = (cache, props, theme: null | Object, ref) => {
   let registeredStyles = []
 
   let className = ''
+
+  registeredStyles.push(theme === null ? props.css : props.css(theme))
+
   if (props.className !== undefined) {
     className = getRegisteredStyles(
       cache.registered,
@@ -22,7 +25,7 @@ let render = (cache, props, theme: null | Object, ref) => {
       props.className
     )
   }
-  registeredStyles.push(theme === null ? props.css : props.css(theme))
+
   let serialized = serializeStyles(cache.registered, registeredStyles)
 
   if (


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Fix css prop style overwriting
<!-- Why are these changes necessary? -->
**Why**:
I have no idea how I didn't notice this before but this makes it so styles from the className overwrite styles from the css prop so you can create primitive components that have styles and they can be overridden from a parent component. This has been the intended behavior for a long time but there wasn't a test for it so the implementation was wrong.
#753 
<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
