### PR TITLE
fix(typescript): Preserve props union type

### DIFF
--- a/packages/emotion-theming/types/helper.d.ts
+++ b/packages/emotion-theming/types/helper.d.ts
@@ -10,6 +10,6 @@ export type PropsOf<C extends React.ComponentType<any>> = C extends React.SFC<
         : never)
     : never
 
-export type Omit<T, U> = Pick<T, Exclude<keyof T, U>>
+export type Omit<T, U> = T extends any ? Pick<T, Exclude<keyof T, U>> : never
 export type AddOptionalTo<T, U> = Omit<T, U> &
   Partial<Pick<T, Extract<keyof T, U>>>

--- a/packages/emotion-theming/types/tests.tsx
+++ b/packages/emotion-theming/types/tests.tsx
@@ -43,3 +43,33 @@ typedWithTheme(CompSFC)
  * Following line should report an error.
  */
 typedWithTheme((props: { value: number }) => null)
+
+{
+  interface Book {
+    kind: 'book'
+    author: string
+  }
+
+  interface Magazine {
+    kind: 'magazine'
+    issue: number
+  }
+
+  type SomethingToRead = (Book | Magazine) & { theme?: any }
+
+  const Readable: React.SFC<SomethingToRead> = props => {
+    if (props.kind === 'magazine') {
+      return <div>magazine #{props.issue}</div>
+    }
+
+    return <div>magazine #{props.author}</div>
+  }
+
+  const ThemedReadable = withTheme(Readable)
+
+  ;<Readable kind="book" author="Hejlsberg" />
+  ;<ThemedReadable kind="book" author="Hejlsberg" />
+
+  ;<Readable kind="magazine" author="Hejlsberg" /> // $ExpectError
+  ;<ThemedReadable kind="magazine" author="Hejlsberg" /> // $ExpectError
+}

--- a/packages/styled-base/types/helper.d.ts
+++ b/packages/styled-base/types/helper.d.ts
@@ -13,5 +13,5 @@ export type PropsOf<
         : never)
     : never
 
-export type Omit<T, U> = Pick<T, Exclude<keyof T, U>>
+export type Omit<T, U> = T extends any ? Pick<T, Exclude<keyof T, U>> : never
 export type Overwrapped<T, U> = Pick<T, Extract<keyof T, keyof U>>

--- a/packages/styled-base/types/tests.tsx
+++ b/packages/styled-base/types/tests.tsx
@@ -242,3 +242,35 @@ declare const ref3_2: (element: HTMLDivElement | null) => void
 ;<StyledClass3 column={true} ref={ref3_1} />
 // $ExpectError
 ;<StyledClass3 column={true} ref={ref3_2} />
+
+{
+  interface Book {
+    kind: 'book'
+    author: string
+  }
+
+  interface Magazine {
+    kind: 'magazine'
+    issue: number
+  }
+
+  type SomethingToRead = Book | Magazine
+
+  const Readable: React.SFC<SomethingToRead> = props => {
+    if (props.kind === 'magazine') {
+      return <div>magazine #{props.issue}</div>
+    }
+
+    return <div>magazine #{props.author}</div>
+  }
+
+  const StyledReadable = styled(Readable)`
+    font-size: ${props => (props.kind === 'book' ? 16 : 14)};
+  `
+
+  ;<Readable kind="book" author="Hejlsberg" />
+  ;<StyledReadable kind="book" author="Hejlsberg" />
+
+  ;<Readable kind="magazine" author="Hejlsberg" /> // $ExpectError
+  ;<StyledReadable kind="magazine" author="Hejlsberg" /> // $ExpectError
+}


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
- change `Omit` to be distributive over union types

<!-- Why are these changes necessary? -->
**Why**:
- `withTheme` and `styled` loose union type informaton

<!-- How were these changes implemented? -->
**How**:
- use recommended pattern from https://github.com/Microsoft/TypeScript/issues/28339#issuecomment-467220238
- use `any` instead of `unknown` for backwards compatibility. If you don't support typescript 2.x we can use `unknown`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [ ] Code complete N/A

<!-- feel free to add additional comments -->
- typescript tests were also failing on `master`
- similar fix was accepted for `styled-components`:DefinitelyTyped/DefinitelyTyped#33061