### PR TITLE
adds enzyme mount snapshot test using css from @emotion/core

### DIFF
--- a/packages/core/src/jsx.js
+++ b/packages/core/src/jsx.js
@@ -103,6 +103,10 @@ let Emotion = withEmotionCache((props, cache, ref) => {
   return render(cache, props, null, ref)
 })
 
+if (process.env.NODE_ENV !== 'production') {
+  Emotion.displayName = 'EmotionCssPropInternal'
+}
+
 // $FlowFixMe
 export const jsx: typeof React.createElement = function(
   type: React.ElementType,

--- a/packages/jest-emotion/package.json
+++ b/packages/jest-emotion/package.json
@@ -20,6 +20,7 @@
     "object-assign": "^4.1.1"
   },
   "devDependencies": {
+    "@emotion/core": "^10.0.7",
     "dtslint": "^0.3.0",
     "emotion": "^10.0.7",
     "enzyme-to-json": "^3.3.5",

--- a/packages/jest-emotion/package.json
+++ b/packages/jest-emotion/package.json
@@ -26,7 +26,9 @@
     "enzyme-to-json": "^3.3.5",
     "preact": "^8.2.9",
     "preact-render-to-json": "^3.6.6",
-    "pretty-format": "^22.4.3"
+    "pretty-format": "^22.4.3",
+    "react": "^16.8.1",
+    "react-dom": "^16.8.1"
   },
   "author": "Kye Hohenberger",
   "homepage": "https://emotion.sh",

--- a/packages/jest-emotion/package.json
+++ b/packages/jest-emotion/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "dtslint": "^0.3.0",
     "emotion": "^10.0.7",
+    "enzyme-to-json": "^3.3.5",
     "preact": "^8.2.9",
     "preact-render-to-json": "^3.6.6",
     "pretty-format": "^22.4.3"

