### PR TITLE
[cache] Add ignore flag for the unreliable selectors warning

### DIFF
--- a/packages/cache/src/index.js
+++ b/packages/cache/src/index.js
@@ -201,21 +201,30 @@ let createCache = (options?: Options): EmotionCache => {
 
     stylis.use((context, content, selectors) => {
       switch (context) {
-        case 2: {
-          for (let i = 0, len = selectors.length; len > i; i++) {
-            // :last-child isn't included here since it's safe
-            // because a style element will never be the last element
-            let match = selectors[i].match(/:(first|nth|nth-last)-child/)
-            if (match !== null) {
-              console.error(
-                `The pseudo class "${
-                  match[0]
-                }" is potentially unsafe when doing server-side rendering. Try changing it to "${
-                  match[1]
-                }-of-type"`
+        case -1: {
+          const flag =
+            'emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason'
+          const unsafePseudoClasses = content.match(
+            /(:first|:nth|:nth-last)-child/g
+          )
+
+          if (unsafePseudoClasses) {
+            unsafePseudoClasses.forEach(unsafePseudoClass => {
+              const ignoreRegExp = new RegExp(
+                `${unsafePseudoClass}.*\\/\\* ${flag} \\*\\/`
               )
-            }
+              const ignore = ignoreRegExp.test(content)
+
+              if (unsafePseudoClass && !ignore) {
+                console.error(
+                  `The pseudo class "${unsafePseudoClass}" is potentially unsafe when doing server-side rendering. Try changing it to "${
+                    unsafePseudoClass.split('-child')[0]
+                  }-of-type".`
+                )
+              }
+            })
           }
+
           break
         }
       }

--- a/packages/core/__tests__/__snapshots__/warnings.js.snap
+++ b/packages/core/__tests__/__snapshots__/warnings.js.snap
@@ -40,7 +40,213 @@ exports[`does warn when invalid values are passed for the content property 2`] =
 />
 `;
 
-exports[`does warn when using :first-child 1`] = `
+exports[`global with css prop 1`] = `null`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":first-child /* [flag] */" in a style object 1`] = `
+.emotion-0:first-child {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":first-child /* [flag] */" in a style string 1`] = `
+.emotion-0:first-child {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":first-child :nth-child(3) /* [flag] */" in a style object 1`] = `
+.emotion-0:first-child :nth-child(3) {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":first-child :nth-child(3) /* [flag] */" in a style string 1`] = `
+.emotion-0:first-child :nth-child(3) {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":first-child span /* [flag] */" in a style object 1`] = `
+.emotion-0:first-child span {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":first-child span /* [flag] */" in a style string 1`] = `
+.emotion-0:first-child span {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":first-child, :nth-child(3) /* [flag] */" in a style object 1`] = `
+.emotion-0:first-child,
+.emotion-0:nth-child(3) {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":first-child, :nth-child(3) /* [flag] */" in a style string 1`] = `
+.emotion-0:first-child,
+.emotion-0:nth-child(3) {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":first-child, span /* [flag] */" in a style object 1`] = `
+.emotion-0:first-child,
+.emotion-0 span {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":first-child, span /* [flag] */" in a style string 1`] = `
+.emotion-0:first-child,
+.emotion-0 span {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":first-child:nth-child(3) /* [flag] */" in a style object 1`] = `
+.emotion-0:first-child:nth-child(3) {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":first-child:nth-child(3) /* [flag] */" in a style string 1`] = `
+.emotion-0:first-child:nth-child(3) {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":not(:first-child) /* [flag] */" in a style object 1`] = `
+.emotion-0:not(:first-child) {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":not(:first-child) /* [flag] */" in a style string 1`] = `
+.emotion-0:not(:first-child) {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":not(:nth-child(3)) /* [flag] */" in a style object 1`] = `
+.emotion-0:not(:nth-child(3)) {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":not(:nth-child(3)) /* [flag] */" in a style string 1`] = `
+.emotion-0:not(:nth-child(3)) {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":nth-child(3) /* [flag] */" in a style object 1`] = `
+.emotion-0:nth-child(3) {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":nth-child(3) /* [flag] */" in a style string 1`] = `
+.emotion-0:nth-child(3) {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":nth-last-child(7) /* [flag] */" in a style object 1`] = `
+.emotion-0:nth-last-child(7) {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes does not warn when using with flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":nth-last-child(7) /* [flag] */" in a style string 1`] = `
+.emotion-0:nth-last-child(7) {
+  color: rebeccapurple;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes warns when using without flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":first-child" 1`] = `
 .emotion-0:first-child {
   color: hotpink;
 }
@@ -50,7 +256,27 @@ exports[`does warn when using :first-child 1`] = `
 />
 `;
 
-exports[`does warn when using :nth-child(3) 1`] = `
+exports[`unsafe pseudo classes warns when using without flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":not(:first-child)" 1`] = `
+.emotion-0:not(:first-child) {
+  color: hotpink;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes warns when using without flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":not(:nth-child(3))" 1`] = `
+.emotion-0:not(:nth-child(3)) {
+  color: hotpink;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`unsafe pseudo classes warns when using without flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":nth-child(3)" 1`] = `
 .emotion-0:nth-child(3) {
   color: hotpink;
 }
@@ -60,7 +286,7 @@ exports[`does warn when using :nth-child(3) 1`] = `
 />
 `;
 
-exports[`does warn when using :nth-last-child(7) 1`] = `
+exports[`unsafe pseudo classes warns when using without flag: /* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */ ":nth-last-child(7)" 1`] = `
 .emotion-0:nth-last-child(7) {
   color: hotpink;
 }
@@ -69,5 +295,3 @@ exports[`does warn when using :nth-last-child(7) 1`] = `
   className="emotion-0"
 />
 `;
-
-exports[`global with css prop 1`] = `null`;

--- a/packages/core/__tests__/warnings.js
+++ b/packages/core/__tests__/warnings.js
@@ -50,29 +50,84 @@ it('does warn when invalid values are passed for the content property', () => {
   })
 })
 
-let unsafePseudoClasses = [
-  ':first-child',
-  ':nth-child(3)',
-  ':nth-last-child(7)'
-]
+describe('unsafe pseudo classes', () => {
+  const ignoreSsrFlag =
+    '/* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */'
 
-unsafePseudoClasses.forEach(pseudoClass => {
-  it('does warn when using ' + pseudoClass, () => {
-    const style = css`
-      ${pseudoClass} {
-        color: hotpink;
+  describe(`warns when using without flag: ${ignoreSsrFlag}`, () => {
+    const unsafePseudoClasses = [
+      ':first-child',
+      ':not(:first-child)',
+      ':nth-child(3)',
+      ':not(:nth-child(3))',
+      ':nth-last-child(7)'
+    ]
+
+    unsafePseudoClasses.forEach(pseudoClass => {
+      it(`"${pseudoClass}"`, () => {
+        const style = css`
+          ${pseudoClass} {
+            color: hotpink;
+          }
+        `
+        const match = (pseudoClass.match(/(:first|:nth|:nth-last)-child/): any)
+        expect(match).not.toBeNull()
+        expect(renderer.create(<div css={style} />).toJSON()).toMatchSnapshot()
+        expect(console.error).toBeCalledWith(
+          `The pseudo class "${
+            match[0]
+          }" is potentially unsafe when doing server-side rendering. Try changing it to "${
+            match[1]
+          }-of-type".`
+        )
+      })
+    })
+  })
+
+  describe(`does not warn when using with flag: ${ignoreSsrFlag}`, () => {
+    const ignoredUnsafePseudoClasses = [
+      `:first-child ${ignoreSsrFlag}`,
+      `:not(:first-child) ${ignoreSsrFlag}`,
+      `:nth-child(3) ${ignoreSsrFlag}`,
+      `:not(:nth-child(3)) ${ignoreSsrFlag}`,
+      `:nth-last-child(7) ${ignoreSsrFlag}`,
+      `:first-child span ${ignoreSsrFlag}`,
+      `:first-child, span ${ignoreSsrFlag}`,
+      `:first-child :nth-child(3) ${ignoreSsrFlag}`,
+      `:first-child, :nth-child(3) ${ignoreSsrFlag}`,
+      `:first-child:nth-child(3) ${ignoreSsrFlag}`
+    ]
+
+    ignoredUnsafePseudoClasses.forEach(pseudoClass => {
+      const styles = {
+        string: css`
+          ${pseudoClass} {
+            color: rebeccapurple;
+          }
+        `,
+        object: {
+          [pseudoClass]: {
+            color: 'rebeccapurple'
+          }
+        }
       }
-    `
-    let match = (pseudoClass.match(/:(first|nth|nth-last)-child/): any)
-    expect(match).not.toBeNull()
-    expect(renderer.create(<div css={style} />).toJSON()).toMatchSnapshot()
-    expect(console.error).toBeCalledWith(
-      `The pseudo class "${
-        match[0]
-      }" is potentially unsafe when doing server-side rendering. Try changing it to "${
-        match[1]
-      }-of-type"`
-    )
+
+      Object.keys(styles).forEach(type => {
+        it(`"${pseudoClass.replace(
+          /\/\* \S+ \*\//g,
+          '/* [flag] */'
+        )}" in a style ${type}`, () => {
+          const match = (pseudoClass.match(
+            /(:first|:nth|:nth-last)-child/
+          ): any)
+          expect(match).not.toBeNull()
+          expect(
+            renderer.create(<div css={styles[type]} />).toJSON()
+          ).toMatchSnapshot()
+          expect(console.error).not.toBeCalled()
+        })
+      })
+    })
   })
 })
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
1. Add the ability to ignore a selector's "potentially unsafe when doing server-side rendering" warning message by adding `/* emotion-disable-server-rendering-unsafe-selector-warning-please-do-not-use-this-the-warning-exists-for-a-reason */` after the pseudo class
    - The flag is intentionally verbose (see [comments below](https://github.com/emotion-js/emotion/pull/1209#issuecomment-462035404))
2. Add tests for above

<!-- Why are these changes necessary? -->
**Why**:

The inability to disable or ignore these warnings is an issue for some (#1105). Until a decision is made on #1178, it is likely worthwhile to provide a way to ignore them. This seemed like a lightweight way of doing so, that is nicely co-located with the existing warning logic.

<!-- How were these changes implemented? -->
**How**:

Modified the implementation of the stylis plugin used for the warning to check for the presence of the flag.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation — Maintainers wish for this flag to be hard to discover, so docs were intentionally not updated
- [x] Tests
- [x] Code complete

<!-- feel free to add additional comments -->
