### PR TITLE
Adds @babel/core as peer dependency of babel-preset-css-prop

### DIFF
--- a/packages/babel-preset-css-prop/package.json
+++ b/packages/babel-preset-css-prop/package.json
@@ -12,6 +12,9 @@
     "babel-plugin-emotion": "^10.0.7",
     "object-assign": "^4.1.1"
   },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
**What**:

`@babel/core` is added as a peer dependency.

**Why**:

`@babel/plugin-transform-react-jsx` has a peer dependency on `@babel/core`, but this package doesn't provide it - which is [invalid](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0).

**Checklist**:
- [ ] Documentation - n/a
- [ ] Tests - n/a
- [ ] Code complete - n/a
