### PR TITLE
Add Option to Keep CSS Comments in babel-plugin-emotion. Fixes #1325

### DIFF
--- a/packages/babel-plugin-emotion/__tests__/__snapshots__/vanilla-emotion.js.snap
+++ b/packages/babel-plugin-emotion/__tests__/__snapshots__/vanilla-emotion.js.snap
@@ -25,30 +25,40 @@ css\`
   &.foo {
     left: 3px;
   }
+
+  &.zot {
+    /* @noflip */
+    right: 1px;
+  }
 \`
 
 css\`
-  // @noflip
+  /* @whatever */
   left: 4px;
 \`
 
 css\`
-  /* @shouldberemoved */
   left: 5px;
+
+  /* @whatever */
+  &.foo {
+    left: 6px;
+  }
+
+  &.zot {
+    /* @whatever */
+    right: 2px;
+  }
+\`
+
+css\`
+  // @noflip should-be-removed
+  left: 7px;
 \`
 
 css\`
   // @shouldberemoved
-  left: 6px;
-\`
-
-css\`
-  left: 7px;
-
-  /* @shouldberemoved */
-  &.foo {
-    left: 8px;
-  }
+  left: 8px;
 \`
 
 
@@ -63,7 +73,7 @@ _css(process.env.NODE_ENV === \\"production\\" ? {
 } : {
   name: \\"1lrxbo5\\",
   styles: \\"color:hotpink;\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVHIiwiZmlsZSI6ImNvbW1lbnRzLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbidcblxuY3NzYFxuICAvLyBkaXNwbGF5OmZsZXg7XG5cbiAgLypcbndlZlxuXG5kZndmKi9cbiAgY29sb3I6IGhvdHBpbms7XG5gXG5cbmNzc2BcbiAgLyogQG5vZmxpcCAqL1xuICBsZWZ0OiAxcHg7XG5gXG5cbmNzc2BcbiAgbGVmdDogMnB4O1xuXG4gIC8qIEBub2ZsaXAgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDNweDtcbiAgfVxuYFxuXG5jc3NgXG4gIC8vIEBub2ZsaXBcbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIC8qIEBzaG91bGRiZXJlbW92ZWQgKi9cbiAgbGVmdDogNXB4O1xuYFxuXG5jc3NgXG4gIC8vIEBzaG91bGRiZXJlbW92ZWRcbiAgbGVmdDogNnB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDdweDtcblxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiA4cHg7XG4gIH1cbmBcbiJdfQ== */\\"
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVHIiwiZmlsZSI6ImNvbW1lbnRzLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbidcblxuY3NzYFxuICAvLyBkaXNwbGF5OmZsZXg7XG5cbiAgLypcbndlZlxuXG5kZndmKi9cbiAgY29sb3I6IGhvdHBpbms7XG5gXG5cbmNzc2BcbiAgLyogQG5vZmxpcCAqL1xuICBsZWZ0OiAxcHg7XG5gXG5cbmNzc2BcbiAgbGVmdDogMnB4O1xuXG4gIC8qIEBub2ZsaXAgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDNweDtcbiAgfVxuXG4gICYuem90IHtcbiAgICAvKiBAbm9mbGlwICovXG4gICAgcmlnaHQ6IDFweDtcbiAgfVxuYFxuXG5jc3NgXG4gIC8qIEB3aGF0ZXZlciAqL1xuICBsZWZ0OiA0cHg7XG5gXG5cbmNzc2BcbiAgbGVmdDogNXB4O1xuXG4gIC8qIEB3aGF0ZXZlciAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogNnB4O1xuICB9XG5cbiAgJi56b3Qge1xuICAgIC8qIEB3aGF0ZXZlciAqL1xuICAgIHJpZ2h0OiAycHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwIHNob3VsZC1iZS1yZW1vdmVkXG4gIGxlZnQ6IDdweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDhweDtcbmBcbiJdfQ== */\\"
 });
 
 /*#__PURE__*/
@@ -73,57 +83,57 @@ _css(process.env.NODE_ENV === \\"production\\" ? {
 } : {
   name: \\"njzoxi\\",
   styles: \\"/* @noflip */ left:1px;\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQVlHIiwiZmlsZSI6ImNvbW1lbnRzLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbidcblxuY3NzYFxuICAvLyBkaXNwbGF5OmZsZXg7XG5cbiAgLypcbndlZlxuXG5kZndmKi9cbiAgY29sb3I6IGhvdHBpbms7XG5gXG5cbmNzc2BcbiAgLyogQG5vZmxpcCAqL1xuICBsZWZ0OiAxcHg7XG5gXG5cbmNzc2BcbiAgbGVmdDogMnB4O1xuXG4gIC8qIEBub2ZsaXAgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDNweDtcbiAgfVxuYFxuXG5jc3NgXG4gIC8vIEBub2ZsaXBcbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIC8qIEBzaG91bGRiZXJlbW92ZWQgKi9cbiAgbGVmdDogNXB4O1xuYFxuXG5jc3NgXG4gIC8vIEBzaG91bGRiZXJlbW92ZWRcbiAgbGVmdDogNnB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDdweDtcblxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiA4cHg7XG4gIH1cbmBcbiJdfQ== */\\"
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQVlHIiwiZmlsZSI6ImNvbW1lbnRzLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbidcblxuY3NzYFxuICAvLyBkaXNwbGF5OmZsZXg7XG5cbiAgLypcbndlZlxuXG5kZndmKi9cbiAgY29sb3I6IGhvdHBpbms7XG5gXG5cbmNzc2BcbiAgLyogQG5vZmxpcCAqL1xuICBsZWZ0OiAxcHg7XG5gXG5cbmNzc2BcbiAgbGVmdDogMnB4O1xuXG4gIC8qIEBub2ZsaXAgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDNweDtcbiAgfVxuXG4gICYuem90IHtcbiAgICAvKiBAbm9mbGlwICovXG4gICAgcmlnaHQ6IDFweDtcbiAgfVxuYFxuXG5jc3NgXG4gIC8qIEB3aGF0ZXZlciAqL1xuICBsZWZ0OiA0cHg7XG5gXG5cbmNzc2BcbiAgbGVmdDogNXB4O1xuXG4gIC8qIEB3aGF0ZXZlciAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogNnB4O1xuICB9XG5cbiAgJi56b3Qge1xuICAgIC8qIEB3aGF0ZXZlciAqL1xuICAgIHJpZ2h0OiAycHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwIHNob3VsZC1iZS1yZW1vdmVkXG4gIGxlZnQ6IDdweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDhweDtcbmBcbiJdfQ== */\\"
 });
 
 /*#__PURE__*/
 _css(process.env.NODE_ENV === \\"production\\" ? {
-  name: \\"1h3pgg4\\",
-  styles: \\"left:2px;/* @noflip */ &.foo{left:3px;}\\"
+  name: \\"1d9s3pk\\",
+  styles: \\"left:2px;/* @noflip */ &.foo{left:3px;}&.zot{/* @noflip */ right:1px;}\\"
 } : {
-  name: \\"1h3pgg4\\",
-  styles: \\"left:2px;/* @noflip */ &.foo{left:3px;}\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQWlCRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+  name: \\"1d9s3pk\\",
+  styles: \\"left:2px;/* @noflip */ &.foo{left:3px;}&.zot{/* @noflip */ right:1px;}\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQWlCRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cblxuICAmLnpvdCB7XG4gICAgLyogQG5vZmxpcCAqL1xuICAgIHJpZ2h0OiAxcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDVweDtcblxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDZweDtcbiAgfVxuXG4gICYuem90IHtcbiAgICAvKiBAd2hhdGV2ZXIgKi9cbiAgICByaWdodDogMnB4O1xuICB9XG5gXG5cbmNzc2BcbiAgLy8gQG5vZmxpcCBzaG91bGQtYmUtcmVtb3ZlZFxuICBsZWZ0OiA3cHg7XG5gXG5cbmNzc2BcbiAgLy8gQHNob3VsZGJlcmVtb3ZlZFxuICBsZWZ0OiA4cHg7XG5gXG4iXX0= */\\"
 });
 
 /*#__PURE__*/
 _css(process.env.NODE_ENV === \\"production\\" ? {
-  name: \\"kiy9xc\\",
-  styles: \\"left:4px;\\"
+  name: \\"197xj9y\\",
+  styles: \\"/* @whatever */ left:4px;\\"
 } : {
-  name: \\"kiy9xc\\",
-  styles: \\"left:4px;\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQTBCRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+  name: \\"197xj9y\\",
+  styles: \\"/* @whatever */ left:4px;\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQStCRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cblxuICAmLnpvdCB7XG4gICAgLyogQG5vZmxpcCAqL1xuICAgIHJpZ2h0OiAxcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDVweDtcblxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDZweDtcbiAgfVxuXG4gICYuem90IHtcbiAgICAvKiBAd2hhdGV2ZXIgKi9cbiAgICByaWdodDogMnB4O1xuICB9XG5gXG5cbmNzc2BcbiAgLy8gQG5vZmxpcCBzaG91bGQtYmUtcmVtb3ZlZFxuICBsZWZ0OiA3cHg7XG5gXG5cbmNzc2BcbiAgLy8gQHNob3VsZGJlcmVtb3ZlZFxuICBsZWZ0OiA4cHg7XG5gXG4iXX0= */\\"
 });
 
 /*#__PURE__*/
 _css(process.env.NODE_ENV === \\"production\\" ? {
-  name: \\"k9l721\\",
-  styles: \\"left:5px;\\"
+  name: \\"11qyfqd\\",
+  styles: \\"left:5px;/* @whatever */ &.foo{left:6px;}&.zot{/* @whatever */ right:2px;}\\"
 } : {
-  name: \\"k9l721\\",
-  styles: \\"left:5px;\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQStCRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+  name: \\"11qyfqd\\",
+  styles: \\"left:5px;/* @whatever */ &.foo{left:6px;}&.zot{/* @whatever */ right:2px;}\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQW9DRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cblxuICAmLnpvdCB7XG4gICAgLyogQG5vZmxpcCAqL1xuICAgIHJpZ2h0OiAxcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDVweDtcblxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDZweDtcbiAgfVxuXG4gICYuem90IHtcbiAgICAvKiBAd2hhdGV2ZXIgKi9cbiAgICByaWdodDogMnB4O1xuICB9XG5gXG5cbmNzc2BcbiAgLy8gQG5vZmxpcCBzaG91bGQtYmUtcmVtb3ZlZFxuICBsZWZ0OiA3cHg7XG5gXG5cbmNzc2BcbiAgLy8gQHNob3VsZGJlcmVtb3ZlZFxuICBsZWZ0OiA4cHg7XG5gXG4iXX0= */\\"
 });
 
 /*#__PURE__*/
 _css(process.env.NODE_ENV === \\"production\\" ? {
-  name: \\"1a86t35\\",
-  styles: \\"left:6px;\\"
+  name: \\"luqhsn\\",
+  styles: \\"left:7px;\\"
 } : {
-  name: \\"1a86t35\\",
-  styles: \\"left:6px;\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQW9DRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+  name: \\"luqhsn\\",
+  styles: \\"left:7px;\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQWtERyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cblxuICAmLnpvdCB7XG4gICAgLyogQG5vZmxpcCAqL1xuICAgIHJpZ2h0OiAxcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDVweDtcblxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDZweDtcbiAgfVxuXG4gICYuem90IHtcbiAgICAvKiBAd2hhdGV2ZXIgKi9cbiAgICByaWdodDogMnB4O1xuICB9XG5gXG5cbmNzc2BcbiAgLy8gQG5vZmxpcCBzaG91bGQtYmUtcmVtb3ZlZFxuICBsZWZ0OiA3cHg7XG5gXG5cbmNzc2BcbiAgLy8gQHNob3VsZGJlcmVtb3ZlZFxuICBsZWZ0OiA4cHg7XG5gXG4iXX0= */\\"
 });
 
 /*#__PURE__*/
 _css(process.env.NODE_ENV === \\"production\\" ? {
-  name: \\"15q6a81\\",
-  styles: \\"left:7px;&.foo{left:8px;}\\"
+  name: \\"1v35xj1\\",
+  styles: \\"left:8px;\\"
 } : {
-  name: \\"15q6a81\\",
-  styles: \\"left:7px;&.foo{left:8px;}\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQXlDRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+  name: \\"1v35xj1\\",
+  styles: \\"left:8px;\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQXVERyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cblxuICAmLnpvdCB7XG4gICAgLyogQG5vZmxpcCAqL1xuICAgIHJpZ2h0OiAxcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDVweDtcblxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDZweDtcbiAgfVxuXG4gICYuem90IHtcbiAgICAvKiBAd2hhdGV2ZXIgKi9cbiAgICByaWdodDogMnB4O1xuICB9XG5gXG5cbmNzc2BcbiAgLy8gQG5vZmxpcCBzaG91bGQtYmUtcmVtb3ZlZFxuICBsZWZ0OiA3cHg7XG5gXG5cbmNzc2BcbiAgLy8gQHNob3VsZGJlcmVtb3ZlZFxuICBsZWZ0OiA4cHg7XG5gXG4iXX0= */\\"
 });"
 `;
 

