### PR TITLE
fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Frequently viewed docs:
 
 - [Introduction](https://emotion.sh/docs/introduction)
 - [Install](https://emotion.sh/docs/install)
-- [CSS](https://emotion.sh/docs/css-prop)
+- [CSS Prop](https://emotion.sh/docs/css-prop)
 - [Styled Components](https://emotion.sh/docs/styled)
 - [Composition](https://emotion.sh/docs/composition)
 - [Nested Selectors](https://emotion.sh/docs/nested)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Frequently viewed docs:
 
 - [Introduction](https://emotion.sh/docs/introduction)
 - [Install](https://emotion.sh/docs/install)
-- [CSS](https://emotion.sh/docs/css)
+- [CSS](https://emotion.sh/docs/css-prop)
 - [Styled Components](https://emotion.sh/docs/styled)
 - [Composition](https://emotion.sh/docs/composition)
 - [Nested Selectors](https://emotion.sh/docs/nested)

--- a/packages/emotion/README.md
+++ b/packages/emotion/README.md
@@ -23,7 +23,7 @@ Frequently viewed docs:
 
 - [Introduction](https://emotion.sh/docs/introduction)
 - [Install](https://emotion.sh/docs/install)
-- [CSS](https://emotion.sh/docs/css)
+- [CSS](https://emotion.sh/docs/css-prop)
 - [Styled Components](https://emotion.sh/docs/styled)
 - [Composition](https://emotion.sh/docs/composition)
 - [Nested Selectors](https://emotion.sh/docs/nested)

--- a/packages/emotion/README.md
+++ b/packages/emotion/README.md
@@ -23,7 +23,7 @@ Frequently viewed docs:
 
 - [Introduction](https://emotion.sh/docs/introduction)
 - [Install](https://emotion.sh/docs/install)
-- [CSS](https://emotion.sh/docs/css-prop)
+- [CSS Prop](https://emotion.sh/docs/css-prop)
 - [Styled Components](https://emotion.sh/docs/styled)
 - [Composition](https://emotion.sh/docs/composition)
 - [Nested Selectors](https://emotion.sh/docs/nested)


### PR DESCRIPTION
**What**: fix a broken link in the [emotion documentation](https://emotion.sh/docs/emotion)
CSS Link is broken

**Why**:
We got this message : `You just hit a route that doesn't exist... the sadness.😢`, and i don't want anybody to be sad!

**How**: just fix the link :)

