### PR TITLE
adds failing test for prop containing components using css

### DIFF
--- a/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
+++ b/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
@@ -17,3 +17,36 @@ exports[`enzyme mount test 1`] = `
   </div>
 </Greeting>
 `;
+
+exports[`enzyme test with prop containing css element 1`] = `
+.emotion-0 {
+  width: 100%;
+}
+
+.emotion-0 {
+  width: 100%;
+}
+
+<Greeting
+  content={
+    <ForwardRef(render)
+      __EMOTION_TYPE_PLEASE_DO_NOT_USE__="p"
+      css={
+        Object {
+          "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInJlYWN0LWVuenltZS50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQXVCMEIiLCJmaWxlIjoicmVhY3QtZW56eW1lLnRlc3QuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgJ3Rlc3QtdXRpbHMvbGVnYWN5LWVudidcbi8qKiBAanN4IGpzeCAqL1xuaW1wb3J0ICogYXMgZW56eW1lIGZyb20gJ2VuenltZSdcbmltcG9ydCB7IGpzeCB9IGZyb20gJ0BlbW90aW9uL2NvcmUnXG5pbXBvcnQgeyBjcmVhdGVTZXJpYWxpemVyIGFzIGNyZWF0ZUVuenltZVNlcmlhbGl6ZXIgfSBmcm9tICdlbnp5bWUtdG8tanNvbidcbmltcG9ydCB7IGNyZWF0ZVNlcmlhbGl6ZXIgfSBmcm9tICdqZXN0LWVtb3Rpb24nXG5cbmV4cGVjdC5hZGRTbmFwc2hvdFNlcmlhbGl6ZXIoY3JlYXRlRW56eW1lU2VyaWFsaXplcigpKVxuZXhwZWN0LmFkZFNuYXBzaG90U2VyaWFsaXplcihjcmVhdGVTZXJpYWxpemVyKCkpXG5cbnRlc3QoJ2VuenltZSBtb3VudCB0ZXN0JywgKCkgPT4ge1xuICBjb25zdCBHcmVldGluZyA9ICh7IGNoaWxkcmVuIH0pID0+IChcbiAgICA8ZGl2IGNzcz17eyBiYWNrZ3JvdW5kQ29sb3I6ICdyZWQnIH19PntjaGlsZHJlbn08L2Rpdj5cbiAgKVxuICBjb25zdCB0cmVlID0gZW56eW1lLm1vdW50KDxHcmVldGluZz5oZWxsbzwvR3JlZXRpbmc+KVxuICBleHBlY3QodHJlZSkudG9NYXRjaFNuYXBzaG90KClcbn0pXG5cbnRlc3Qub25seSgnZW56eW1lIHRlc3Qgd2l0aCBwcm9wIGNvbnRhaW5pbmcgY3NzIGVsZW1lbnQnLCAoKSA9PiB7XG4gIGNvbnN0IEdyZWV0aW5nID0gKHsgY2hpbGRyZW4sIGNvbnRlbnQgfSkgPT4gKFxuICAgIDxkaXYgY3NzPXt7IHdpZHRoOiAnMTAwJScgfX0+e2NoaWxkcmVufTwvZGl2PlxuICApXG4gIGNvbnN0IHRyZWUgPSBlbnp5bWUubW91bnQoXG4gICAgPEdyZWV0aW5nIGNvbnRlbnQ9ezxwIGNzcz17eyBiYWNrZ3JvdW5kOiAncmVkJyB9fT5oZWxsbzwvcD59PlxuICAgICAgaGVsbG9cbiAgICA8L0dyZWV0aW5nPlxuICApXG4gIGV4cGVjdCh0cmVlKS50b01hdGNoU25hcHNob3QoKVxufSlcbiJdfQ== */",
+          "name": "1et9bco-tree",
+          "styles": "background:red;label:tree;",
+        }
+      }
+    >
+      hello
+    </ForwardRef(render)>
+  }
+>
+  <div
+    className="emotion-0"
+  >
+    hello
+  </div>
+</Greeting>
+`;

--- a/packages/jest-emotion/test/react-enzyme.test.js
+++ b/packages/jest-emotion/test/react-enzyme.test.js
@@ -15,3 +15,15 @@ test('enzyme mount test', () => {
   const tree = enzyme.mount(<Greeting>hello</Greeting>)
   expect(tree).toMatchSnapshot()
 })
+
+test.only('enzyme test with prop containing css element', () => {
+  const Greeting = ({ children, content }) => (
+    <div css={{ width: '100%' }}>{children}</div>
+  )
+  const tree = enzyme.mount(
+    <Greeting content={<p css={{ background: 'red' }}>hello</p>}>
+      hello
+    </Greeting>
+  )
+  expect(tree).toMatchSnapshot()
+})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: 👋 @danieldelcore and I found an edge case with snapshot tests. The emotion `ForwardRef` component is not being skipped in cases like:
```jsx
expect(
  <Greeting content={<div css={{ background: 'hi' }}>cool</Greeting>
).toMatchSnapshot();
```
In the above example the forwardRef component around `div` will be serialised. We will take a look at this tomorrow morning and update the PR.


**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Code complete

<!-- feel free to add additional comments -->
