### PR TITLE
Uses require.resolve when calling @emotion/core

### DIFF
--- a/packages/babel-preset-css-prop/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-preset-css-prop/__tests__/__snapshots__/index.js.snap
@@ -19,7 +19,7 @@ export let Button = props => {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { jsx as ___EmotionJSX } from \\"@emotion/core\\";
+import { jsx as ___EmotionJSX } from \\"/path/to/emotion/packages/core/dist/core.cjs.js\\";
 
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 

--- a/packages/babel-preset-css-prop/__tests__/__snapshots__/options-are-used.js.snap
+++ b/packages/babel-preset-css-prop/__tests__/__snapshots__/options-are-used.js.snap
@@ -19,7 +19,7 @@ export let Button = props => {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { jsx as ___EmotionJSX } from \\"@emotion/core\\";
+import { jsx as ___EmotionJSX } from \\"/path/to/emotion/packages/core/dist/core.cjs.js\\";
 
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 

--- a/packages/babel-preset-css-prop/package.json
+++ b/packages/babel-preset-css-prop/package.json
@@ -13,7 +13,8 @@
     "object-assign": "^4.1.1"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0"
+    "@babel/core": "^7.0.0",
+    "@emotion/core": "^10.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/babel-preset-css-prop/src/index.js
+++ b/packages/babel-preset-css-prop/src/index.js
@@ -18,7 +18,7 @@ export default (
         pragmatic,
         {
           export: 'jsx',
-          module: '@emotion/core',
+          module: require.resolve('@emotion/core'),
           import: pragmaName
         }
       ],

--- a/scripts/babel-tester/src/index.js
+++ b/scripts/babel-tester/src/index.js
@@ -33,9 +33,16 @@ const tester = allOpts => async opts => {
     ast: true,
     filename: opts.babelFileName || __filename
   })
+
+  // Removes absolute paths from the output
+  const normalizedCode = code.replace(
+    /\/(?:\w+\/)+(packages)/,
+    '/path/to/emotion/$1'
+  )
+
   expect(() => checkDuplicatedNodes(babel, ast)).not.toThrow()
 
-  expect(`${rawCode}${separator}${code}`).toMatchSnapshot()
+  expect(`${rawCode}${separator}${normalizedCode}`).toMatchSnapshot()
 }
 
 function doThing(dirname) {


### PR DESCRIPTION
**What**:

This PR fixes Emotion with PnP.

**Why**:

The `@emotion/babel-preset-css-prop` plugin is listing `@emotion/core` in its configuration without resolving first using `require.resolve`. It causes the resolution to lose track of the real package making the request, causing access denied errors with PnP.

**How**:

- The package now uses `require.resolve` before sending the module name forward. It's a good practice for babel plugins to do this ([cf in Jest](https://github.com/facebook/jest/blob/master/packages/babel-preset-jest/index.js), for example).

- The `@emotion/core` peer dependency is now properly listed.

**Checklist**:

- [ ] Documentation - n/a
- [ ] Tests - n/a
- [ ] Code complete - n/a
