### PR TITLE
Improve code highlighting in jest-emotion docs

### DIFF
--- a/packages/jest-emotion/README.md
+++ b/packages/jest-emotion/README.md
@@ -133,22 +133,22 @@ You can provide additional options for `toHaveStyleRule` matcher.
 `target` - helps to specify css selector or other component
 where style rule should be found.
 
-```
+```js
 expect(tree).toHaveStyleRule('width', '50px', { target: ':hover' })
 ```
 
-```
+```js
 expect(tree).toHaveStyleRule('color', 'yellow', { target: 'span' })
 ```
 
-```
+```js
 expect(tree).toHaveStyleRule('fill', 'green', { target: `${Svg}` })
 ```
 
 `media` - specifies the media rule where the matcher
 should look for the style property.
 
-```
+```js
 expect(tree).toHaveStyleRule('font-size', '14px', {
   media: 'screen and (max-width: 1200px)'
 })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: This PR improves the code highlighting in the `jest-emotion` README (and therefore the documentation site for that package).

<!-- Why are these changes necessary? -->
**Why**: Improves readability and code snippet style consistency. Also just looking to help improve documentation sites for projects I use.

<!-- How were these changes implemented? -->
**How**: Added `js` as the language for some of the code blocks. If these changes are not useful, feel free to close, but thought this was a little visual improvement for this page. 😄 

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A

<!-- feel free to add additional comments -->

**Before**:

<img width="731" alt="Screen Shot 2019-04-25 at 3 37 12 PM" src="https://user-images.githubusercontent.com/2344137/56772739-14888480-6770-11e9-8577-bc476d7f48da.png">

**After**:

<img width="731" alt="Screen Shot 2019-04-25 at 3 37 28 PM" src="https://user-images.githubusercontent.com/2344137/56772740-14888480-6770-11e9-9e12-1b580caa361b.png">