--- a/packages/babel-plugin-emotion/__tests__/__snapshots__/vanilla-emotion.js.snap
+++ b/packages/babel-plugin-emotion/__tests__/__snapshots__/vanilla-emotion.js.snap
@@ -13,6 +13,44 @@ dfwf*/
   color: hotpink;
 \`
 
+css\`
+  /* @noflip */
+  left: 1px;
+\`
+
+css\`
+  left: 2px;
+
+  /* @noflip */
+  &.foo {
+    left: 3px;
+  }
+\`
+
+css\`
+  // @noflip
+  left: 4px;
+\`
+
+css\`
+  /* @shouldberemoved */
+  left: 5px;
+\`
+
+css\`
+  // @shouldberemoved
+  left: 6px;
+\`
+
+css\`
+  left: 7px;
+
+  /* @shouldberemoved */
+  &.foo {
+    left: 8px;
+  }
+\`
+
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -25,7 +63,67 @@ _css(process.env.NODE_ENV === \\"production\\" ? {
 } : {
   name: \\"1lrxbo5\\",
   styles: \\"color:hotpink;\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVHIiwiZmlsZSI6ImNvbW1lbnRzLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbidcblxuY3NzYFxuICAvLyBkaXNwbGF5OmZsZXg7XG5cbiAgLypcbndlZlxuXG5kZndmKi9cbiAgY29sb3I6IGhvdHBpbms7XG5gXG4iXX0= */\\"
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVHIiwiZmlsZSI6ImNvbW1lbnRzLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbidcblxuY3NzYFxuICAvLyBkaXNwbGF5OmZsZXg7XG5cbiAgLypcbndlZlxuXG5kZndmKi9cbiAgY29sb3I6IGhvdHBpbms7XG5gXG5cbmNzc2BcbiAgLyogQG5vZmxpcCAqL1xuICBsZWZ0OiAxcHg7XG5gXG5cbmNzc2BcbiAgbGVmdDogMnB4O1xuXG4gIC8qIEBub2ZsaXAgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDNweDtcbiAgfVxuYFxuXG5jc3NgXG4gIC8vIEBub2ZsaXBcbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIC8qIEBzaG91bGRiZXJlbW92ZWQgKi9cbiAgbGVmdDogNXB4O1xuYFxuXG5jc3NgXG4gIC8vIEBzaG91bGRiZXJlbW92ZWRcbiAgbGVmdDogNnB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDdweDtcblxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiA4cHg7XG4gIH1cbmBcbiJdfQ== */\\"
+});
+
+/*#__PURE__*/
+_css(process.env.NODE_ENV === \\"production\\" ? {
+  name: \\"njzoxi\\",
+  styles: \\"/* @noflip */ left:1px;\\"
+} : {
+  name: \\"njzoxi\\",
+  styles: \\"/* @noflip */ left:1px;\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQVlHIiwiZmlsZSI6ImNvbW1lbnRzLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbidcblxuY3NzYFxuICAvLyBkaXNwbGF5OmZsZXg7XG5cbiAgLypcbndlZlxuXG5kZndmKi9cbiAgY29sb3I6IGhvdHBpbms7XG5gXG5cbmNzc2BcbiAgLyogQG5vZmxpcCAqL1xuICBsZWZ0OiAxcHg7XG5gXG5cbmNzc2BcbiAgbGVmdDogMnB4O1xuXG4gIC8qIEBub2ZsaXAgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDNweDtcbiAgfVxuYFxuXG5jc3NgXG4gIC8vIEBub2ZsaXBcbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIC8qIEBzaG91bGRiZXJlbW92ZWQgKi9cbiAgbGVmdDogNXB4O1xuYFxuXG5jc3NgXG4gIC8vIEBzaG91bGRiZXJlbW92ZWRcbiAgbGVmdDogNnB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDdweDtcblxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiA4cHg7XG4gIH1cbmBcbiJdfQ== */\\"
+});
+
+/*#__PURE__*/
+_css(process.env.NODE_ENV === \\"production\\" ? {
+  name: \\"1h3pgg4\\",
+  styles: \\"left:2px;/* @noflip */ &.foo{left:3px;}\\"
+} : {
+  name: \\"1h3pgg4\\",
+  styles: \\"left:2px;/* @noflip */ &.foo{left:3px;}\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQWlCRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+});
+
+/*#__PURE__*/
+_css(process.env.NODE_ENV === \\"production\\" ? {
+  name: \\"kiy9xc\\",
+  styles: \\"left:4px;\\"
+} : {
+  name: \\"kiy9xc\\",
+  styles: \\"left:4px;\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQTBCRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+});
+
+/*#__PURE__*/
+_css(process.env.NODE_ENV === \\"production\\" ? {
+  name: \\"k9l721\\",
+  styles: \\"left:5px;\\"
+} : {
+  name: \\"k9l721\\",
+  styles: \\"left:5px;\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQStCRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+});
+
+/*#__PURE__*/
+_css(process.env.NODE_ENV === \\"production\\" ? {
+  name: \\"1a86t35\\",
+  styles: \\"left:6px;\\"
+} : {
+  name: \\"1a86t35\\",
+  styles: \\"left:6px;\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQW9DRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+});
+
+/*#__PURE__*/
+_css(process.env.NODE_ENV === \\"production\\" ? {
+  name: \\"15q6a81\\",
+  styles: \\"left:7px;&.foo{left:8px;}\\"
+} : {
+  name: \\"15q6a81\\",
+  styles: \\"left:7px;&.foo{left:8px;}\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQXlDRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
 });"
 `;
 

