### PR TITLE
fix(TS): allow CSSObject on @emotion/styled

### DIFF
--- a/packages/styled-base/types/index.d.ts
+++ b/packages/styled-base/types/index.d.ts
@@ -12,19 +12,18 @@
  * a style of that component.
  */
 
-import { ComponentSelector, Interpolation } from '@emotion/serialize'
+import { ComponentSelector, Interpolation, CSSObject } from '@emotion/serialize'
 import * as React from 'react'
 
 import { Omit, Overwrapped, PropsOf } from './helper'
 
 export {
   ArrayInterpolation,
-  CSSObject,
   FunctionInterpolation,
   ObjectInterpolation
 } from '@emotion/serialize'
 
-export { ComponentSelector, Interpolation }
+export { ComponentSelector, Interpolation, CSSObject }
 
 type JSXInEl = JSX.IntrinsicElements
 
@@ -72,7 +71,7 @@ export interface CreateStyledComponentBase<
       ReactClassPropKeys
     > = Omit<InnerProps & ExtraProps, ReactClassPropKeys>
   >(
-    template: TemplateStringsArray,
+    template: TemplateStringsArray | CSSObject,
     ...styles: Array<Interpolation<WithTheme<StyleProps, Theme>>>
   ): StyledComponent<InnerProps, StyleProps, Theme>
 }

--- a/packages/styled-base/types/tests.tsx
+++ b/packages/styled-base/types/tests.tsx
@@ -39,7 +39,7 @@ const Button0 = styled('button')`
 const Button1 = styled('button')({
   color: 'blue'
 })
-const Button2 = styled.button({
+const Button1Dot = styled.button({
   color: 'blue'
 })
 ;<div>
@@ -51,8 +51,8 @@ const Button2 = styled.button({
   <Button1 type="button" />
 </div>
 ;<div>
-  <Button2 />
-  <Button2 type="button" />
+  <Button1Dot />
+  <Button1Dot type="button" />
 </div>
 
 const Input0 = styled('input', {

--- a/packages/styled-base/types/tests.tsx
+++ b/packages/styled-base/types/tests.tsx
@@ -39,9 +39,6 @@ const Button0 = styled('button')`
 const Button1 = styled('button')({
   color: 'blue'
 })
-const Button1Dot = styled.button({
-  color: 'blue'
-})
 ;<div>
   <Button0 />
   <Button0 type="button" />
@@ -49,10 +46,6 @@ const Button1Dot = styled.button({
 ;<div>
   <Button1 />
   <Button1 type="button" />
-</div>
-;<div>
-  <Button1Dot />
-  <Button1Dot type="button" />
 </div>
 
 const Input0 = styled('input', {

--- a/packages/styled-base/types/tests.tsx
+++ b/packages/styled-base/types/tests.tsx
@@ -48,6 +48,11 @@ const Button1 = styled('button')({
   <Button1 type="button" />
 </div>
 
+// $ExpectError
+const BadButton0 = styled('button')({ bad: 'value' })
+// $ExpectError
+const BadButton1 = styled('button')(() => ({ bad: 'value' }))
+
 const Input0 = styled('input', {
   label: 'mystyle'
 })`

--- a/packages/styled-base/types/tests.tsx
+++ b/packages/styled-base/types/tests.tsx
@@ -39,6 +39,9 @@ const Button0 = styled('button')`
 const Button1 = styled('button')({
   color: 'blue'
 })
+const Button2 = styled.button({
+  color: 'blue'
+})
 ;<div>
   <Button0 />
   <Button0 type="button" />
@@ -46,6 +49,10 @@ const Button1 = styled('button')({
 ;<div>
   <Button1 />
   <Button1 type="button" />
+</div>
+;<div>
+  <Button2 />
+  <Button2 type="button" />
 </div>
 
 const Input0 = styled('input', {

--- a/packages/styled/types/tests.tsx
+++ b/packages/styled/types/tests.tsx
@@ -21,3 +21,18 @@ ui = (
     <Button1 type="button" />
   </div>
 )
+
+const Button2 = styled.button<{ size?: 'md' | 'sm' }>(
+  ({ size }) => (size === 'md' ? { fontSize: 15 } : { fontSize: 10 })
+)
+ui = (
+  <div>
+    <Button2 />
+    <Button2 size="sm" />
+  </div>
+)
+
+// $ExpectError
+const BadButton0 = styled.button({ bad: 'value' })
+// $ExpectError
+const BadButton1 = styled.button(() => ({ bad: 'value' }))

--- a/packages/styled/types/tests.tsx
+++ b/packages/styled/types/tests.tsx
@@ -1,4 +1,7 @@
+import * as React from 'react'
 import styled from '@emotion/styled'
+
+let ui: React.ReactElement<any>
 
 // $ExpectType CreateStyledComponentIntrinsic<"a", {}, any>
 styled.a
@@ -8,3 +11,13 @@ styled.body
 styled.div
 // $ExpectType CreateStyledComponentIntrinsic<"svg", {}, any>
 styled.svg
+
+const Button1 = styled.button({
+  color: 'blue'
+})
+ui = (
+  <div>
+    <Button1 />
+    <Button1 type="button" />
+  </div>
+)


### PR DESCRIPTION
**What**: This allows: `styled.div(/* this can be an object /*)`

<!-- Why are these changes necessary? -->
**Why**: Because that API is supported so the typings should allow for it.

<!-- How were these changes implemented? -->
**How**: Tried it locally and it typed fine (even helped me fix an issue I had), so I just made this change in the github editor.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
