### PR TITLE
Add dirname value to babel plugin labelFormat option

### DIFF
--- a/packages/babel-plugin-emotion/README.md
+++ b/packages/babel-plugin-emotion/README.md
@@ -224,6 +224,7 @@ Allowed values:
 
 - `[local]` - the name of the variable the result of the `css` or `styled` expression is assigned to.
 - `[filename]` - name of the file (without extension) where `css` or `styled` expression is located.
+- `[dirname]` - name of the directory containing the file where `css` or `styled` expression is located.
 
 This format only affects the label property of the expression, meaning that the `css` prefix and hash will
 be prepended automatically.

--- a/packages/babel-plugin-emotion/__tests__/__snapshots__/css-requires-options.js.snap
+++ b/packages/babel-plugin-emotion/__tests__/__snapshots__/css-requires-options.js.snap
@@ -39,6 +39,19 @@ exports[`babel css inline babel 6 custom instance relative complex 1`] = `
 });"
 `;
 
+exports[`babel css inline babel 6 label format with dirname, filename, and local 1`] = `
+"import { css as _css } from 'emotion';
+
+let cls = /*#__PURE__*/_css(process.env.NODE_ENV === 'production' ? {
+    name: '1azqn5t-my-css-__tests__-css-requires-options-cls',
+    styles: 'color:hotpink;label:my-css-__tests__-css-requires-options-cls;'
+} : {
+    name: '1azqn5t-my-css-__tests__-css-requires-options-cls',
+    styles: 'color:hotpink;label:my-css-__tests__-css-requires-options-cls;',
+    map: '/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNzcy1yZXF1aXJlcy1vcHRpb25zLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVjIiwiZmlsZSI6ImNzcy1yZXF1aXJlcy1vcHRpb25zLmpzIiwic291cmNlc0NvbnRlbnQiOlsiXG4gICAgaW1wb3J0IHtjc3N9IGZyb20gJ2Vtb3Rpb24nXG4gICAgbGV0IGNscyA9IGNzcyh7Y29sb3I6J2hvdHBpbmsnfSlcbiAgICAiXX0= */'
+});"
+`;
+
 exports[`babel css inline babel 6 label format with filename and local 1`] = `
 "import { css as _css } from 'emotion';
 
@@ -117,6 +130,21 @@ _css(process.env.NODE_ENV === \\"production\\" ? {
   name: \\"1lrxbo5\\",
   styles: \\"color:hotpink;\\",
   map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNzcy1yZXF1aXJlcy1vcHRpb25zLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVPIiwiZmlsZSI6ImNzcy1yZXF1aXJlcy1vcHRpb25zLmpzIiwic291cmNlc0NvbnRlbnQiOlsiXG4gICAgaW1wb3J0IHtjc3MgYXMgbG9sfSBmcm9tICcuLi9fX3Rlc3RzX18vbXktZW1vdGlvbi1pbnN0YW5jZSdcbiAgICBsb2xgY29sb3I6aG90cGluaztgIl19 */\\"
+});"
+`;
+
+exports[`babel css inline babel 7 label format with dirname, filename, and local 1`] = `
+"import { css as _css } from \\"emotion\\";
+
+let cls =
+/*#__PURE__*/
+_css(process.env.NODE_ENV === \\"production\\" ? {
+  name: \\"1azqn5t-my-css-__tests__-css-requires-options-cls\\",
+  styles: \\"color:hotpink;label:my-css-__tests__-css-requires-options-cls;\\"
+} : {
+  name: \\"1azqn5t-my-css-__tests__-css-requires-options-cls\\",
+  styles: \\"color:hotpink;label:my-css-__tests__-css-requires-options-cls;\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNzcy1yZXF1aXJlcy1vcHRpb25zLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVjIiwiZmlsZSI6ImNzcy1yZXF1aXJlcy1vcHRpb25zLmpzIiwic291cmNlc0NvbnRlbnQiOlsiXG4gICAgaW1wb3J0IHtjc3N9IGZyb20gJ2Vtb3Rpb24nXG4gICAgbGV0IGNscyA9IGNzcyh7Y29sb3I6J2hvdHBpbmsnfSlcbiAgICAiXX0= */\\"
 });"
 `;
 

--- a/packages/babel-plugin-emotion/__tests__/css-requires-options.js
+++ b/packages/babel-plugin-emotion/__tests__/css-requires-options.js
@@ -38,6 +38,18 @@ const inline = {
     filename: __filename
   },
 
+  'label format with dirname, filename, and local': {
+    code: `
+    import {css} from 'emotion'
+    let cls = css({color:'hotpink'})
+    `,
+    opts: {
+      labelFormat: 'my-css-[dirname]-[filename]-[local]',
+      autoLabel: true
+    },
+    filename: __filename
+  },
+
   'custom instance': {
     code: `
     import {css as lol} from 'my-emotion-instance'

--- a/packages/babel-plugin-emotion/src/utils/label.js
+++ b/packages/babel-plugin-emotion/src/utils/label.js
@@ -11,15 +11,17 @@ function getLabel(
   if (!labelFormat) return identifierName.trim()
 
   const parsedPath = nodePath.parse(filename)
+  let localDirname = nodePath.basename(parsedPath.dir)
   let localFilename = parsedPath.name
   if (localFilename === 'index') {
-    localFilename = nodePath.basename(parsedPath.dir)
+    localFilename = localDirname
   }
   localFilename = localFilename.replace('.', '-')
 
   return labelFormat
     .replace(/\[local\]/gi, identifierName.trim())
     .replace(/\[filename\]/gi, localFilename)
+    .replace(/\[dirname\]/gi, localDirname)
 }
 
 export function getLabelFromPath(path: *, state: *, t: *) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

A new value to use in the `labelFormat` option for the babel plugin.

<!-- Why are these changes necessary? -->
**Why**:

In our project most styles end up in a file called `styles.js` or `styles.ts`. It would be nice to have the flexibility to name our classes after the directory when in development.

<!-- How were these changes implemented? -->
**How**:

Vim.
<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
