### PR TITLE
Flow fix: allow weak type checks in `classnames`

### DIFF
--- a/packages/create-emotion/src/index.js
+++ b/packages/create-emotion/src/index.js
@@ -37,8 +37,10 @@ type CreateStyles<ReturnValue> = (...args: Interpolations) => ReturnValue
 type ClassNameArg =
   | string
   | boolean
-  | { [key: string]: boolean }
+  | { [key: string]: boolean | void | null }
   | Array<ClassNameArg>
+  | void
+  | null
 
 declare class StyleSheet {
   insert(rule: string): void;


### PR DESCRIPTION
The function `classnames` checks for truthy and falsy values (`== null`). This avoids a lot of type checking and also is in line with how the original classnames code is typed: https://github.com/JedWatson/classnames/blob/master/index.d.ts#L1