--- a/packages/babel-plugin-emotion/__tests__/vanilla-emotion-macro/__fixtures__/comments.js
+++ b/packages/babel-plugin-emotion/__tests__/vanilla-emotion-macro/__fixtures__/comments.js
@@ -9,3 +9,41 @@ wef
 dfwf*/
   color: hotpink;
 `
+
+css`
+  /* @noflip */
+  left: 1px;
+`
+
+css`
+  left: 2px;
+
+  /* @noflip */
+  &.foo {
+    left: 3px;
+  }
+`
+
+css`
+  // @noflip
+  left: 4px;
+`
+
+css`
+  /* @shouldberemoved */
+  left: 5px;
+`
+
+css`
+  // @shouldberemoved
+  left: 6px;
+`
+
+css`
+  left: 7px;
+
+  /* @shouldberemoved */
+  &.foo {
+    left: 8px;
+  }
+`

--- a/packages/babel-plugin-emotion/__tests__/vanilla-emotion-macro/__fixtures__/comments.js
+++ b/packages/babel-plugin-emotion/__tests__/vanilla-emotion-macro/__fixtures__/comments.js
@@ -22,28 +22,38 @@ css`
   &.foo {
     left: 3px;
   }
+
+  &.zot {
+    /* @noflip */
+    right: 1px;
+  }
 `
 
 css`
