### PR TITLE
add CacheProvider SSR usage to docs

### DIFF
--- a/docs/cache-provider.md
+++ b/docs/cache-provider.md
@@ -50,4 +50,4 @@ render(
 
 ## Using CacheProvider with Server-Side-Rendering
 
-Emotion works with SSR out of the box. However, when implmenting `CacheProvider` we must also create our own server implmentation using [`createEmotionServer`](https://emotion.sh/docs/create-emotion-server) and pass it the same `cache` to ensure styles are created and hydrated properly.
+Emotion works with SSR out of the box. However, when implementing `CacheProvider`, we must also create our own server implementation using [`createEmotionServer`](https://emotion.sh/docs/create-emotion-server) and pass it the same `cache` to ensure styles are created and hydrated properly.

--- a/docs/cache-provider.md
+++ b/docs/cache-provider.md
@@ -47,3 +47,7 @@ render(
   </CacheProvider>
 )
 ```
+
+## Using CacheProvider with Server-Side-Rendering
+
+Emotion works with SSR out of the box. However, when implmenting `CacheProvider` we must also create our own server implmentation using [`createEmotionServer`](https://emotion.sh/docs/create-emotion-server) and pass it the same `cache` to ensure styles are created and hydrated properly.


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Updated docs about using `CacheProvider` with SSR.
<!-- Why are these changes necessary? -->
**Why**:
I ran into issues when using `CacheProvider` and SSR specifically with Gatsby. After chatting with @tkh44 on Slack we came to realize it was the fact that I didn't use my own server implementation using `createEmotionServer` and passing the same `cache` through.
<!-- How were these changes implemented? -->
**How**:
Added documentation describing what to be aware of when using `CacheProvider` + SSR. I'm happy to expand on this with a code snippet or more information if it seems like it would be more helpful.