### PR TITLE
Components with render props no longer output base64 in snapshot tests

### DIFF
--- a/packages/jest-emotion/src/utils.js
+++ b/packages/jest-emotion/src/utils.js
@@ -44,7 +44,7 @@ export function isReactElement(val: any): boolean {
   return val.$$typeof === Symbol.for('react.test.json')
 }
 
-export function isReactForwardRef(val: any): boolean {
+export function isEmotionCssPropElementType(val: any): boolean {
   return (
     val.$$typeof === Symbol.for('react.element') &&
     val.type.$$typeof === Symbol.for('react.forward_ref') &&
@@ -52,13 +52,12 @@ export function isReactForwardRef(val: any): boolean {
   )
 }
 
-export function isEmotionElement(val: any): boolean {
+export function isEmotionCssPropEnzymeElement(val: any): boolean {
   return (
     val.$$typeof === Symbol.for('react.test.json') &&
     val.type === 'EmotionCssPropInternal'
   )
 }
-
 const domElementPattern = /^((HTML|SVG)\w*)?Element$/
 
 export function isDOMElement(val: any): boolean {

--- a/packages/jest-emotion/src/utils.js
+++ b/packages/jest-emotion/src/utils.js
@@ -44,6 +44,21 @@ export function isReactElement(val: any): boolean {
   return val.$$typeof === Symbol.for('react.test.json')
 }
 
+export function isReactForwardRef(val: any): boolean {
+  return (
+    val.$$typeof === Symbol.for('react.element') &&
+    val.type.$$typeof === Symbol.for('react.forward_ref') &&
+    val.type.displayName === 'EmotionCssPropInternal'
+  )
+}
+
+export function isEmotionElement(val: any): boolean {
+  return (
+    val.$$typeof === Symbol.for('react.test.json') &&
+    val.type === 'EmotionCssPropInternal'
+  )
+}
+
 const domElementPattern = /^((HTML|SVG)\w*)?Element$/
 
 export function isDOMElement(val: any): boolean {

--- a/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
+++ b/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
@@ -17,3 +17,36 @@ exports[`enzyme mount test 1`] = `
   </div>
 </Greeting>
 `;
+
+exports[`enzyme test with prop containing css element 1`] = `
+.emotion-0 {
+  width: 100%;
+}
+
+.emotion-0 {
+  width: 100%;
+}
+
+<Greeting
+  content={
+    <ForwardRef(render)
+      __EMOTION_TYPE_PLEASE_DO_NOT_USE__="p"
+      css={
+        Object {
+          "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInJlYWN0LWVuenltZS50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQXVCMEIiLCJmaWxlIjoicmVhY3QtZW56eW1lLnRlc3QuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgJ3Rlc3QtdXRpbHMvbGVnYWN5LWVudidcbi8qKiBAanN4IGpzeCAqL1xuaW1wb3J0ICogYXMgZW56eW1lIGZyb20gJ2VuenltZSdcbmltcG9ydCB7IGpzeCB9IGZyb20gJ0BlbW90aW9uL2NvcmUnXG5pbXBvcnQgeyBjcmVhdGVTZXJpYWxpemVyIGFzIGNyZWF0ZUVuenltZVNlcmlhbGl6ZXIgfSBmcm9tICdlbnp5bWUtdG8tanNvbidcbmltcG9ydCB7IGNyZWF0ZVNlcmlhbGl6ZXIgfSBmcm9tICdqZXN0LWVtb3Rpb24nXG5cbmV4cGVjdC5hZGRTbmFwc2hvdFNlcmlhbGl6ZXIoY3JlYXRlRW56eW1lU2VyaWFsaXplcigpKVxuZXhwZWN0LmFkZFNuYXBzaG90U2VyaWFsaXplcihjcmVhdGVTZXJpYWxpemVyKCkpXG5cbnRlc3QoJ2VuenltZSBtb3VudCB0ZXN0JywgKCkgPT4ge1xuICBjb25zdCBHcmVldGluZyA9ICh7IGNoaWxkcmVuIH0pID0+IChcbiAgICA8ZGl2IGNzcz17eyBiYWNrZ3JvdW5kQ29sb3I6ICdyZWQnIH19PntjaGlsZHJlbn08L2Rpdj5cbiAgKVxuICBjb25zdCB0cmVlID0gZW56eW1lLm1vdW50KDxHcmVldGluZz5oZWxsbzwvR3JlZXRpbmc+KVxuICBleHBlY3QodHJlZSkudG9NYXRjaFNuYXBzaG90KClcbn0pXG5cbnRlc3Qub25seSgnZW56eW1lIHRlc3Qgd2l0aCBwcm9wIGNvbnRhaW5pbmcgY3NzIGVsZW1lbnQnLCAoKSA9PiB7XG4gIGNvbnN0IEdyZWV0aW5nID0gKHsgY2hpbGRyZW4sIGNvbnRlbnQgfSkgPT4gKFxuICAgIDxkaXYgY3NzPXt7IHdpZHRoOiAnMTAwJScgfX0+e2NoaWxkcmVufTwvZGl2PlxuICApXG4gIGNvbnN0IHRyZWUgPSBlbnp5bWUubW91bnQoXG4gICAgPEdyZWV0aW5nIGNvbnRlbnQ9ezxwIGNzcz17eyBiYWNrZ3JvdW5kOiAncmVkJyB9fT5oZWxsbzwvcD59PlxuICAgICAgaGVsbG9cbiAgICA8L0dyZWV0aW5nPlxuICApXG4gIGV4cGVjdCh0cmVlKS50b01hdGNoU25hcHNob3QoKVxufSlcbiJdfQ== */",
+          "name": "1et9bco-tree",
+          "styles": "background:red;label:tree;",
+        }
+      }
+    >
+      hello
+    </ForwardRef(render)>
+  }
+>
+  <div
+    className="emotion-0"
+  >
+    hello
+  </div>
+</Greeting>
+`;

--- a/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
+++ b/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
@@ -20,33 +20,28 @@ exports[`enzyme mount test 1`] = `
 
 exports[`enzyme test with prop containing css element 1`] = `
 .emotion-0 {
-  width: 100%;
+  background-color: blue;
 }
 
 .emotion-0 {
-  width: 100%;
+  background-color: blue;
 }
 
 <Greeting
   content={
-    <ForwardRef(render)
-      __EMOTION_TYPE_PLEASE_DO_NOT_USE__="p"
-      css={
-        Object {
-          "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInJlYWN0LWVuenltZS50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQXVCMEIiLCJmaWxlIjoicmVhY3QtZW56eW1lLnRlc3QuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgJ3Rlc3QtdXRpbHMvbGVnYWN5LWVudidcbi8qKiBAanN4IGpzeCAqL1xuaW1wb3J0ICogYXMgZW56eW1lIGZyb20gJ2VuenltZSdcbmltcG9ydCB7IGpzeCB9IGZyb20gJ0BlbW90aW9uL2NvcmUnXG5pbXBvcnQgeyBjcmVhdGVTZXJpYWxpemVyIGFzIGNyZWF0ZUVuenltZVNlcmlhbGl6ZXIgfSBmcm9tICdlbnp5bWUtdG8tanNvbidcbmltcG9ydCB7IGNyZWF0ZVNlcmlhbGl6ZXIgfSBmcm9tICdqZXN0LWVtb3Rpb24nXG5cbmV4cGVjdC5hZGRTbmFwc2hvdFNlcmlhbGl6ZXIoY3JlYXRlRW56eW1lU2VyaWFsaXplcigpKVxuZXhwZWN0LmFkZFNuYXBzaG90U2VyaWFsaXplcihjcmVhdGVTZXJpYWxpemVyKCkpXG5cbnRlc3QoJ2VuenltZSBtb3VudCB0ZXN0JywgKCkgPT4ge1xuICBjb25zdCBHcmVldGluZyA9ICh7IGNoaWxkcmVuIH0pID0+IChcbiAgICA8ZGl2IGNzcz17eyBiYWNrZ3JvdW5kQ29sb3I6ICdyZWQnIH19PntjaGlsZHJlbn08L2Rpdj5cbiAgKVxuICBjb25zdCB0cmVlID0gZW56eW1lLm1vdW50KDxHcmVldGluZz5oZWxsbzwvR3JlZXRpbmc+KVxuICBleHBlY3QodHJlZSkudG9NYXRjaFNuYXBzaG90KClcbn0pXG5cbnRlc3Qub25seSgnZW56eW1lIHRlc3Qgd2l0aCBwcm9wIGNvbnRhaW5pbmcgY3NzIGVsZW1lbnQnLCAoKSA9PiB7XG4gIGNvbnN0IEdyZWV0aW5nID0gKHsgY2hpbGRyZW4sIGNvbnRlbnQgfSkgPT4gKFxuICAgIDxkaXYgY3NzPXt7IHdpZHRoOiAnMTAwJScgfX0+e2NoaWxkcmVufTwvZGl2PlxuICApXG4gIGNvbnN0IHRyZWUgPSBlbnp5bWUubW91bnQoXG4gICAgPEdyZWV0aW5nIGNvbnRlbnQ9ezxwIGNzcz17eyBiYWNrZ3JvdW5kOiAncmVkJyB9fT5oZWxsbzwvcD59PlxuICAgICAgaGVsbG9cbiAgICA8L0dyZWV0aW5nPlxuICApXG4gIGV4cGVjdCh0cmVlKS50b01hdGNoU25hcHNob3QoKVxufSlcbiJdfQ== */",
-          "name": "1et9bco-tree",
-          "styles": "background:red;label:tree;",
-        }
-      }
-    >
-      hello
-    </ForwardRef(render)>
+    <CssProp(p)>
+      Hello
+    </CssProp(p)>
   }
 >
-  <div
-    className="emotion-0"
-  >
-    hello
+  <div>
+    <p
+      className="emotion-0"
+    >
+      Hello
+    </p>
+     
+    World!
   </div>
 </Greeting>
 `;

--- a/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
+++ b/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
@@ -29,14 +29,120 @@ exports[`enzyme test with prop containing css element 1`] = `
 
 <Greeting
   content={
-    <CssProp(p)>
+    <p
+      css="unknown styles"
+    >
       Hello
-    </CssProp(p)>
+    </p>
   }
 >
   <div>
     <p
       className="emotion-0"
+    >
+      Hello
+    </p>
+     
+    World!
+  </div>
+</Greeting>
+`;
+
+exports[`enzyme test with prop containing css element not at the top level 1`] = `
+.emotion-0 {
+  background-color: blue;
+}
+
+.emotion-0 {
+  background-color: blue;
+}
+
+<div>
+  <Greeting
+    content={
+      <p
+        css="unknown styles"
+        id="something"
+      >
+        Hello
+      </p>
+    }
+  >
+    <div>
+      <p
+        className="emotion-0"
+        id="something"
+      >
+        Hello
+      </p>
+       
+      World!
+    </div>
+  </Greeting>
+</div>
+`;
+
+exports[`enzyme test with prop containing css element with other label 1`] = `
+.emotion-0 {
+  background-color: blue;
+}
+
+.emotion-0 {
+  background-color: blue;
+}
+
+<Greeting
+  content={
+    <p
+      css="unknown styles"
+      id="something"
+    >
+      Hello
+    </p>
+  }
+>
+  <Thing
+    content={
+      <div
+        css="unknown styles"
+      />
+    }
+  >
+    <p
+      className="emotion-0"
+      id="something"
+    >
+      Hello
+    </p>
+     
+    World!
+  </Thing>
+</Greeting>
+`;
+
+exports[`enzyme test with prop containing css element with other props 1`] = `
+.emotion-0 {
+  background-color: blue;
+}
+
+.emotion-0 {
+  background-color: blue;
+}
+
+<Greeting
+  content={
+    <p
+      css="unknown styles"
+      id="something"
+    >
+      Hello
+    </p>
+  }
+>
+  <div>
+    <p
+      className="emotion-0"
+      id="something"
     >
       Hello
     </p>

--- a/packages/jest-emotion/test/react-enzyme.test.js
+++ b/packages/jest-emotion/test/react-enzyme.test.js
@@ -15,3 +15,15 @@ test('enzyme mount test', () => {
   const tree = enzyme.mount(<Greeting>hello</Greeting>)
   expect(tree).toMatchSnapshot()
 })
+
+test.only('enzyme test with prop containing css element', () => {
+  const Greeting = ({ children, content }) => (
+    <div css={{ width: '100%' }}>{children}</div>
+  )
+  const tree = enzyme.mount(
+    <Greeting content={<p css={{ background: 'red' }}>hello</p>}>
+      hello
+    </Greeting>
+  )
+  expect(tree).toMatchSnapshot()
+})

--- a/packages/jest-emotion/test/react-enzyme.test.js
+++ b/packages/jest-emotion/test/react-enzyme.test.js
@@ -30,3 +30,71 @@ test('enzyme test with prop containing css element', () => {
   )
   expect(tree).toMatchSnapshot()
 })
+
+test('enzyme test with prop containing css element not at the top level', () => {
+  const Greeting = ({ children, content }) => (
+    <div>
+      {content} {children}
+    </div>
+  )
+
+  const tree = enzyme.mount(
+    <div>
+      <Greeting
+        content={
+          <p id="something" css={{ backgroundColor: 'blue' }}>
+            Hello
+          </p>
+        }
+      >
+        World!
+      </Greeting>
+    </div>
+  )
+  expect(tree).toMatchSnapshot()
+})
+
+test('enzyme test with prop containing css element with other props', () => {
+  const Greeting = ({ children, content }) => (
+    <div>
+      {content} {children}
+    </div>
+  )
+
+  const tree = enzyme.mount(
+    <Greeting
+      content={
+        <p id="something" css={{ backgroundColor: 'blue' }}>
+          Hello
+        </p>
+      }
+    >
+      World!
+    </Greeting>
+  )
+  expect(tree).toMatchSnapshot()
+})
+
+test('enzyme test with prop containing css element with other label', () => {
+  const Thing = ({ content, children }) => {
+    return children
+  }
+  const Greeting = ({ children, content }) => (
+    <Thing content={<div css={{ color: 'hotpink' }} />}>
+      {content} {children}
+    </Thing>
+  )
+
+  const tree = enzyme.mount(
+    <Greeting
+      content={
+        <p id="something" css={{ backgroundColor: 'blue' }}>
+          Hello
+        </p>
+      }
+    >
+      World!
+    </Greeting>
+  )
+  expect(tree).toMatchSnapshot()
+})

--- a/packages/jest-emotion/test/react-enzyme.test.js
+++ b/packages/jest-emotion/test/react-enzyme.test.js
@@ -16,13 +16,16 @@ test('enzyme mount test', () => {
   expect(tree).toMatchSnapshot()
 })
 
-test.only('enzyme test with prop containing css element', () => {
+test('enzyme test with prop containing css element', () => {
   const Greeting = ({ children, content }) => (
-    <div css={{ width: '100%' }}>{children}</div>
+    <div>
+      {content} {children}
+    </div>
   )
+
   const tree = enzyme.mount(
-    <Greeting content={<p css={{ background: 'red' }}>hello</p>}>
-      hello
+    <Greeting content={<p css={{ backgroundColor: 'blue' }}>Hello</p>}>
+      World!
     </Greeting>
   )
   expect(tree).toMatchSnapshot()


### PR DESCRIPTION
**What**:
Omits CSS prop internals in snapshot tests

**Why**:
Because currently we're getting base64 strings in our snapshot tests when we pass a component with a CSS prop to another component. 

**Example:** 
```jsx
const tree = enzyme.mount(
    <Greeting content={<p css={{ background: 'red' }}>hello</p>}>
      hello
    </Greeting>
  )
```

**Snapshot output:**
```jsx
<Greeting
  content={
    <ForwardRef(render)
      __EMOTION_TYPE_PLEASE_DO_NOT_USE__="p"
      css={
        Object {
          "map": "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInJlYWN0LWVuenltZS50ZXN0LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQXVCMEIiLCJmaWxlIjoicmVhY3QtZW56eW1lLnRlc3QuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgJ3Rlc3QtdXRpbHMvbGVnYWN5LWVudidcbi8qKiBAanN4IGpzeCAqL1xuaW1wb3J0ICogYXMgZW56eW1lIGZyb20gJ2VuenltZSdcbmltcG9ydCB7IGpzeCB9IGZyb20gJ0BlbW90aW9uL2NvcmUnXG5pbXBvcnQgeyBjcmVhdGVTZXJpYWxpemVyIGFzIGNyZWF0ZUVuenltZVNlcmlhbGl6ZXIgfSBmcm9tICdlbnp5bWUtdG8tanNvbidcbmltcG9ydCB7IGNyZWF0ZVNlcmlhbGl6ZXIgfSBmcm9tICdqZXN0LWVtb3Rpb24nXG5cbmV4cGVjdC5hZGRTbmFw== */",
          "name": "1et9bco-tree",
          "styles": "background:red;label:tree;",
        }
      }
    >
      hello
    </ForwardRef(render)>
  }
>
```

**How**:
I've added a prop filter which removes all of the emotion specific props (This is currently breaking a lot of tests and still needs refactoring)

**Checklist**:
- [x] Documentation N/A
- [x] Tests
- [x] Code complete

cc: @petegleeson 
