### PR TITLE
The default export of react-native has been removed.

### DIFF
--- a/packages/native/src/index.js
+++ b/packages/native/src/index.js
@@ -1,4 +1,4 @@
-import reactNative from 'react-native'
+import * as reactNative from 'react-native'
 import { createCss } from '@emotion/primitives-core'
 
 import { styled } from './styled'


### PR DESCRIPTION
The default export of react-native has been removed. We must import it this way in order to make emotion/native works with react-native-web.

Related: 
https://github.com/necolas/react-native-web/issues/1310