### PR TITLE
Fix Flow type for withTheme

### DIFF
--- a/.changeset/thick-brooms-yell/changes.json
+++ b/.changeset/thick-brooms-yell/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "emotion-theming", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/thick-brooms-yell/changes.md
+++ b/.changeset/thick-brooms-yell/changes.md
@@ -1,0 +1,1 @@
+Fixing flow types for the withTheme HOC

--- a/packages/emotion-theming/__tests__/with-theme.js
+++ b/packages/emotion-theming/__tests__/with-theme.js
@@ -30,6 +30,7 @@ test(`withTheme(Comp) hoists non-react static class properties`, () => {
   const ComponentWithTheme = withTheme(ExampleComponent)
 
   expect(ComponentWithTheme.displayName).toBe('WithTheme(foo)')
+  // $FlowFixMe
   expect(ComponentWithTheme.someSpecialStatic).toBe(
     ExampleComponent.someSpecialStatic
   )

--- a/packages/emotion-theming/src/with-theme.js
+++ b/packages/emotion-theming/src/with-theme.js
@@ -7,7 +7,9 @@ type Props = { theme: Object }
 
 // should we change this to be forwardRef/withCSSContext style so it doesn't merge with props?
 
-const withTheme = (Component: React.ComponentType<Props>) => {
+export default function withTheme<Config: {}>(
+  Component: React.AbstractComponent<Config>
+): React.AbstractComponent<$Diff<Config, Props>> {
   const componentName = Component.displayName || Component.name || 'Component'
   let render = (props, ref) => {
     return (
@@ -25,5 +27,3 @@ const withTheme = (Component: React.ComponentType<Props>) => {
 
   return hoistNonReactStatics(WithTheme, Component)
 }
-
-export default withTheme


### PR DESCRIPTION
**What**: Flow Typeing for `withTheme` isn't correctly altering props.

**Why**: As mentioned in [comment](https://github.com/emotion-js/emotion/issues/469#issuecomment-498804266) you can't use `withTheme` easily with flow prop types.

**How**: Switching the `React.ComponentType` to `React.AbstractComponent`. To do this also changed it to a normal function as that displays the flow types in a more consise and clear way.

**Checklist**:
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete
- [x] Changeset