### PR TITLE
Adds missing peer dependency in @emotion/styled

### DIFF
--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -14,6 +14,9 @@
     "@emotion/styled-base": "^10.0.7",
     "babel-plugin-emotion": "^10.0.7"
   },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
+  },
   "devDependencies": {
     "dtslint": "^0.3.0"
   },

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -17,6 +17,11 @@
   "peerDependencies": {
     "@babel/core": "^7.0.0"
   },
+  "peerDependenciesMeta": {
+    "@babel/core": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "dtslint": "^0.3.0"
   },


### PR DESCRIPTION
**What**:

`@babel/core` is added as a peer dependency.

**Why**:

`@emotion/styled-base` has a peer dependency on `@babel/core`, but this package doesn't provide it - which is [invalid](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0).

**Checklist**:
- [ ] Documentation - n/a
- [ ] Tests - n/a
- [ ] Code complete - n/a
