### PR TITLE
Adds @babel/core as peer dependency of babel-plugin-jsx-pragmatic

### DIFF
--- a/packages/babel-plugin-jsx-pragmatic/package.json
+++ b/packages/babel-plugin-jsx-pragmatic/package.json
@@ -9,6 +9,9 @@
   "dependencies": {
     "@babel/plugin-syntax-jsx": "^7.2.0"
   },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
+  },
   "files": [
     "src",
     "dist"


### PR DESCRIPTION
**What**:

`@babel/core` is added as a peer dependency.

**Why**:

`@babel/plugin-syntax-jsx` has a peer dependency on `@babel/core`, but this package doesn't provide it - which is [invalid](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0).

**Checklist**:
- [ ] Documentation - n/a
- [ ] Tests - n/a
- [ ] Code complete - n/a
