### PR TITLE
Add new react primitives accessibility props

### DIFF
--- a/packages/primitives/src/test-props.js
+++ b/packages/primitives/src/test-props.js
@@ -8,6 +8,8 @@ const forwardableProps = {
   accessibilityElementsHidden: true,
   accessibilityLabel: true,
   accessibilityLiveRegion: true,
+  accessibilityRole: true,
+  accessibilityStates: true,
   accessibilityTraits: true,
   accessibilityViewIsModal: true,
   accessible: true,


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

react-native / react-native web has 2 new accessibility props to provide better cross platform support. See https://facebook.github.io/react-native/docs/accessibility#accessibilityrole-ios-android.

<!-- Why are these changes necessary? -->
**Why**:

Without this these props are not forwarded to the underlying View component.

<!-- How were these changes implemented? -->
**How**:

Add the 2 new props to the `forwardableProps` mapping.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A (haven't found existing tests related to props forwarding)
- [x] Code complete
