### PR TITLE
Fixing 'Cannot read property 'key' of undefined' error

### DIFF
--- a/packages/core/src/context.js
+++ b/packages/core/src/context.js
@@ -51,7 +51,7 @@ if (!isBrowser) {
     return (props: Props) => (
       <EmotionCacheContext.Consumer>
         {context => {
-          if (context === null) {
+          if (!context) {
             return (
               <BasicProvider>
                 {newContext => {


### PR DESCRIPTION
**What**:
Fixing "Cannot read property 'key' of undefined" error when context provider's cache value is undefined

**Why**:
I am facing it in my project

> TypeError: Cannot read property 'key' of undefined
    at Object.insertStyles (/Users/user/misc/code/mobile/web/node_modules/@emotion/utils/dist/utils.cjs.dev.js:18:25)
    at render (/Users/user/misc/code/mobile/web/node_modules/@emotion/core/dist/core.cjs.dev.js:110:21)
    at /Users/user/misc/code/mobile/web/node_modules/@emotion/core/dist/core.cjs.dev.js:151:10
    at Object.children (/Users/user/misc/code/mobile/web/node_modules/@emotion/core/dist/core.cjs.dev.js:71:18)
    at ReactDOMServerRenderer.render (/Users/user/misc/code/mobile/web/node_modules/react-wildcat-handoff/node_modules/react-dom/cjs/react-dom-server.node.development.js:2446:55)
    at ReactDOMServerRenderer.read (/Users/user/misc/code/mobile/web/node_modules/react-wildcat-handoff/node_modules/react-dom/cjs/react-dom-server.node.development.js:2307:19)
    at Object.renderToString (/Users/user/misc/code/mobile/web/node_modules/react-wildcat-handoff/node_modules/react-dom/cjs/react-dom-server.node.development.js:2679:25)
    at serverRenderPromiseResult (/Users/user/misc/code/mobile/web/node_modules/react-wildcat-handoff/src/utils/serverRender.js:103:72)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)

**How**:
One-line change: null check replaced by not false check

**Checklist**
- [N/A] Documentation
- [N/A ] Tests
- [x] Code complete