### PR TITLE
fix: allow class declaration inside object destructuring

### DIFF
--- a/packages/core/src/class-names.js
+++ b/packages/core/src/class-names.js
@@ -75,7 +75,7 @@ type Props = {
     cx: (...args: Array<ClassNameArg>) => string,
     theme: Object,
     // This allows to do `({ css, myClass = css`color: red;` }) => `
-    [string]: string,
+    [string]: string
   }) => React.Node
 }
 

--- a/packages/core/src/class-names.js
+++ b/packages/core/src/class-names.js
@@ -73,7 +73,9 @@ type Props = {
   children: ({
     css: (...args: Array<any>) => string,
     cx: (...args: Array<ClassNameArg>) => string,
-    theme: Object
+    theme: Object,
+    // This allows to do `({ css, myClass = css`color: red;` }) => `
+    [string]: string,
   }) => React.Node
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
With the current types, we can't do this:

```jsx
<ClassNames>
  {({ css, redText = css`color: red` }) => (
    <div className={redText}>I'm red</div>
  )}
</ClassNames>
```

<!-- Why are these changes necessary? -->
**Why**:
My type change make the above syntax allowed.

<!-- How were these changes implemented? -->
**How**:
I just added a type wildcard that accepts any property that has a string as value.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete

<!-- feel free to add additional comments -->

The practice of defining classes inside the object destructuring is very useful to make the code more concise, without it we are forced to create a new code block, define the variable, and return the JSX with an explicit return.
