### PR TITLE
only changes jsx pragma when a css prop is detected

### DIFF
--- a/packages/babel-plugin-jsx-pragmatic/__tests__/__fixtures__/css-prop.js
+++ b/packages/babel-plugin-jsx-pragmatic/__tests__/__fixtures__/css-prop.js
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export default () => <p css={{ backgroundColor: 'hotpink' }}>hello</p>

--- a/packages/babel-plugin-jsx-pragmatic/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-jsx-pragmatic/__tests__/__snapshots__/index.js.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`@emotion/babel-plugin-jsx-pragmatic css-prop 1`] = `
+"import React from 'react'
+
+export default () => <p css={{ backgroundColor: 'hotpink' }}>hello</p>
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { jsx as ___EmotionJSX } from \\"@emotion/core\\";
+import React from 'react';
+export default (() => <p css={{
+  backgroundColor: 'hotpink'
+}}>hello</p>);"
+`;
+
 exports[`@emotion/babel-plugin-jsx-pragmatic fragment-only 1`] = `
 "import * as React from 'react'
 
@@ -8,7 +23,6 @@ const F = () => <></>
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { jsx as ___EmotionJSX } from \\"@emotion/core\\";
 import * as React from 'react';
 
 const F = () => <></>;"
@@ -22,7 +36,6 @@ const P = () => <p />
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { jsx as ___EmotionJSX } from \\"@emotion/core\\";
 import * as React from 'react';
 
 const P = () => <p />;"

--- a/packages/babel-plugin-jsx-pragmatic/src/index.js
+++ b/packages/babel-plugin-jsx-pragmatic/src/index.js
@@ -34,11 +34,15 @@ export default function jsxPragmatic(babel) {
         }
       },
 
-      JSXElement: function(path, state) {
-        state.set('jsxDetected', true)
-      },
-      JSXFragment: function(path, state) {
-        state.set('jsxDetected', true)
+      // jsx components with a prop called 'css'
+      JSXIdentifier: function(path, state) {
+        if (
+          path.node.name === 'css' &&
+          path.parentPath &&
+          t.isJSXAttribute(path.parentPath.node)
+        ) {
+          state.set('jsxDetected', true)
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

<!-- Why are these changes necessary? -->
**Why**:
👋We are currently upgrading our monorepo from emotion 9 to emotion 10. The migration is pretty close to done. One thing we noticed were the bundle sizes of all our packages increasing by the size of `emotion/core`. This increase was happening regardless of whether the package was using emotion at all.

Digging in a bit, it looks like the `@emotion/babel-preset-css-prop` was always changing the pragma and adding a `@emotion/core` import. We only want to include emotion when it is used.

<!-- How were these changes implemented? -->
**How**:
The current version of the `@emotion/babel-plugin-jsx-pragmatic` changes the pragma if any JSX is found in the file. I made it a bit more specific and only change the pragma when a `css` prop exists on a component.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Code complete

<!-- feel free to add additional comments -->
I don't have full context of the impact of this change. Let me know if there are alternative ways of solving this issue. Thanks.