### PR TITLE
Fix out of bounds access in @emotion/serialize

### DIFF
--- a/packages/serialize/src/index.js
+++ b/packages/serialize/src/index.js
@@ -314,7 +314,7 @@ export const serializeStyles = function(
       args[i],
       styles.charCodeAt(styles.length - 1) === 46
     )
-    if (stringMode) {
+    if (stringMode && strings.length > i) {
       styles += strings[i]
     }
   }


### PR DESCRIPTION
This is an attempt to fix #1119 

I havent yet time to test if this even works, just sending PR to trigger CI as I dont have time right now to check it on my machine. If this won't break anything I'll add a test case for the (hopefully) fixed issue later.

There was similar guard in v9 - https://github.com/emotion-js/emotion/blob/7c582301317cd9c0038a13a118456e798ffcadf8/packages/create-emotion/src/index.js#L270 . I've chosen the length check as supposedly out of bounds access should be avoided for perf reasons.