-  // @noflip
+  /* @whatever */
   left: 4px;
 `
 
 css`
-  /* @shouldberemoved */
   left: 5px;
+
+  /* @whatever */
+  &.foo {
+    left: 6px;
+  }
+
+  &.zot {
+    /* @whatever */
+    right: 2px;
+  }
+`
+
+css`
+  // @noflip should-be-removed
+  left: 7px;
 `
 
 css`
   // @shouldberemoved
-  left: 6px;
-`
-
-css`
-  left: 7px;
-
-  /* @shouldberemoved */
-  &.foo {
-    left: 8px;
-  }
+  left: 8px;
 `

--- a/packages/babel-plugin-emotion/__tests__/vanilla-emotion-macro/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-emotion/__tests__/vanilla-emotion-macro/__snapshots__/index.js.snap
@@ -25,30 +25,40 @@ css\`
   &.foo {
     left: 3px;
   }
+
+  &.zot {
+    /* @noflip */
+    right: 1px;
+  }
 \`
 
 css\`
-  // @noflip
+  /* @whatever */
   left: 4px;
 \`
 
 css\`
-  /* @shouldberemoved */
   left: 5px;
+
+  /* @whatever */
+  &.foo {
+    left: 6px;
+  }
+
+  &.zot {
+    /* @whatever */
+    right: 2px;
+  }
+\`
+
+css\`
+  // @noflip should-be-removed
+  left: 7px;
 \`
 
 css\`
   // @shouldberemoved
-  left: 6px;
-\`
-
-css\`
-  left: 7px;
-
-  /* @shouldberemoved */
-  &.foo {
-    left: 8px;
-  }
+  left: 8px;
 \`
 
 
@@ -63,7 +73,7 @@ _css(process.env.NODE_ENV === \\"production\\" ? {
 } : {
   name: \\"1lrxbo5\\",
   styles: \\"color:hotpink;\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVHIiwiZmlsZSI6ImNvbW1lbnRzLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbi9tYWNybydcblxuY3NzYFxuICAvLyBkaXNwbGF5OmZsZXg7XG5cbiAgLypcbndlZlxuXG5kZndmKi9cbiAgY29sb3I6IGhvdHBpbms7XG5gXG5cbmNzc2BcbiAgLyogQG5vZmxpcCAqL1xuICBsZWZ0OiAxcHg7XG5gXG5cbmNzc2BcbiAgbGVmdDogMnB4O1xuXG4gIC8qIEBub2ZsaXAgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDNweDtcbiAgfVxuYFxuXG5jc3NgXG4gIC8vIEBub2ZsaXBcbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIC8qIEBzaG91bGRiZXJlbW92ZWQgKi9cbiAgbGVmdDogNXB4O1xuYFxuXG5jc3NgXG4gIC8vIEBzaG91bGRiZXJlbW92ZWRcbiAgbGVmdDogNnB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDdweDtcblxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiA4cHg7XG4gIH1cbmBcbiJdfQ== */\\"
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVHIiwiZmlsZSI6ImNvbW1lbnRzLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbi9tYWNybydcblxuY3NzYFxuICAvLyBkaXNwbGF5OmZsZXg7XG5cbiAgLypcbndlZlxuXG5kZndmKi9cbiAgY29sb3I6IGhvdHBpbms7XG5gXG5cbmNzc2BcbiAgLyogQG5vZmxpcCAqL1xuICBsZWZ0OiAxcHg7XG5gXG5cbmNzc2BcbiAgbGVmdDogMnB4O1xuXG4gIC8qIEBub2ZsaXAgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDNweDtcbiAgfVxuXG4gICYuem90IHtcbiAgICAvKiBAbm9mbGlwICovXG4gICAgcmlnaHQ6IDFweDtcbiAgfVxuYFxuXG5jc3NgXG4gIC8qIEB3aGF0ZXZlciAqL1xuICBsZWZ0OiA0cHg7XG5gXG5cbmNzc2BcbiAgbGVmdDogNXB4O1xuXG4gIC8qIEB3aGF0ZXZlciAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogNnB4O1xuICB9XG5cbiAgJi56b3Qge1xuICAgIC8qIEB3aGF0ZXZlciAqL1xuICAgIHJpZ2h0OiAycHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwIHNob3VsZC1iZS1yZW1vdmVkXG4gIGxlZnQ6IDdweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDhweDtcbmBcbiJdfQ== */\\"
 });
 
 /*#__PURE__*/
@@ -73,57 +83,57 @@ _css(process.env.NODE_ENV === \\"production\\" ? {
 } : {
   name: \\"njzoxi\\",
   styles: \\"/* @noflip */ left:1px;\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQVlHIiwiZmlsZSI6ImNvbW1lbnRzLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbi9tYWNybydcblxuY3NzYFxuICAvLyBkaXNwbGF5OmZsZXg7XG5cbiAgLypcbndlZlxuXG5kZndmKi9cbiAgY29sb3I6IGhvdHBpbms7XG5gXG5cbmNzc2BcbiAgLyogQG5vZmxpcCAqL1xuICBsZWZ0OiAxcHg7XG5gXG5cbmNzc2BcbiAgbGVmdDogMnB4O1xuXG4gIC8qIEBub2ZsaXAgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDNweDtcbiAgfVxuYFxuXG5jc3NgXG4gIC8vIEBub2ZsaXBcbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIC8qIEBzaG91bGRiZXJlbW92ZWQgKi9cbiAgbGVmdDogNXB4O1xuYFxuXG5jc3NgXG4gIC8vIEBzaG91bGRiZXJlbW92ZWRcbiAgbGVmdDogNnB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDdweDtcblxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiA4cHg7XG4gIH1cbmBcbiJdfQ== */\\"
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQVlHIiwiZmlsZSI6ImNvbW1lbnRzLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbi9tYWNybydcblxuY3NzYFxuICAvLyBkaXNwbGF5OmZsZXg7XG5cbiAgLypcbndlZlxuXG5kZndmKi9cbiAgY29sb3I6IGhvdHBpbms7XG5gXG5cbmNzc2BcbiAgLyogQG5vZmxpcCAqL1xuICBsZWZ0OiAxcHg7XG5gXG5cbmNzc2BcbiAgbGVmdDogMnB4O1xuXG4gIC8qIEBub2ZsaXAgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDNweDtcbiAgfVxuXG4gICYuem90IHtcbiAgICAvKiBAbm9mbGlwICovXG4gICAgcmlnaHQ6IDFweDtcbiAgfVxuYFxuXG5jc3NgXG4gIC8qIEB3aGF0ZXZlciAqL1xuICBsZWZ0OiA0cHg7XG5gXG5cbmNzc2BcbiAgbGVmdDogNXB4O1xuXG4gIC8qIEB3aGF0ZXZlciAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogNnB4O1xuICB9XG5cbiAgJi56b3Qge1xuICAgIC8qIEB3aGF0ZXZlciAqL1xuICAgIHJpZ2h0OiAycHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwIHNob3VsZC1iZS1yZW1vdmVkXG4gIGxlZnQ6IDdweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDhweDtcbmBcbiJdfQ== */\\"
 });
 
 /*#__PURE__*/
 _css(process.env.NODE_ENV === \\"production\\" ? {
-  name: \\"1h3pgg4\\",
-  styles: \\"left:2px;/* @noflip */ &.foo{left:3px;}\\"
+  name: \\"1d9s3pk\\",
+  styles: \\"left:2px;/* @noflip */ &.foo{left:3px;}&.zot{/* @noflip */ right:1px;}\\"
 } : {
-  name: \\"1h3pgg4\\",
-  styles: \\"left:2px;/* @noflip */ &.foo{left:3px;}\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQWlCRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+  name: \\"1d9s3pk\\",
+  styles: \\"left:2px;/* @noflip */ &.foo{left:3px;}&.zot{/* @noflip */ right:1px;}\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQWlCRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cblxuICAmLnpvdCB7XG4gICAgLyogQG5vZmxpcCAqL1xuICAgIHJpZ2h0OiAxcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDVweDtcblxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDZweDtcbiAgfVxuXG4gICYuem90IHtcbiAgICAvKiBAd2hhdGV2ZXIgKi9cbiAgICByaWdodDogMnB4O1xuICB9XG5gXG5cbmNzc2BcbiAgLy8gQG5vZmxpcCBzaG91bGQtYmUtcmVtb3ZlZFxuICBsZWZ0OiA3cHg7XG5gXG5cbmNzc2BcbiAgLy8gQHNob3VsZGJlcmVtb3ZlZFxuICBsZWZ0OiA4cHg7XG5gXG4iXX0= */\\"
 });
 
 /*#__PURE__*/
 _css(process.env.NODE_ENV === \\"production\\" ? {
-  name: \\"kiy9xc\\",
-  styles: \\"left:4px;\\"
+  name: \\"197xj9y\\",
+  styles: \\"/* @whatever */ left:4px;\\"
 } : {
-  name: \\"kiy9xc\\",
-  styles: \\"left:4px;\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQTBCRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+  name: \\"197xj9y\\",
+  styles: \\"/* @whatever */ left:4px;\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQStCRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cblxuICAmLnpvdCB7XG4gICAgLyogQG5vZmxpcCAqL1xuICAgIHJpZ2h0OiAxcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDVweDtcblxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDZweDtcbiAgfVxuXG4gICYuem90IHtcbiAgICAvKiBAd2hhdGV2ZXIgKi9cbiAgICByaWdodDogMnB4O1xuICB9XG5gXG5cbmNzc2BcbiAgLy8gQG5vZmxpcCBzaG91bGQtYmUtcmVtb3ZlZFxuICBsZWZ0OiA3cHg7XG5gXG5cbmNzc2BcbiAgLy8gQHNob3VsZGJlcmVtb3ZlZFxuICBsZWZ0OiA4cHg7XG5gXG4iXX0= */\\"
 });
 
 /*#__PURE__*/
 _css(process.env.NODE_ENV === \\"production\\" ? {
-  name: \\"k9l721\\",
-  styles: \\"left:5px;\\"
+  name: \\"11qyfqd\\",
+  styles: \\"left:5px;/* @whatever */ &.foo{left:6px;}&.zot{/* @whatever */ right:2px;}\\"
 } : {
-  name: \\"k9l721\\",
-  styles: \\"left:5px;\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQStCRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+  name: \\"11qyfqd\\",
+  styles: \\"left:5px;/* @whatever */ &.foo{left:6px;}&.zot{/* @whatever */ right:2px;}\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQW9DRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cblxuICAmLnpvdCB7XG4gICAgLyogQG5vZmxpcCAqL1xuICAgIHJpZ2h0OiAxcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDVweDtcblxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDZweDtcbiAgfVxuXG4gICYuem90IHtcbiAgICAvKiBAd2hhdGV2ZXIgKi9cbiAgICByaWdodDogMnB4O1xuICB9XG5gXG5cbmNzc2BcbiAgLy8gQG5vZmxpcCBzaG91bGQtYmUtcmVtb3ZlZFxuICBsZWZ0OiA3cHg7XG5gXG5cbmNzc2BcbiAgLy8gQHNob3VsZGJlcmVtb3ZlZFxuICBsZWZ0OiA4cHg7XG5gXG4iXX0= */\\"
 });
 
 /*#__PURE__*/
 _css(process.env.NODE_ENV === \\"production\\" ? {
-  name: \\"1a86t35\\",
-  styles: \\"left:6px;\\"
+  name: \\"luqhsn\\",
+  styles: \\"left:7px;\\"
 } : {
-  name: \\"1a86t35\\",
-  styles: \\"left:6px;\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQW9DRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+  name: \\"luqhsn\\",
+  styles: \\"left:7px;\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQWtERyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cblxuICAmLnpvdCB7XG4gICAgLyogQG5vZmxpcCAqL1xuICAgIHJpZ2h0OiAxcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDVweDtcblxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDZweDtcbiAgfVxuXG4gICYuem90IHtcbiAgICAvKiBAd2hhdGV2ZXIgKi9cbiAgICByaWdodDogMnB4O1xuICB9XG5gXG5cbmNzc2BcbiAgLy8gQG5vZmxpcCBzaG91bGQtYmUtcmVtb3ZlZFxuICBsZWZ0OiA3cHg7XG5gXG5cbmNzc2BcbiAgLy8gQHNob3VsZGJlcmVtb3ZlZFxuICBsZWZ0OiA4cHg7XG5gXG4iXX0= */\\"
 });
 
 /*#__PURE__*/
 _css(process.env.NODE_ENV === \\"production\\" ? {
-  name: \\"15q6a81\\",
-  styles: \\"left:7px;&.foo{left:8px;}\\"
+  name: \\"1v35xj1\\",
+  styles: \\"left:8px;\\"
 } : {
-  name: \\"15q6a81\\",
-  styles: \\"left:7px;&.foo{left:8px;}\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQXlDRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+  name: \\"1v35xj1\\",
+  styles: \\"left:8px;\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQXVERyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cblxuICAmLnpvdCB7XG4gICAgLyogQG5vZmxpcCAqL1xuICAgIHJpZ2h0OiAxcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDVweDtcblxuICAvKiBAd2hhdGV2ZXIgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDZweDtcbiAgfVxuXG4gICYuem90IHtcbiAgICAvKiBAd2hhdGV2ZXIgKi9cbiAgICByaWdodDogMnB4O1xuICB9XG5gXG5cbmNzc2BcbiAgLy8gQG5vZmxpcCBzaG91bGQtYmUtcmVtb3ZlZFxuICBsZWZ0OiA3cHg7XG5gXG5cbmNzc2BcbiAgLy8gQHNob3VsZGJlcmVtb3ZlZFxuICBsZWZ0OiA4cHg7XG5gXG4iXX0= */\\"
 });"
 `;
 

