### PR TITLE
Mark loading as valid prop for lazy loading images and iFrames

### DIFF
--- a/.changeset/1897dfce/changes.json
+++ b/.changeset/1897dfce/changes.json
@@ -1,0 +1,15 @@
+{
+  "releases": [{ "name": "@emotion/is-prop-valid", "type": "minor" }],
+  "dependents": [
+    {
+      "name": "@emotion/primitives",
+      "type": "patch",
+      "dependencies": ["@emotion/is-prop-valid"]
+    },
+    {
+      "name": "@emotion/styled-base",
+      "type": "patch",
+      "dependencies": ["@emotion/is-prop-valid"]
+    }
+  ]
+}

--- a/.changeset/1897dfce/changes.md
+++ b/.changeset/1897dfce/changes.md
@@ -1,0 +1,1 @@
+Mark loading as a valid property. This property is used to lazily load images and iFrames.

--- a/packages/is-prop-valid/src/props.js
+++ b/packages/is-prop-valid/src/props.js
@@ -464,7 +464,9 @@ const props = {
   // preact
   for: true,
   class: true,
-  autofocus: true
+  autofocus: true,
+  // Loading attribute for images and iframes Spec PR https://github.com/whatwg/html/pull/3752/files#diff-36cd38f49b9afa08222c0dc9ebfe35eb
+  loading: true
 }
 // eslint-disable-next-line import/no-commonjs
 module.exports = `/^((${Object.keys(props).join(


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Marking `loading` as valid property.  It is used to lazily load images and iFrames.

<!-- Why are these changes necessary? -->
**Why**:
It fixes this issue in styled-components 
https://github.com/styled-components/styled-components/issues/2552

<!-- feel free to add additional comments -->
Reference: https://addyosmani.com/blog/lazy-loading/ 
https://github.com/whatwg/html/pull/3752