### PR TITLE
Remove --exact from versioning script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "flow": "flow",
     "flow:check": "flow check",
     "postinstall": "opencollective postinstall",
-    "version-packages": "lerna version --preid=beta --exact"
+    "version-packages": "lerna version --preid=beta"
   },
   "resolutions": {
     "**/react": "16.5.2",


### PR DESCRIPTION
Seems like it is a good fit for prereleases but when doing stable releases it's imho a worse choice. It might require preparing 2 versioning scripts though - one for prereleases and one for stable ones. WDYT?