--- a/packages/babel-plugin-emotion/__tests__/vanilla-emotion-macro/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-emotion/__tests__/vanilla-emotion-macro/__snapshots__/index.js.snap
@@ -13,6 +13,44 @@ dfwf*/
   color: hotpink;
 \`
 
+css\`
+  /* @noflip */
+  left: 1px;
+\`
+
+css\`
+  left: 2px;
+
+  /* @noflip */
+  &.foo {
+    left: 3px;
+  }
+\`
+
+css\`
+  // @noflip
+  left: 4px;
+\`
+
+css\`
+  /* @shouldberemoved */
+  left: 5px;
+\`
+
+css\`
+  // @shouldberemoved
+  left: 6px;
+\`
+
+css\`
+  left: 7px;
+
+  /* @shouldberemoved */
+  &.foo {
+    left: 8px;
+  }
+\`
+
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
@@ -25,7 +63,67 @@ _css(process.env.NODE_ENV === \\"production\\" ? {
 } : {
   name: \\"1lrxbo5\\",
   styles: \\"color:hotpink;\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVHIiwiZmlsZSI6ImNvbW1lbnRzLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbi9tYWNybydcblxuY3NzYFxuICAvLyBkaXNwbGF5OmZsZXg7XG5cbiAgLypcbndlZlxuXG5kZndmKi9cbiAgY29sb3I6IGhvdHBpbms7XG5gXG4iXX0= */\\"
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVHIiwiZmlsZSI6ImNvbW1lbnRzLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbi9tYWNybydcblxuY3NzYFxuICAvLyBkaXNwbGF5OmZsZXg7XG5cbiAgLypcbndlZlxuXG5kZndmKi9cbiAgY29sb3I6IGhvdHBpbms7XG5gXG5cbmNzc2BcbiAgLyogQG5vZmxpcCAqL1xuICBsZWZ0OiAxcHg7XG5gXG5cbmNzc2BcbiAgbGVmdDogMnB4O1xuXG4gIC8qIEBub2ZsaXAgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDNweDtcbiAgfVxuYFxuXG5jc3NgXG4gIC8vIEBub2ZsaXBcbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIC8qIEBzaG91bGRiZXJlbW92ZWQgKi9cbiAgbGVmdDogNXB4O1xuYFxuXG5jc3NgXG4gIC8vIEBzaG91bGRiZXJlbW92ZWRcbiAgbGVmdDogNnB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDdweDtcblxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiA4cHg7XG4gIH1cbmBcbiJdfQ== */\\"
+});
+
+/*#__PURE__*/
+_css(process.env.NODE_ENV === \\"production\\" ? {
+  name: \\"njzoxi\\",
+  styles: \\"/* @noflip */ left:1px;\\"
+} : {
+  name: \\"njzoxi\\",
+  styles: \\"/* @noflip */ left:1px;\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQVlHIiwiZmlsZSI6ImNvbW1lbnRzLmpzIiwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3NzIH0gZnJvbSAnZW1vdGlvbi9tYWNybydcblxuY3NzYFxuICAvLyBkaXNwbGF5OmZsZXg7XG5cbiAgLypcbndlZlxuXG5kZndmKi9cbiAgY29sb3I6IGhvdHBpbms7XG5gXG5cbmNzc2BcbiAgLyogQG5vZmxpcCAqL1xuICBsZWZ0OiAxcHg7XG5gXG5cbmNzc2BcbiAgbGVmdDogMnB4O1xuXG4gIC8qIEBub2ZsaXAgKi9cbiAgJi5mb28ge1xuICAgIGxlZnQ6IDNweDtcbiAgfVxuYFxuXG5jc3NgXG4gIC8vIEBub2ZsaXBcbiAgbGVmdDogNHB4O1xuYFxuXG5jc3NgXG4gIC8qIEBzaG91bGRiZXJlbW92ZWQgKi9cbiAgbGVmdDogNXB4O1xuYFxuXG5jc3NgXG4gIC8vIEBzaG91bGRiZXJlbW92ZWRcbiAgbGVmdDogNnB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDdweDtcblxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiA4cHg7XG4gIH1cbmBcbiJdfQ== */\\"
+});
+
+/*#__PURE__*/
+_css(process.env.NODE_ENV === \\"production\\" ? {
+  name: \\"1h3pgg4\\",
+  styles: \\"left:2px;/* @noflip */ &.foo{left:3px;}\\"
+} : {
+  name: \\"1h3pgg4\\",
+  styles: \\"left:2px;/* @noflip */ &.foo{left:3px;}\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQWlCRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+});
+
+/*#__PURE__*/
+_css(process.env.NODE_ENV === \\"production\\" ? {
+  name: \\"kiy9xc\\",
+  styles: \\"left:4px;\\"
+} : {
+  name: \\"kiy9xc\\",
+  styles: \\"left:4px;\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQTBCRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+});
+
+/*#__PURE__*/
+_css(process.env.NODE_ENV === \\"production\\" ? {
+  name: \\"k9l721\\",
+  styles: \\"left:5px;\\"
+} : {
+  name: \\"k9l721\\",
+  styles: \\"left:5px;\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQStCRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+});
+
+/*#__PURE__*/
+_css(process.env.NODE_ENV === \\"production\\" ? {
+  name: \\"1a86t35\\",
+  styles: \\"left:6px;\\"
+} : {
+  name: \\"1a86t35\\",
+  styles: \\"left:6px;\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQW9DRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
+});
+
+/*#__PURE__*/
+_css(process.env.NODE_ENV === \\"production\\" ? {
+  name: \\"15q6a81\\",
+  styles: \\"left:7px;&.foo{left:8px;}\\"
+} : {
+  name: \\"15q6a81\\",
+  styles: \\"left:7px;&.foo{left:8px;}\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNvbW1lbnRzLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQXlDRyIsImZpbGUiOiJjb21tZW50cy5qcyIsInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB7IGNzcyB9IGZyb20gJ2Vtb3Rpb24vbWFjcm8nXG5cbmNzc2BcbiAgLy8gZGlzcGxheTpmbGV4O1xuXG4gIC8qXG53ZWZcblxuZGZ3ZiovXG4gIGNvbG9yOiBob3RwaW5rO1xuYFxuXG5jc3NgXG4gIC8qIEBub2ZsaXAgKi9cbiAgbGVmdDogMXB4O1xuYFxuXG5jc3NgXG4gIGxlZnQ6IDJweDtcblxuICAvKiBAbm9mbGlwICovXG4gICYuZm9vIHtcbiAgICBsZWZ0OiAzcHg7XG4gIH1cbmBcblxuY3NzYFxuICAvLyBAbm9mbGlwXG4gIGxlZnQ6IDRweDtcbmBcblxuY3NzYFxuICAvKiBAc2hvdWxkYmVyZW1vdmVkICovXG4gIGxlZnQ6IDVweDtcbmBcblxuY3NzYFxuICAvLyBAc2hvdWxkYmVyZW1vdmVkXG4gIGxlZnQ6IDZweDtcbmBcblxuY3NzYFxuICBsZWZ0OiA3cHg7XG5cbiAgLyogQHNob3VsZGJlcmVtb3ZlZCAqL1xuICAmLmZvbyB7XG4gICAgbGVmdDogOHB4O1xuICB9XG5gXG4iXX0= */\\"
 });"
 `;
 

