### PR TITLE
Feature/babel plugin emotion auto label object properties #1293

### DIFF
--- a/.changeset/good-sloths-repeat/changes.json
+++ b/.changeset/good-sloths-repeat/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "babel-plugin-emotion", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/good-sloths-repeat/changes.md
+++ b/.changeset/good-sloths-repeat/changes.md
@@ -1,0 +1,1 @@
+Added object property auto label support for babel-plugin-emotion

--- a/packages/babel-plugin-emotion/__tests__/__fixtures__/object-property.js
+++ b/packages/babel-plugin-emotion/__tests__/__fixtures__/object-property.js
@@ -1,0 +1,12 @@
+// @flow
+import * as React from 'react'
+import { jsx } from '@emotion/core'
+import styled from '@emotion/styled'
+
+const MyObject = {
+  MyProperty: styled.div({ color: 'hotpink' })
+}
+
+function Logo(props) {
+  return <MyObject.MyProperty />
+}

--- a/packages/babel-plugin-emotion/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-emotion/__tests__/__snapshots__/index.js.snap
@@ -130,12 +130,12 @@ import * as React from 'react'
 import { jsx } from '@emotion/core'
 import styled from '@emotion/styled'
 
-const MyStyles = {
+const MyObject = {
   MyProperty: styled.div({ color: 'hotpink' })
 }
 
 function Logo(props) {
-  return <MyStyles.MyProperty />
+  return <MyObject.MyProperty />
 }
 
 
@@ -145,7 +145,7 @@ import _styled from \\"@emotion/styled-base\\";
 // @flow
 import * as React from 'react';
 import { jsx } from '@emotion/core';
-const MyStyles = {
+const MyObject = {
   MyProperty: _styled(\\"div\\", {
     target: \\"e1mmqgwa0\\",
     label: \\"MyProperty\\"
@@ -155,12 +155,12 @@ const MyStyles = {
   } : {
     name: \\"1lrxbo5\\",
     styles: \\"color:hotpink;\\",
-    map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm9iamVjdC1wcm9wZXJ0eS5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFNYyIsImZpbGUiOiJvYmplY3QtcHJvcGVydHkuanMiLCJzb3VyY2VzQ29udGVudCI6WyIvLyBAZmxvd1xuaW1wb3J0ICogYXMgUmVhY3QgZnJvbSAncmVhY3QnXG5pbXBvcnQgeyBqc3ggfSBmcm9tICdAZW1vdGlvbi9jb3JlJ1xuaW1wb3J0IHN0eWxlZCBmcm9tICdAZW1vdGlvbi9zdHlsZWQnXG5cbmNvbnN0IE15U3R5bGVzID0ge1xuICBNeVByb3BlcnR5OiBzdHlsZWQuZGl2KHsgY29sb3I6ICdob3RwaW5rJyB9KVxufVxuXG5mdW5jdGlvbiBMb2dvKHByb3BzKSB7XG4gIHJldHVybiA8TXlTdHlsZXMuTXlQcm9wZXJ0eSAvPlxufVxuIl19 */\\"
+    map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm9iamVjdC1wcm9wZXJ0eS5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFNYyIsImZpbGUiOiJvYmplY3QtcHJvcGVydHkuanMiLCJzb3VyY2VzQ29udGVudCI6WyIvLyBAZmxvd1xuaW1wb3J0ICogYXMgUmVhY3QgZnJvbSAncmVhY3QnXG5pbXBvcnQgeyBqc3ggfSBmcm9tICdAZW1vdGlvbi9jb3JlJ1xuaW1wb3J0IHN0eWxlZCBmcm9tICdAZW1vdGlvbi9zdHlsZWQnXG5cbmNvbnN0IE15T2JqZWN0ID0ge1xuICBNeVByb3BlcnR5OiBzdHlsZWQuZGl2KHsgY29sb3I6ICdob3RwaW5rJyB9KVxufVxuXG5mdW5jdGlvbiBMb2dvKHByb3BzKSB7XG4gIHJldHVybiA8TXlPYmplY3QuTXlQcm9wZXJ0eSAvPlxufVxuIl19 */\\"
   })
 };
 
 function Logo(props) {
-  return <MyStyles.MyProperty />;
+  return <MyObject.MyProperty />;
 }"
 `;
 

--- a/packages/babel-plugin-emotion/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-emotion/__tests__/__snapshots__/index.js.snap
@@ -124,6 +124,46 @@ var _ref = process.env.NODE_ENV === \\"production\\" ? {
 const SomeComponent = props => <div css={_ref} {...props} />;"
 `;
 
+exports[`@emotion/babel-plugin-core object-property 1`] = `
+"// @flow
+import * as React from 'react'
+import { jsx } from '@emotion/core'
+import styled from '@emotion/styled'
+
+const MyStyles = {
+  MyProperty: styled.div({ color: 'hotpink' })
+}
+
+function Logo(props) {
+  return <MyStyles.MyProperty />
+}
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _styled from \\"@emotion/styled-base\\";
+// @flow
+import * as React from 'react';
+import { jsx } from '@emotion/core';
+const MyStyles = {
+  MyProperty: _styled(\\"div\\", {
+    target: \\"e1mmqgwa0\\",
+    label: \\"MyProperty\\"
+  })(process.env.NODE_ENV === \\"production\\" ? {
+    name: \\"1lrxbo5\\",
+    styles: \\"color:hotpink;\\"
+  } : {
+    name: \\"1lrxbo5\\",
+    styles: \\"color:hotpink;\\",
+    map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm9iamVjdC1wcm9wZXJ0eS5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFNYyIsImZpbGUiOiJvYmplY3QtcHJvcGVydHkuanMiLCJzb3VyY2VzQ29udGVudCI6WyIvLyBAZmxvd1xuaW1wb3J0ICogYXMgUmVhY3QgZnJvbSAncmVhY3QnXG5pbXBvcnQgeyBqc3ggfSBmcm9tICdAZW1vdGlvbi9jb3JlJ1xuaW1wb3J0IHN0eWxlZCBmcm9tICdAZW1vdGlvbi9zdHlsZWQnXG5cbmNvbnN0IE15U3R5bGVzID0ge1xuICBNeVByb3BlcnR5OiBzdHlsZWQuZGl2KHsgY29sb3I6ICdob3RwaW5rJyB9KVxufVxuXG5mdW5jdGlvbiBMb2dvKHByb3BzKSB7XG4gIHJldHVybiA8TXlTdHlsZXMuTXlQcm9wZXJ0eSAvPlxufVxuIl19 */\\"
+  })
+};
+
+function Logo(props) {
+  return <MyStyles.MyProperty />;
+}"
+`;
+
 exports[`@emotion/babel-plugin-core static-object-with-camel-case 1`] = `
 "/** @jsx jsx */
 import { jsx } from '@emotion/core'

--- a/packages/babel-plugin-emotion/src/utils/label.js
+++ b/packages/babel-plugin-emotion/src/utils/label.js
@@ -44,15 +44,16 @@ function getDeclaratorName(path, t) {
       p.isVariableDeclarator() ||
       p.isFunctionDeclaration() ||
       p.isFunctionExpression() ||
-      p.isArrowFunctionExpression()
+      p.isArrowFunctionExpression() ||
+      p.isObjectProperty()
   )
   if (!parent) {
     return ''
   }
 
+  // we probably have a css call assigned to a variable
+  // so we'll just return the variable name
   if (parent.isVariableDeclarator()) {
-    // we probably have a css call assigned to a variable
-    // so we'll just return the variable name
     return parent.node.id.name
   }
 
@@ -63,6 +64,11 @@ function getDeclaratorName(path, t) {
       return name
     }
     return ''
+  }
+
+  // we could also have an object property
+  if (parent.isObjectProperty()) {
+    return parent.node.key.name || parent.node.key.value
   }
 
   let variableDeclarator = path.findParent(p => p.isVariableDeclarator())

--- a/packages/babel-plugin-emotion/src/utils/label.js
+++ b/packages/babel-plugin-emotion/src/utils/label.js
@@ -68,7 +68,7 @@ function getDeclaratorName(path, t) {
 
   // we could also have an object property
   if (parent.isObjectProperty()) {
-    return parent.node.key.name || parent.node.key.value
+    return parent.node.key.name
   }
 
   let variableDeclarator = path.findParent(p => p.isVariableDeclarator())


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Adds object property auto label support to babel-plugin-emotion.

<!-- Why are these changes necessary? -->
**Why**:

If all styled components are nested within a shared object, they will received the same label despite being different components.

See related issue: https://github.com/emotion-js/emotion/issues/1293

<!-- How were these changes implemented? -->
**How**:

Added a single, final case before fallbacks that handles object properties.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->

This behavior was already present on a previous version of babel-plugin-emotion, so this PR is fixing a regression.

Thanks!