### PR TITLE
update react-primitives & react-native-web dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   "resolutions": {
     "**/react": "16.5.2",
     "**/react-dom": "16.5.2",
-    "**/browserslist": "^3.2.8",
-    "**/react-primitives/react-native-web": "0.9.6"
+    "**/browserslist": "^3.2.8"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "**/react": "16.5.2",
     "**/react-dom": "16.5.2",
     "**/browserslist": "^3.2.8",
-    "**/react-primitives/react-native-web": "0.9.3"
+    "**/react-primitives/react-native-web": "0.9.6"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
@@ -101,7 +101,7 @@
     "react-art": "^16.5.2",
     "react-dom": "^16.5.2",
     "react-native": "^0.57.0",
-    "react-primitives": "^0.6.1",
+    "react-primitives": "^0.7.0",
     "react-router-dom": "^4.2.2",
     "react-test-renderer": "^16.3.2",
     "react-testing-library": "^5.2.0"

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -13,14 +13,14 @@
     "babel-plugin-emotion": "^10.0.0-beta.8"
   },
   "peerDependencies": {
-    "react-primitives": "^0.6.1"
+    "react-primitives": "^0.7.0"
   },
   "devDependencies": {
     "emotion-theming": "^10.0.0-beta.8",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "react": "^16.5.2",
-    "react-primitives": "^0.6.1"
+    "react-primitives": "^0.7.0"
   },
   "homepage": "https://emotion.sh",
   "license": "MIT",

--- a/scripts/benchmarks/package.json
+++ b/scripts/benchmarks/package.json
@@ -11,7 +11,7 @@
     "@babel/core": "^7.0.0",
     "babel-core": "^6.26.3",
     "babel-plugin-emotion": "^10.0.0-beta.8",
-    "babel-plugin-react-native-web": "^0.8.8",
+    "babel-plugin-react-native-web": "^0.9.6",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "d3-scale-chromatic": "^1.3.0",
     "http-server": "^0.11.1",
@@ -19,7 +19,7 @@
     "puppeteer": "^1.6.0",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
-    "react-native-web": "0.9.3",
+    "react-native-web": "0.9.6",
     "stats-analysis": "^2.0.0"
   },
   "alias": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3210,10 +3210,10 @@ babel-plugin-macros@^2.4.0:
   dependencies:
     cosmiconfig "^5.0.5"
 
-babel-plugin-react-native-web@^0.8.8:
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.8.8.tgz#f896da73d3038f396d2181fc6779d061e52d32b8"
-  integrity sha512-yYQDlCUn68AzigBuFEKL/teDd0bEoumRKDhk3mPItkF950swHofoIV/VVLcang8IhhKxqNh+1wYE70MbVlhNoQ==
+babel-plugin-react-native-web@^0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.9.6.tgz#21ca8c097d4d475f5b8cd435fa461d1342fcb103"
+  integrity sha512-toyQWuiwwpVFDtlUtpKuf01Qjxk/f3kUi6TvT8kJ9HT59xjchUflhFYrBvQeESS6Mi+psHRWUxhDjX01m2IeUQ==
 
 babel-plugin-remove-graphql-queries@^2.0.2-rc.3:
   version "2.0.2-rc.3"
@@ -17584,7 +17584,7 @@ rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-art@^16.4.0, react-art@^16.5.2:
+react-art@^16.5.2:
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/react-art/-/react-art-16.5.2.tgz#dabfc9a5ef565ecb4f817bb0e872f9a5cd7f89cb"
   integrity sha512-55g2iFRVE+YhkNdzKAtO3BhTdROefBVZ+bif3K5mI7shXE4shOHpWnhbdKZyU1o9O8pvfPApRWbZWdV8fkxyOw==
@@ -17781,10 +17781,10 @@ react-live@^1.7.1:
     prop-types "^15.5.8"
     unescape "^0.2.0"
 
-react-native-web@0.9.3, react-native-web@^0.8.3:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.9.3.tgz#7d504a4d331e6965061496a5954dfefe1cdc1239"
-  integrity sha512-2CqfN0hTbjxqJOV/RUdX/WGxp6FyDHZI/fIrBhxNrJ1UFk95Q086Zr9MLjcXLS3/dqTFnIB1SDV6VdkMrLhE5g==
+react-native-web@0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.9.6.tgz#d51073963582b76775bcdff328aeee0fca807c99"
+  integrity sha512-i0tN/UCLNgsoFkoJOxCtW92L07A5XIJe6p2tlqF3/gdgBL4HK5m63fhc1Ywr1OoU/YJ59/Dnwz1VE/lak5ar3w==
   dependencies:
     array-find-index "^1.0.2"
     create-react-class "^15.6.2"
@@ -17855,10 +17855,10 @@ react-native@^0.57.0:
     xmldoc "^0.4.0"
     yargs "^9.0.0"
 
-react-primitives@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/react-primitives/-/react-primitives-0.6.1.tgz#7ea4082a7831cbaf928a12058f7950d228dbcdec"
-  integrity sha512-8v1fTTHq9D3Nn3gIDcb/e/aXmEed5FReV8jknyYqeFuVhYhXPKyhdE3Tt6Gl2tSDnC6MFi2KMPxYSbQUtCELdQ==
+react-primitives@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/react-primitives/-/react-primitives-0.7.0.tgz#ccd83c7aa374c66bb1dc4982b423403c59a33805"
+  integrity sha512-9JwzJExMVFIR1H+e+4fF8cTeS1Fj+W5+oL5vHawar36vwsJB5CLvdP3DY2DlYVH+pOZoCCQpBgeOjD2d7e6GKg==
   dependencies:
     animated "^0.2.2"
     asap "^2.0.5"
@@ -17868,8 +17868,6 @@ react-primitives@^0.6.1:
     invariant "^2.2.1"
     normalize-css-color "^1.0.1"
     prop-types "^15.5.10"
-    react-art "^16.4.0"
-    react-native-web "^0.8.3"
     react-timer-mixin "^0.13.3"
     string-hash "^1.1.3"
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Updated the `react-primitives` and `react-native-web` dependencies for `emotion-primitives`.

<!-- Why are these changes necessary? -->
**Why**: React DOM 16.5 changed an unstable API that `react-native-web` depends upon. Namely,  `EventPluginHub` was removed (see [#1096](https://github.com/necolas/react-native-web/issues/1096) & (#506dba9)[https://github.com/necolas/react-native-web/commit/506dba933ce69830feaace08aee85c38ce3e59fb]). This was addressed in 16.5.1, and react-native-web 0.9.0.
I see that this library is already using ^0.9.x of react-native-web, so I figured it'd make sense to update the `react-primitives` dependency that is now also using ^0.9.x.

<!-- How were these changes implemented? -->
**How**: I cloned the repo, updated the dependencies, and ran the tests.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation - N/A
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
