### PR TITLE
feat: expose EmotionCacheContext

### DIFF
--- a/packages/core/src/context.js
+++ b/packages/core/src/context.js
@@ -4,7 +4,7 @@ import * as React from 'react'
 import createCache from '@emotion/cache'
 import { isBrowser } from './utils'
 
-let EmotionCacheContext: React.Context<EmotionCache | null> = React.createContext(
+export let EmotionCacheContext: React.Context<EmotionCache | null> = React.createContext(
   isBrowser ? createCache() : null
 )
 

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,5 +1,5 @@
 // @flow
-export { withEmotionCache, CacheProvider, ThemeContext } from './context'
+export { withEmotionCache, CacheProvider, ThemeContext, EmotionCacheContext } from './context'
 export { jsx } from './jsx'
 export { Global } from './global'
 export { keyframes } from './keyframes'


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

It exposes the `EmotionCacheContext` from `@emotion/core`, like it already happens with the `ThemeContext` export.

<!-- Why are these changes necessary? -->
**Why**:

`React#useContext` works only if the whole React Context is provided, right now we only expose `CacheProvider`, which is not enough.

<!-- How were these changes implemented? -->
**How**:

I made the bare minimum amount of changes needed to export the pre-existing `EmotionCacheContext`.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete

<!-- feel free to add additional comments -->