--- a/packages/babel-plugin-emotion/src/utils/minify-utils.js
+++ b/packages/babel-plugin-emotion/src/utils/minify-utils.js
@@ -2,11 +2,6 @@
 // babel-plugin-styled-components
 // https://github.com/styled-components/babel-plugin-styled-components/blob/8d44acc36f067d60d4e09f9c22ff89695bc332d2/src/minify/index.js
 
-const CSS_ALLOWED_COMMENTS = [
-  // @noflip supports RTL via stylis plugin using cssjanus lib. If the comments
-  // that include this are stripped out, RTL will not work.
-  '@noflip'
-]
 const multilineCommentRegex = /\/\*[^!](.|[\r\n])*?\*\//g
 const lineCommentStart = /\/\//g
 const symbolRegex = /(\s*[;:{},]\s*)/g
@@ -71,17 +66,16 @@ const linebreakRegex = /[\r\n]\s*/g
 const spacesAndLinebreakRegex = /\s+|\n+/g
 
 function multilineReplacer(match: string) {
-  // When we encounter a standard multi-line CSS comment and it contains one of
-  // the allowed values, we keep the comment but optimize it into a single line.
+  // When we encounter a standard multi-line CSS comment and it contains a '@'
+  // character, we keep the comment but optimize it into a single line. Some
+  // Stylis plugins, such as the stylis-rtl via the cssjanus plugin, use this
+  // special comment syntax to control behavior (such as: /* @noflip */).
   // We can do this with standard CSS comments because they will work with
   // compression, as opposed to non-standard single-line comments that will
-  // break compressed CSS. If the comment doesn't contain one of the allowed
-  // values, we replace it with a line break, which effectively removes it from
-  // the output.
+  // break compressed CSS. If the comment doesn't contain '@', then we replace
+  // it with a line break, which effectively removes it from the output.
 
-  const keepComment = CSS_ALLOWED_COMMENTS.some(allowedValue => {
-    return match.indexOf(allowedValue) > -1
-  })
+  const keepComment = match.indexOf('@') > -1
 
   if (keepComment) {
     return match.replace(spacesAndLinebreakRegex, ' ').trim()

--- a/packages/babel-plugin-emotion/src/utils/minify-utils.js
+++ b/packages/babel-plugin-emotion/src/utils/minify-utils.js
@@ -2,6 +2,11 @@
 // babel-plugin-styled-components
 // https://github.com/styled-components/babel-plugin-styled-components/blob/8d44acc36f067d60d4e09f9c22ff89695bc332d2/src/minify/index.js
 
+const CSS_ALLOWED_COMMENTS = [
+  // @noflip supports RTL via stylis plugin using cssjanus lib. If the comments
+  // that include this are stripped out, RTL will not work.
+  '@noflip'
+]
 const multilineCommentRegex = /\/\*[^!](.|[\r\n])*?\*\//g
 const lineCommentStart = /\/\//g
 const symbolRegex = /(\s*[;:{},]\s*)/g
@@ -63,10 +68,31 @@ export const compressSymbols = (code: string) =>
 // Detects lines that are exclusively line comments
 const isLineComment = line => line.trim().startsWith('//')
 const linebreakRegex = /[\r\n]\s*/g
+const spacesAndLinebreakRegex = /\s+|\n+/g
+
+function multilineReplacer(match: string) {
+  // When we encounter a standard multi-line CSS comment and it contains one of
+  // the allowed values, we keep the comment but optimize it into a single line.
+  // We can do this with standard CSS comments because they will work with
+  // compression, as opposed to non-standard single-line comments that will
+  // break compressed CSS. If the comment doesn't contain one of the allowed
+  // values, we replace it with a line break, which effectively removes it from
+  // the output.
+
+  const keepComment = CSS_ALLOWED_COMMENTS.some(allowedValue => {
+    return match.indexOf(allowedValue) > -1
+  })
+
+  if (keepComment) {
+    return match.replace(spacesAndLinebreakRegex, ' ').trim()
+  }
+
+  return '\n'
+}
 
 export const minify = (code: string) => {
   const newCode = code
-    .replace(multilineCommentRegex, '\n') // Remove multiline comments
+    .replace(multilineCommentRegex, multilineReplacer) // If allowed, remove line breaks and extra space from multi-line comments so they appear on one line
     .split(linebreakRegex) // Split at newlines
     .filter(line => line.length > 0 && !isLineComment(line)) // Removes lines containing only line comments
     .map(stripLineComment) // Remove line comments inside text


### PR DESCRIPTION
_[edited to reflect current changes]_

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Fixes #1325. This PR adds a list of CSS comment values that, when found, keeps the CSS comment instead of removing it when using the `babel-plugin-emotion` package.

**Why**:

Some CSS libraries require the use of comments to control library functionality. Stylis plugins can use these libraries to provide support via Stylis that Emotion uses. One example of this is the [stylis-rtl plugin](https://github.com/FindHotel/stylis-rtl) and the [cssjanus library](https://github.com/cssjanus/cssjanus/).

The cssjanus lib requires the use of comments to control the rtl flipping behavior for individual style rules or properties. This is an example of the comment: `/* @noflip */`.

The babel plugin is very convenient for developers using `babel-preset-css-prop` for the `css` react prop by automatically inserting the jsx pragma: `/* @jsx jsx */`. It would be really helpful if developers using libraries that depend on comments can leverage the plugin instead of having to manually configure every file.

**How**:

In order to support retaining comments, I added an approved list of CSS comment values. When a standard CSS comment contains the special values, the plugin will keep the comment instead of removing it. All other comments are removed.

**Checklist**:
- [ ] Documentation
- [x] Tests -- Updated the comments fixture and snapshot with new test cases.
- [x] Code complete

Thank you!
