### PR TITLE
Allow for parametrizing styled calls with Theme type

### DIFF
--- a/packages/styled-base/types/index.d.ts
+++ b/packages/styled-base/types/index.d.ts
@@ -56,13 +56,14 @@ type ReactClassPropKeys = keyof React.ClassAttributes<any>
 export interface CreateStyledComponentBase<
   InnerProps,
   ExtraProps,
-  Theme extends object
+  StyledInstanceTheme extends object
 > {
   <
     StyleProps extends Omit<
       Overwrapped<InnerProps, StyleProps>,
       ReactClassPropKeys
-    > = Omit<InnerProps & ExtraProps, ReactClassPropKeys>
+    > = Omit<InnerProps & ExtraProps, ReactClassPropKeys>,
+    Theme extends object = StyledInstanceTheme
   >(
     ...styles: Array<Interpolation<WithTheme<StyleProps, Theme>>>
   ): StyledComponent<InnerProps, StyleProps, Theme>
@@ -70,7 +71,8 @@ export interface CreateStyledComponentBase<
     StyleProps extends Omit<
       Overwrapped<InnerProps, StyleProps>,
       ReactClassPropKeys
-    > = Omit<InnerProps & ExtraProps, ReactClassPropKeys>
+    > = Omit<InnerProps & ExtraProps, ReactClassPropKeys>,
+    Theme extends object = StyledInstanceTheme
   >(
     template: TemplateStringsArray,
     ...styles: Array<Interpolation<WithTheme<StyleProps, Theme>>>

--- a/packages/styled/types/tests.tsx
+++ b/packages/styled/types/tests.tsx
@@ -8,3 +8,14 @@ styled.body
 styled.div
 // $ExpectType CreateStyledComponentIntrinsic<"svg", {}, any>
 styled.svg
+
+{
+  // $ExpectType CreateStyledComponentIntrinsic<"svg", { bar: string }, { themed: "black" }>
+  styled.div<{ bar: string }, { themed: 'black' }>`
+    color: ${props => {
+      // $ExpectType { themed: "black" }
+      const { theme } = props
+      return theme.themed
+    }};
+  `
+}


### PR DESCRIPTION
@Ailrun would love for you to validate this idea. Currently babel plugin etc doesn't quite support custom styled instances so CreateStyled is kinda unusable if we want to use them because it requires importing styled from a custom (typed) location