--- a/packages/jest-emotion/src/index.js
+++ b/packages/jest-emotion/src/index.js
@@ -53,6 +53,12 @@ export function createSerializer({
 }: Options = {}) {
   let cache = new WeakSet()
   function print(val: *, printer: Function) {
+    if (
+      val.$$typeof === Symbol.for('react.test.json') &&
+      val.type === 'EmotionCssPropInternal'
+    ) {
+      return val.children.map(printer).join('\n')
+    }
     const nodes = getNodes(val)
     const classNames = getClassNamesFromNodes(nodes)
     let elements = getStyleElements()
@@ -73,8 +79,10 @@ export function createSerializer({
   function test(val: *) {
     return (
       val &&
-      !cache.has(val) &&
-      (isReactElement(val) || (DOMElements && isDOMElement(val)))
+      ((!cache.has(val) &&
+        (isReactElement(val) || (DOMElements && isDOMElement(val)))) ||
+        (val.$$typeof === Symbol.for('react.test.json') &&
+          val.type === 'EmotionCssPropInternal'))
     )
   }
   return { test, print }

--- a/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
+++ b/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
@@ -1,17 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`enzyme mount test 1`] = `
+.emotion-0 {
+  background-color: red;
+}
+
+.emotion-0 {
+  background-color: red;
+}
+
 <Greeting>
-  <div
+  <ForwardRef(render)
+    __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Greeting"
+    __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
     css={
       Object {
-        "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInJlYWN0LWVuenltZS50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQVljIiwiZmlsZSI6InJlYWN0LWVuenltZS50ZXN0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0ICd0ZXN0LXV0aWxzL2xlZ2FjeS1lbnYnXG5pbXBvcnQgUmVhY3QgZnJvbSAncmVhY3QnXG5pbXBvcnQgKiBhcyBlbnp5bWUgZnJvbSAnZW56eW1lJ1xuaW1wb3J0IHsgY3NzIH0gZnJvbSAnQGVtb3Rpb24vY29yZSdcbmltcG9ydCB7IGNyZWF0ZVNlcmlhbGl6ZXIgYXMgY3JlYXRlRW56eW1lU2VyaWFsaXplciB9IGZyb20gJ2VuenltZS10by1qc29uJ1xuaW1wb3J0IHsgY3JlYXRlU2VyaWFsaXplciB9IGZyb20gJ2plc3QtZW1vdGlvbidcblxuZXhwZWN0LmFkZFNuYXBzaG90U2VyaWFsaXplcihjcmVhdGVFbnp5bWVTZXJpYWxpemVyKCkpXG5leHBlY3QuYWRkU25hcHNob3RTZXJpYWxpemVyKGNyZWF0ZVNlcmlhbGl6ZXIoKSlcblxudGVzdCgnZW56eW1lIG1vdW50IHRlc3QnLCAoKSA9PiB7XG4gIGNvbnN0IEdyZWV0aW5nID0gKHsgY2hpbGRyZW4gfSkgPT4gKFxuICAgIDxkaXYgY3NzPXtjc3MoeyBiYWNrZ3JvdW5kQ29sb3I6ICdyZWQnIH0pfT57Y2hpbGRyZW59PC9kaXY+XG4gIClcbiAgY29uc3QgdHJlZSA9IGVuenltZS5tb3VudCg8R3JlZXRpbmc+aGVsbG88L0dyZWV0aW5nPilcbiAgZXhwZWN0KHRyZWUpLnRvTWF0Y2hTbmFwc2hvdCgpXG59KVxuIl19 */",
+        "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInJlYWN0LWVuenltZS50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQVljIiwiZmlsZSI6InJlYWN0LWVuenltZS50ZXN0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0ICd0ZXN0LXV0aWxzL2xlZ2FjeS1lbnYnXG4vKiogQGpzeCBqc3ggKi9cbmltcG9ydCAqIGFzIGVuenltZSBmcm9tICdlbnp5bWUnXG5pbXBvcnQgeyBjc3MsIGpzeCB9IGZyb20gJ0BlbW90aW9uL2NvcmUnXG5pbXBvcnQgeyBjcmVhdGVTZXJpYWxpemVyIGFzIGNyZWF0ZUVuenltZVNlcmlhbGl6ZXIgfSBmcm9tICdlbnp5bWUtdG8tanNvbidcbmltcG9ydCB7IGNyZWF0ZVNlcmlhbGl6ZXIgfSBmcm9tICdqZXN0LWVtb3Rpb24nXG5cbmV4cGVjdC5hZGRTbmFwc2hvdFNlcmlhbGl6ZXIoY3JlYXRlRW56eW1lU2VyaWFsaXplcigpKVxuZXhwZWN0LmFkZFNuYXBzaG90U2VyaWFsaXplcihjcmVhdGVTZXJpYWxpemVyKCkpXG5cbnRlc3QoJ2VuenltZSBtb3VudCB0ZXN0JywgKCkgPT4ge1xuICBjb25zdCBHcmVldGluZyA9ICh7IGNoaWxkcmVuIH0pID0+IChcbiAgICA8ZGl2IGNzcz17Y3NzKHsgYmFja2dyb3VuZENvbG9yOiAncmVkJyB9KX0+e2NoaWxkcmVufTwvZGl2PlxuICApXG4gIGNvbnN0IHRyZWUgPSBlbnp5bWUubW91bnQoPEdyZWV0aW5nPmhlbGxvPC9HcmVldGluZz4pXG4gIGV4cGVjdCh0cmVlKS50b01hdGNoU25hcHNob3QoKVxufSlcbiJdfQ== */",
         "name": "1rveqsm-Greeting",
         "styles": "background-color:red;label:Greeting;",
       }
     }
   >
-    hello
-  </div>
+    <div
+      className="emotion-0"
+    >
+      hello
+    </div>
+  </ForwardRef(render)>
 </Greeting>
 `;

--- a/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
+++ b/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
@@ -10,22 +10,10 @@ exports[`enzyme mount test 1`] = `
 }
 
 <Greeting>
-  <ForwardRef(render)
-    __EMOTION_LABEL_PLEASE_DO_NOT_USE__="Greeting"
-    __EMOTION_TYPE_PLEASE_DO_NOT_USE__="div"
-    css={
-      Object {
-        "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInJlYWN0LWVuenltZS50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQVljIiwiZmlsZSI6InJlYWN0LWVuenltZS50ZXN0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0ICd0ZXN0LXV0aWxzL2xlZ2FjeS1lbnYnXG4vKiogQGpzeCBqc3ggKi9cbmltcG9ydCAqIGFzIGVuenltZSBmcm9tICdlbnp5bWUnXG5pbXBvcnQgeyBjc3MsIGpzeCB9IGZyb20gJ0BlbW90aW9uL2NvcmUnXG5pbXBvcnQgeyBjcmVhdGVTZXJpYWxpemVyIGFzIGNyZWF0ZUVuenltZVNlcmlhbGl6ZXIgfSBmcm9tICdlbnp5bWUtdG8tanNvbidcbmltcG9ydCB7IGNyZWF0ZVNlcmlhbGl6ZXIgfSBmcm9tICdqZXN0LWVtb3Rpb24nXG5cbmV4cGVjdC5hZGRTbmFwc2hvdFNlcmlhbGl6ZXIoY3JlYXRlRW56eW1lU2VyaWFsaXplcigpKVxuZXhwZWN0LmFkZFNuYXBzaG90U2VyaWFsaXplcihjcmVhdGVTZXJpYWxpemVyKCkpXG5cbnRlc3QoJ2VuenltZSBtb3VudCB0ZXN0JywgKCkgPT4ge1xuICBjb25zdCBHcmVldGluZyA9ICh7IGNoaWxkcmVuIH0pID0+IChcbiAgICA8ZGl2IGNzcz17Y3NzKHsgYmFja2dyb3VuZENvbG9yOiAncmVkJyB9KX0+e2NoaWxkcmVufTwvZGl2PlxuICApXG4gIGNvbnN0IHRyZWUgPSBlbnp5bWUubW91bnQoPEdyZWV0aW5nPmhlbGxvPC9HcmVldGluZz4pXG4gIGV4cGVjdCh0cmVlKS50b01hdGNoU25hcHNob3QoKVxufSlcbiJdfQ== */",
-        "name": "1rveqsm-Greeting",
-        "styles": "background-color:red;label:Greeting;",
-      }
-    }
+  <div
+    className="emotion-0"
   >
-    <div
-      className="emotion-0"
-    >
-      hello
-    </div>
-  </ForwardRef(render)>
+    hello
+  </div>
 </Greeting>
 `;

--- a/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
+++ b/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`enzyme mount test 1`] = `
+<Greeting>
+  <div
+    css={
+      Object {
+        "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInJlYWN0LWVuenltZS50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQVljIiwiZmlsZSI6InJlYWN0LWVuenltZS50ZXN0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0ICd0ZXN0LXV0aWxzL2xlZ2FjeS1lbnYnXG5pbXBvcnQgUmVhY3QgZnJvbSAncmVhY3QnXG5pbXBvcnQgKiBhcyBlbnp5bWUgZnJvbSAnZW56eW1lJ1xuaW1wb3J0IHsgY3NzIH0gZnJvbSAnQGVtb3Rpb24vY29yZSdcbmltcG9ydCB7IGNyZWF0ZVNlcmlhbGl6ZXIgYXMgY3JlYXRlRW56eW1lU2VyaWFsaXplciB9IGZyb20gJ2VuenltZS10by1qc29uJ1xuaW1wb3J0IHsgY3JlYXRlU2VyaWFsaXplciB9IGZyb20gJ2plc3QtZW1vdGlvbidcblxuZXhwZWN0LmFkZFNuYXBzaG90U2VyaWFsaXplcihjcmVhdGVFbnp5bWVTZXJpYWxpemVyKCkpXG5leHBlY3QuYWRkU25hcHNob3RTZXJpYWxpemVyKGNyZWF0ZVNlcmlhbGl6ZXIoKSlcblxudGVzdCgnZW56eW1lIG1vdW50IHRlc3QnLCAoKSA9PiB7XG4gIGNvbnN0IEdyZWV0aW5nID0gKHsgY2hpbGRyZW4gfSkgPT4gKFxuICAgIDxkaXYgY3NzPXtjc3MoeyBiYWNrZ3JvdW5kQ29sb3I6ICdyZWQnIH0pfT57Y2hpbGRyZW59PC9kaXY+XG4gIClcbiAgY29uc3QgdHJlZSA9IGVuenltZS5tb3VudCg8R3JlZXRpbmc+aGVsbG88L0dyZWV0aW5nPilcbiAgZXhwZWN0KHRyZWUpLnRvTWF0Y2hTbmFwc2hvdCgpXG59KVxuIl19 */",
+        "name": "1rveqsm-Greeting",
+        "styles": "background-color:red;label:Greeting;",
+      }
+    }
+  >
+    hello
+  </div>
+</Greeting>
+`;

--- a/packages/jest-emotion/test/matchers.test.js
+++ b/packages/jest-emotion/test/matchers.test.js
@@ -1,8 +1,9 @@
 import 'test-utils/legacy-env'
 import React from 'react'
 import renderer from 'react-test-renderer'
+/** @jsx jsx */
 import * as enzyme from 'enzyme'
-import * as emotion from 'emotion'
+import { css, jsx } from '@emotion/core'
 import styled from '@emotion/styled'
 import { matchers } from 'jest-emotion'
 
@@ -11,11 +12,11 @@ const { toHaveStyleRule } = matchers
 expect.extend(matchers)
 
 describe('toHaveStyleRule', () => {
-  const divStyle = emotion.css`
+  const divStyle = css`
     color: red;
   `
 
-  const svgStyle = emotion.css`
+  const svgStyle = css`
     width: 100%;
   `
 
@@ -24,8 +25,8 @@ describe('toHaveStyleRule', () => {
   it('matches styles on the top-most node passed in', () => {
     const tree = renderer
       .create(
-        <div className={divStyle}>
-          <svg className={svgStyle} />
+        <div css={divStyle}>
+          <svg css={svgStyle} />
         </div>
       )
       .toJSON()
@@ -42,8 +43,8 @@ describe('toHaveStyleRule', () => {
   it('supports asymmetric matchers', () => {
     const tree = renderer
       .create(
-        <div className={divStyle}>
-          <svg className={svgStyle} />
+        <div css={divStyle}>
+          <svg css={svgStyle} />
         </div>
       )
       .toJSON()
@@ -58,8 +59,8 @@ describe('toHaveStyleRule', () => {
 
   it('supports enzyme render methods', () => {
     const Component = () => (
-      <div className={divStyle}>
-        <svg className={svgStyle} />
+      <div css={divStyle}>
+        <svg css={svgStyle} />
       </div>
     )
 
@@ -105,12 +106,12 @@ describe('toHaveStyleRule', () => {
   })
 
   it('supports regex values', () => {
-    const tree = renderer.create(<div className={divStyle} />).toJSON()
+    const tree = renderer.create(<div css={divStyle} />).toJSON()
     expect(tree).toHaveStyleRule('color', /red/)
   })
 
   it.skip('returns a message explaining the failure', () => {
-    const tree = renderer.create(<div className={divStyle} />).toJSON()
+    const tree = renderer.create(<div css={divStyle} />).toJSON()
 
     // When expect(tree).toHaveStyleRule('color', 'blue') fails
     const resultFail = toHaveStyleRule(tree, 'color', 'blue')
@@ -122,19 +123,19 @@ describe('toHaveStyleRule', () => {
   })
 
   it('matches styles on the focus, hover targets', () => {
-    const localDivStyle = emotion.css`
+    const localDivStyle = css`
       color: white;
-        &:hover {
-          color: yellow;
-        }
-         &:focus {
-          color: black;
-        }
+      &:hover {
+        color: yellow;
+      }
+      &:focus {
+        color: black;
+      }
     `
     const tree = renderer
       .create(
-        <div className={localDivStyle}>
-          <svg className={svgStyle} />
+        <div css={localDivStyle}>
+          <svg css={svgStyle} />
         </div>
       )
       .toJSON()
@@ -178,10 +179,10 @@ describe('toHaveStyleRule', () => {
     const tree = renderer
       .create(
         <div
-          className={emotion.css`
-        color: green;
-        color: hotpink;
-      `}
+          css={css`
+            color: green;
+            color: hotpink;
+          `}
         />
       )
       .toJSON()
@@ -233,18 +234,18 @@ describe('toHaveStyleRule', () => {
   })
 
   it('matches styles with target and media options', () => {
-    const localDivStyle = emotion.css`
+    const localDivStyle = css`
       color: white;
       @media (min-width: 420px) {
         color: green;
-          &:hover {
+        &:hover {
           color: yellow;
         }
       }
     `
     const tree = renderer
       .create(
-        <div className={localDivStyle}>
+        <div css={localDivStyle}>
           <span>Test</span>
         </div>
       )

--- a/packages/jest-emotion/test/matchers.test.js
+++ b/packages/jest-emotion/test/matchers.test.js
@@ -1,5 +1,4 @@
 import 'test-utils/legacy-env'
-import React from 'react'
 import renderer from 'react-test-renderer'
 /** @jsx jsx */
 import * as enzyme from 'enzyme'
@@ -20,7 +19,7 @@ describe('toHaveStyleRule', () => {
     width: 100%;
   `
 
-  const enzymeMethods = ['shallow', 'mount', 'render']
+  const enzymeMethods = ['mount', 'render']
 
   it('matches styles on the top-most node passed in', () => {
     const tree = renderer

--- a/packages/jest-emotion/test/printer.test.js
+++ b/packages/jest-emotion/test/printer.test.js
@@ -1,9 +1,9 @@
 // @flow
 import 'test-utils/legacy-env'
-import React from 'react'
 import renderer from 'react-test-renderer'
 import prettyFormat from 'pretty-format'
-import { css, cx } from 'emotion'
+/** @jsx jsx */
+import { css, jsx, ClassNames } from '@emotion/core'
 import { createSerializer } from 'jest-emotion'
 import { ignoreConsoleErrors } from 'test-utils'
 
@@ -23,8 +23,8 @@ describe('jest-emotion with dom elements', () => {
   it('replaces class names and inserts styles into React test component snapshots', () => {
     const tree = renderer
       .create(
-        <div className={divStyle}>
-          <svg className={svgStyle} />
+        <div css={divStyle}>
+          <svg css={svgStyle} />
         </div>
       )
       .toJSON()
@@ -65,8 +65,8 @@ describe('jest-emotion with DOM elements disabled', () => {
   it('replaces class names and inserts styles into React test component snapshots', () => {
     const tree = renderer
       .create(
-        <div className={divStyle}>
-          <svg className={svgStyle} />
+        <div css={divStyle}>
+          <svg css={svgStyle} />
         </div>
       )
       .toJSON()
@@ -94,15 +94,23 @@ describe('jest-emotion with DOM elements disabled', () => {
 })
 
 test('does not replace class names that are not from emotion', () => {
-  const classes = cx(
-    'net-42',
-    'net',
-    css`
-      color: darkorchid;
-    `
-  )
-
-  let tree = renderer.create(<div className={classes} />).toJSON()
+  let tree = renderer
+    .create(
+      <ClassNames>
+        {({ css: classNamesCss, cx }) => (
+          <div
+            className={cx([
+              'net-42',
+              'net',
+              classNamesCss`
+                color: darkorchid;
+              `
+            ])}
+          />
+        )}
+      </ClassNames>
+    )
+    .toJSON()
 
   const output = prettyFormat(tree, {
     plugins: [emotionPlugin, ReactElement, ReactTestComponent, DOMElement]
@@ -121,7 +129,7 @@ describe('jest-emotion with nested selectors', () => {
   `
 
   it('replaces class names and inserts styles into React test component snapshots', () => {
-    const tree = renderer.create(<div className={divStyle} />).toJSON()
+    const tree = renderer.create(<div css={divStyle} />).toJSON()
 
     const output = prettyFormat(tree, {
       plugins: [emotionPlugin, ReactElement, ReactTestComponent, DOMElement]
@@ -142,9 +150,7 @@ header .emotion-0 {
 })
 
 test('throws nice error for invalid css', () => {
-  const tree = renderer
-    .create(<div className={css`jnnjvh@'jevhevhb`} />)
-    .toJSON()
+  const tree = renderer.create(<div css={css`jnnjvh@'jevhevhb`} />).toJSON()
 
   expect(() => {
     ignoreConsoleErrors(() => {

--- a/packages/jest-emotion/test/printer.test.js
+++ b/packages/jest-emotion/test/printer.test.js
@@ -1,4 +1,6 @@
 // @flow
+import React from 'react'
+import ReactDOM from 'react-dom'
 import 'test-utils/legacy-env'
 import renderer from 'react-test-renderer'
 import prettyFormat from 'pretty-format'
@@ -37,13 +39,15 @@ describe('jest-emotion with dom elements', () => {
   })
 
   it('replaces class names and inserts styles into DOM element snapshots', () => {
-    const divElement = document.createElement('div')
-    divElement.setAttribute('class', divStyle)
-    const svgElement = document.createElement('svg')
-    svgElement.setAttribute('class', svgStyle)
-    divElement.appendChild(svgElement)
+    const divRef = React.createRef()
+    ReactDOM.render(
+      <div css={divStyle} ref={divRef}>
+        <svg css={svgStyle} />
+      </div>,
+      document.createElement('div')
+    )
 
-    const output = prettyFormat(divElement, {
+    const output = prettyFormat(divRef.current, {
       plugins: [emotionPlugin, ReactElement, ReactTestComponent, DOMElement]
     })
 
@@ -79,13 +83,15 @@ describe('jest-emotion with DOM elements disabled', () => {
   })
 
   it('does not replace class names or insert styles into DOM element snapshots', () => {
-    const divElement = document.createElement('div')
-    divElement.setAttribute('class', divStyle)
-    const svgElement = document.createElement('svg')
-    svgElement.setAttribute('class', svgStyle)
-    divElement.appendChild(svgElement)
+    const divRef = React.createRef()
+    ReactDOM.render(
+      <div css={divStyle} ref={divRef}>
+        <svg css={svgStyle} />
+      </div>,
+      document.createElement('div')
+    )
 
-    const output = prettyFormat(divElement, {
+    const output = prettyFormat(divRef.current, {
       plugins: [emotionPlugin, ReactElement, ReactTestComponent, DOMElement]
     })
 

--- a/packages/jest-emotion/test/printer.test.js
+++ b/packages/jest-emotion/test/printer.test.js
@@ -5,7 +5,7 @@ import 'test-utils/legacy-env'
 import renderer from 'react-test-renderer'
 import prettyFormat from 'pretty-format'
 /** @jsx jsx */
-import { css, jsx, ClassNames } from '@emotion/core'
+import { css, jsx } from '@emotion/core'
 import { createSerializer } from 'jest-emotion'
 import { ignoreConsoleErrors } from 'test-utils'
 
@@ -102,19 +102,12 @@ describe('jest-emotion with DOM elements disabled', () => {
 test('does not replace class names that are not from emotion', () => {
   let tree = renderer
     .create(
-      <ClassNames>
-        {({ css: classNamesCss, cx }) => (
-          <div
-            className={cx([
-              'net-42',
-              'net',
-              classNamesCss`
-                color: darkorchid;
-              `
-            ])}
-          />
-        )}
-      </ClassNames>
+      <div
+        className="net-42 net"
+        css={css`
+          color: darkorchid;
+        `}
+      />
     )
     .toJSON()
 

--- a/packages/jest-emotion/test/react-enzyme.test.js
+++ b/packages/jest-emotion/test/react-enzyme.test.js
@@ -1,7 +1,7 @@
 import 'test-utils/legacy-env'
 /** @jsx jsx */
 import * as enzyme from 'enzyme'
-import { css, jsx } from '@emotion/core'
+import { jsx } from '@emotion/core'
 import { createSerializer as createEnzymeSerializer } from 'enzyme-to-json'
 import { createSerializer } from 'jest-emotion'
 
@@ -10,7 +10,7 @@ expect.addSnapshotSerializer(createSerializer())
 
 test('enzyme mount test', () => {
   const Greeting = ({ children }) => (
-    <div css={css({ backgroundColor: 'red' })}>{children}</div>
+    <div css={{ backgroundColor: 'red' }}>{children}</div>
   )
   const tree = enzyme.mount(<Greeting>hello</Greeting>)
   expect(tree).toMatchSnapshot()

--- a/packages/jest-emotion/test/react-enzyme.test.js
+++ b/packages/jest-emotion/test/react-enzyme.test.js
@@ -1,0 +1,17 @@
+import 'test-utils/legacy-env'
+import React from 'react'
+import * as enzyme from 'enzyme'
+import { css } from '@emotion/core'
+import { createSerializer as createEnzymeSerializer } from 'enzyme-to-json'
+import { createSerializer } from 'jest-emotion'
+
+expect.addSnapshotSerializer(createEnzymeSerializer())
+expect.addSnapshotSerializer(createSerializer())
+
+test('enzyme mount test', () => {
+  const Greeting = ({ children }) => (
+    <div css={css({ backgroundColor: 'red' })}>{children}</div>
+  )
+  const tree = enzyme.mount(<Greeting>hello</Greeting>)
+  expect(tree).toMatchSnapshot()
+})

--- a/packages/jest-emotion/test/react-enzyme.test.js
+++ b/packages/jest-emotion/test/react-enzyme.test.js
@@ -1,7 +1,7 @@
 import 'test-utils/legacy-env'
-import React from 'react'
+/** @jsx jsx */
 import * as enzyme from 'enzyme'
-import { css } from '@emotion/core'
+import { css, jsx } from '@emotion/core'
 import { createSerializer as createEnzymeSerializer } from 'enzyme-to-json'
 import { createSerializer } from 'jest-emotion'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8037,6 +8037,13 @@ enzyme-to-json@^3.2.1:
   dependencies:
     lodash "^4.17.4"
 
+enzyme-to-json@^3.3.5:
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.5.tgz#f8eb82bd3d5941c9d8bc6fd9140030777d17d0af"
+  integrity sha512-DmH1wJ68HyPqKSYXdQqB33ZotwfUhwQZW3IGXaNXgR69Iodaoj8TF/D9RjLdz4pEhGq2Tx2zwNUIjBuqoZeTgA==
+  dependencies:
+    lodash "^4.17.4"
+
 enzyme@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.3.0.tgz#0971abd167f2d4bf3f5bd508229e1c4b6dc50479"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
The entire object returned by css is being serialized in snapshot tests. I have written a test that uses `mount` from `enzyme` and `css` from `@emotion/core`. This output is quite different from previous versions of emotion and what is described in the [snapshot testing docs](https://emotion.sh/docs/testing#writing-a-test).

Related to #1214 and #1187 

<!-- Why are these changes necessary? -->
**Why**:
It would be great if what is serialised stays roughly equivalent between emotion 9 and 10. The value of `map` changes fairly regularly which is problematic for snapshot tests.  

<!-- How were these changes implemented? -->
**How**:
I haven't looked into how to fix this yet but this is an isolated reproduction of the problem. I am going to have a poke around but any guidance on where to go from here would be great.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Code complete

<!-- feel free to add additional comments -->
