### PR TITLE
Update readme to clarify that jsx comment and unused import can be removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ let SomeComponent = props => {
 
 ### Do I Need To Use the Babel Plugin?
 
-The babel plugin is not required, but enables some optimizations and customizations that could be beneficial for your project.
+The babel plugin is not required, but it removes the need for both the `/** @jsx jsx */` comment and the unused jsx import, and enables some optimizations and customizations that could be beneficial for your project.
 
 Look here 👉 _[emotion babel plugin feature table and documentation](https://github.com/emotion-js/emotion/tree/master/packages/babel-plugin-emotion)_
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Update readme to clarify/assure that the jsx comment and unused import can be removed

<!-- Why are these changes necessary? -->
**Why**: Spoke with a seasoned dev evaluating switching to SC because "emotion ruined their api" and pointed to the Quickstart code sample. Also this [tweet](https://twitter.com/larsgraubner/status/1095952530180329474) from another developer rightfully frustrated just enough to decide against this. I myself initially was worried about the same thing and took a bit of clicking around to confirm that the scope of change isn't as large as I was worried it'd be

Also in https://github.com/emotion-js/emotion/issues/1059#issuecomment-455013709
> Maybe it's not the right place to ask, but, in v10, is it possible to get rid of `jsx` import?

The jsx pragma cruft is unnecessarily scaring people away

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation NA
- [ ] Tests NA
- [ ] Code complete NA

<!-- feel free to add additional comments -->

Somewhat related to https://github.com/emotion-js/emotion/issues/1059