### PR TITLE
Properly type serializeStyles for Typescript

### DIFF
--- a/packages/serialize/types/index.d.ts
+++ b/packages/serialize/types/index.d.ts
@@ -79,7 +79,7 @@ export type Interpolation<MP = undefined> =
   | Equal<MP, undefined, never, FunctionInterpolation<MP>>
 
 export function serializeStyles<MP>(
+  args: Array<TemplateStringsArray | Interpolation<MP>>, 
   registered: RegisteredCache,
-  args: Array<TemplateStringsArray | Interpolation<MP>>,
   mergedProps?: MP
 ): SerializedStyles


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

The first two arguments of serializeStyles are switched in the Typescript types. Should be:
https://github.com/emotion-js/emotion/blob/d3a34b38c60de6680db00efb366894863a54058e/packages/serialize/src/index.js#L289-L293

<!-- Why are these changes necessary? -->
**Why**:

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Code complete

<!-- feel free to add additional comments -->
