### PR TITLE
Update Type Definition 👉 Support css prop

### DIFF
--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -82,7 +82,7 @@ export function ClassNames<Theme = any>(
 ): ReactElement<any>
 
 declare module 'react' {
-  interface DOMAttributes<T> {
+  interface HTMLAttributes<T> {
     css?: InterpolationWithTheme<any>
   }
 }


### PR DESCRIPTION
**What**:

Update the type def for `@emotion/core` to support the `css` prop as html elements.

**Why**:

The previous approach doesn't work anymore, use `HTMLAttributes` instead.

**How**:

Use `HTMLAttributes` instead of `DOMAttributes`.

**Checklist**:

- [ ] Documentation **N/A**
- [x] Tests
- [x] Code complete

Before:

![image](https://user-images.githubusercontent.com/232559/49940954-6fb48b80-fee1-11e8-8968-fe48f1227fe2.png)

After:

![image](https://user-images.githubusercontent.com/232559/49940978-85c24c00-fee1-11e8-91cf-36ef8ce49e62.png)
