### PR TITLE
Allow jest-emotion matcher to match target by RegExp

### DIFF
--- a/packages/jest-emotion/README.md
+++ b/packages/jest-emotion/README.md
@@ -105,6 +105,44 @@ test('renders with correct styles', () => {
 })
 ```
 
+Use `media` and `target` options to assert on rules within media queries and to target nested components, pseudo-classes, and pseudo-elements.
+
+```jsx
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { matchers } from 'jest-emotion'
+import styled from '@emotion/styled'
+
+// Add the custom matchers provided by 'jest-emotion'
+expect.extend(matchers)
+
+test('renders with correct link styles', () => {
+  const Container = styled.div`
+    font-size: 14px;
+
+    a {
+      color: yellow;
+    }
+
+    a:hover {
+      color: black;
+    }
+
+    @media (min-width: 768px) {
+      font-size: 16px;
+    }
+  `
+
+  const tree = renderer.create(<Container>hello world</Container>).toJSON()
+
+  expect(tree).toHaveStyleRule('color', 'yellow', { target: /a$/ })
+  expect(tree).toHaveStyleRule('color', 'black', { target: 'a:hover' })
+  expect(tree).toHaveStyleRule('font-size', '16px', {
+    media: '(min-width: 768px)'
+  })
+})
+```
+
 ## Thanks
 
 Thanks to [Kent C. Dodds](https://twitter.com/kentcdodds) who wrote [jest-glamor-react](https://github.com/kentcdodds/jest-glamor-react) which this library is largely based on. ❤️

--- a/packages/jest-emotion/src/utils.js
+++ b/packages/jest-emotion/src/utils.js
@@ -177,7 +177,7 @@ export function getKeys(elements: Array<HTMLStyleElement>) {
 export function hasClassNames(
   classNames: Array<string>,
   selectors: Array<string>,
-  target: ?string
+  target?: string | RegExp
 ): boolean {
   // selectors is the classNames of specific css rule
   return selectors.some(selector => {
@@ -188,7 +188,9 @@ export function hasClassNames(
       return classNames.includes(selector.slice(1))
     }
     // check if selector (className) of specific css rule match target
-    return selector.includes(target)
+    return target instanceof RegExp
+      ? target.test(selector)
+      : selector.includes(target)
   })
 }
 

--- a/packages/jest-emotion/test/matchers.test.js
+++ b/packages/jest-emotion/test/matchers.test.js
@@ -174,6 +174,26 @@ describe('toHaveStyleRule', () => {
     expect(tree).toHaveStyleRule('fill', 'green', { target: `${Svg}` })
   })
 
+  it('matches target styles by regex', () => {
+    const localDivStyle = css`
+      a {
+        color: yellow;
+      }
+      a:hover {
+        color: black;
+      }
+    `
+    const tree = renderer
+      .create(
+        <div css={localDivStyle}>
+          <svg css={svgStyle} />
+        </div>
+      )
+      .toJSON()
+
+    expect(tree).toHaveStyleRule('color', 'yellow', { target: /a$/ })
+  })
+
   it('matches proper style for css', () => {
     const tree = renderer
       .create(


### PR DESCRIPTION
**What**:

The jest-emotion matcher `toHaveStyleRule()` takes an option `target` (added in #1110) that allows developers to target rules in nested components or pseudo-selectors.

It matches the target based on a simple string search and looks like this:

```javascript
expect(div).toHaveStyleRule('color', 'yellow', { target: 'a:hover' })
```

This change lets developers also match the `target` by RegExp:

```javascript
expect(div).toHaveStyleRule('color', 'yellow', { target: /a$/ })
```

**Why**:

In some instances, a simple string search is too naive to target a rule.

For example:

```javascript
const style = css`
  .apple {
    color: red;
  }

  a {
    color: yellow;
  }

  a:hover {
    color: black;
  }
`
```

In this case `{ target: 'a' }` would match all three selectors, potentially causing a failed assertion by matching the wrong rule. Matching with RegExp gives the developer the opportunity to narrow down on the appropriate selector.

**How**:

The underlying util `hasClassNames()` was updated to accept a string or RegExp target, and it does basic type checking on the param to determine whether to do a RegExp test or a string search.

**Checklist**:
- [x] Documentation
- [x] Tests
- [x] Code complete

**A little note**:

I'm coming in green to Flow, so you might double-check my `target?: string | RegExp` type annotation.