### PR TITLE
add dependency @emotion/core requested by @emotion/styled-base and @e…

### DIFF
--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -11,8 +11,10 @@
     "test:typescript": "dtslint types"
   },
   "dependencies": {
+    "@emotion/core": "^10.0.0",
     "@emotion/styled-base": "^10.0.10",
-    "babel-plugin-emotion": "^10.0.9"
+    "babel-plugin-emotion": "^10.0.9",
+    "react": ">=16.3.0"
   },
   "devDependencies": {
     "dtslint": "^0.3.0"


### PR DESCRIPTION
…motion/styled-base

There is a missing dependency on this worktree, as react and @emotion/core are listed as a peer dependencies of dependency @emotion/styled-base

this raises a warning when running with yarn2(berry) and will break PNP when using emotion as a dependency.

tagging @arcanis as requested in https://yarnpkg.com/en/docs/pnp/troubleshooting
