### PR TITLE
Add warning message about order of presets

### DIFF
--- a/packages/babel-preset-css-prop/README.md
+++ b/packages/babel-preset-css-prop/README.md
@@ -23,7 +23,7 @@ yarn add @emotion/babel-preset-css-prop
 }
 ```
 
-`@emotion/babel-preset-css-prop` includes the emotion plugin. The `babel-plugin-emotion` entry should be be removed from your config and any options moved to the preset.
+`@emotion/babel-preset-css-prop` includes the emotion plugin. The `babel-plugin-emotion` entry should be be removed from your config and any options moved to the preset. If you use `@babel/preset-react` ensure that `@emotion/babel-preset-css-props` is inserted after `@babel/preset-react`.
 
 ```diff
 {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Add warning message about the order of presets

<!-- Why are these changes necessary? -->
**Why**: When `@babel/preset-react` is placed after `@emotion/babel-preset-css-prop`, the pragma is overwritten back to `React.createElement` not `___EmotionJSX`.

<!-- How were these changes implemented? -->
**How**: There was no warning message about the order of presets available.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A
- [ ] Changeset N/A <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
