### PR TITLE
Add test for inheriting shouldForwardProp

### DIFF
--- a/packages/react-emotion/test/__snapshots__/prop-filtering.test.js.snap
+++ b/packages/react-emotion/test/__snapshots__/prop-filtering.test.js.snap
@@ -103,3 +103,24 @@ exports[`prop filtering on composed styled components that are string tags 1`] =
   hello world
 </a>
 `;
+
+exports[`shouldForwardProp should get inherited for wrapped styled components 1`] = `
+Array [
+  .emotion-0 {
+  background-color: red;
+}
+
+<div
+    className="emotion-0 emotion-1"
+    id="test-1"
+  />,
+  .emotion-0 {
+  background-color: green;
+}
+
+<div
+    className="emotion-0 emotion-1"
+    id="test-2"
+  />,
+]
+`;

--- a/packages/react-emotion/test/prop-filtering.test.js
+++ b/packages/react-emotion/test/prop-filtering.test.js
@@ -48,6 +48,26 @@ test('custom shouldForwardProp works', () => {
   expect(tree).toMatchSnapshot()
 })
 
+test('shouldForwardProp should get inherited for wrapped styled components', () => {
+  const Div1 = styled('div', {
+    shouldForwardProp: prop => prop !== 'color'
+  })`
+    background-color: ${({ color }) => color};
+  `
+
+  const Div2 = styled(Div1)``
+
+  const tree = renderer
+    .create(
+      <>
+        <Div1 color="red" id="test-1" />
+        <Div2 color="green" id="test-2" />
+      </>
+    )
+    .toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
 test('prop filtering', () => {
   const Link = styled.a`
     color: green;


### PR DESCRIPTION
Test for this changed behaviour - https://github.com/emotion-js/emotion/pull/843/files#diff-a4094d9c0107dddca9d6947c95035c51R46

Previously the shouldForwardProp were only composed, but not inherited - which was imho a bug in the initial implementation of this feature.