### PR TITLE
Fix styled shorthand transform

### DIFF
--- a/packages/babel-plugin-emotion/__tests__/__snapshots__/styled.js.snap
+++ b/packages/babel-plugin-emotion/__tests__/__snapshots__/styled.js.snap
@@ -383,6 +383,25 @@ _styled.View(\\"color:hotpink;\\");
 _styled.View(\\"\\");"
 `;
 
+exports[`@emotion/babel-plugin-core styled no-call 1`] = `
+"import styled from '@emotion/styled'
+
+export let thing = styled
+
+console.log(styled)
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _styled from \\"@emotion/styled\\";
+export let thing =
+/*#__PURE__*/
+_styled;
+console.log(
+/*#__PURE__*/
+_styled);"
+`;
+
 exports[`@emotion/babel-plugin-core styled no-import 1`] = `
 "import '@emotion/styled'
 

--- a/packages/babel-plugin-emotion/__tests__/styled-macro/__fixtures__/no-call.js
+++ b/packages/babel-plugin-emotion/__tests__/styled-macro/__fixtures__/no-call.js
@@ -1,0 +1,5 @@
+import styled from '@emotion/styled/macro'
+
+export let thing = styled
+
+console.log(styled)

--- a/packages/babel-plugin-emotion/__tests__/styled-macro/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-emotion/__tests__/styled-macro/__snapshots__/index.js.snap
@@ -381,6 +381,25 @@ styled.View\`
 styled.View({});"
 `;
 
+exports[`@emotion/styled.macro no-call 1`] = `
+"import styled from '@emotion/styled/macro'
+
+export let thing = styled
+
+console.log(styled)
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _styled from \\"@emotion/styled\\";
+export let thing =
+/*#__PURE__*/
+_styled;
+console.log(
+/*#__PURE__*/
+_styled);"
+`;
+
 exports[`@emotion/styled.macro no-import 1`] = `
 "import '@emotion/styled'
 

--- a/packages/babel-plugin-emotion/src/index.js
+++ b/packages/babel-plugin-emotion/src/index.js
@@ -8,14 +8,17 @@ import { getSourceMap, getStyledOptions } from './utils'
 
 let webStyledMacro = createStyledMacro({
   importPath: '@emotion/styled-base',
+  originalImportPath: '@emotion/styled',
   isWeb: true
 })
 let nativeStyledMacro = createStyledMacro({
   importPath: '@emotion/native',
+  originalImportPath: '@emotion/native',
   isWeb: false
 })
 let primitivesStyledMacro = createStyledMacro({
   importPath: '@emotion/primitives',
+  originalImportPath: '@emotion/primitives',
   isWeb: false
 })
 

--- a/packages/babel-plugin-emotion/src/styled-macro.js
+++ b/packages/babel-plugin-emotion/src/styled-macro.js
@@ -78,11 +78,7 @@ export let createStyledMacro = ({
         } else {
           reference.replaceWith(getOriginalImportPathStyledIdentifier())
         }
-        if (
-          reference.parentPath &&
-          reference.parentPath.parentPath &&
-          reference.parentPath.parentPath
-        ) {
+        if (reference.parentPath && reference.parentPath.parentPath) {
           const styledCallPath = reference.parentPath.parentPath
           let { node } = transformExpressionWithStyles({
             path: styledCallPath,

--- a/packages/styled/macro.js
+++ b/packages/styled/macro.js
@@ -1,4 +1,5 @@
 module.exports = require('babel-plugin-emotion').macros.createStyledMacro({
   importPath: '@emotion/styled-base',
+  originalImportPath: '@emotion/styled',
   isWeb: true
 })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Fix styled shorthand transform so if styled is not used a function call or .div and etc. the import won't be changed to `@emotion/styled-base`
<!-- Why are these changes necessary? -->
**Why**:
I think this will fix #1056 
<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
