### PR TITLE
ESLint jsx-import rule: Add jsx specifier to existing import from @emotion/core when auto-fixing

### DIFF
--- a/.changeset/polite-lions-visit/changes.json
+++ b/.changeset/polite-lions-visit/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "eslint-plugin-emotion", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/polite-lions-visit/changes.md
+++ b/.changeset/polite-lions-visit/changes.md
@@ -1,0 +1,1 @@
+jsx-import rule: Add jsx specifier to existing import from @emotion/core when auto-fixing

--- a/packages/eslint-plugin-emotion/src/rules/jsx-import.js
+++ b/packages/eslint-plugin-emotion/src/rules/jsx-import.js
@@ -25,11 +25,21 @@ export default {
             x.source.value === '@emotion/core'
           ) {
             emotionCoreNode = x
-            // TODO: maybe handle namespace specifiers, not high priority though
-            let jsxSpecifier = x.specifiers.find(x => x.imported.name === 'jsx')
-            if (jsxSpecifier) {
+
+            if (
+              x.specifiers.length === 1 &&
+              x.specifiers[0].type === 'ImportNamespaceSpecifier'
+            ) {
               hasJsxImport = true
-              local = jsxSpecifier.local.name
+              local = x.specifiers[0].local.name + '.jsx'
+            } else {
+              let jsxSpecifier = x.specifiers.find(
+                x => x.type === 'ImportSpecifier' && x.imported.name === 'jsx'
+              )
+              if (jsxSpecifier) {
+                hasJsxImport = true
+                local = jsxSpecifier.local.name
+              }
             }
           }
         })
@@ -63,6 +73,11 @@ export default {
                     emotionCoreNode.specifiers[
                       emotionCoreNode.specifiers.length - 1
                     ]
+
+                  if (lastSpecifier.type === 'ImportDefaultSpecifier') {
+                    return fixer.insertTextAfter(lastSpecifier, ', { jsx }')
+                  }
+
                   return fixer.insertTextAfter(lastSpecifier, ', jsx')
                 }
 

--- a/packages/eslint-plugin-emotion/src/rules/jsx-import.js
+++ b/packages/eslint-plugin-emotion/src/rules/jsx-import.js
@@ -24,12 +24,12 @@ export default {
             x.type === 'ImportDeclaration' &&
             x.source.value === '@emotion/core'
           ) {
+            emotionCoreNode = x
             // TODO: maybe handle namespace specifiers, not high priority though
             let jsxSpecifier = x.specifiers.find(x => x.imported.name === 'jsx')
             if (jsxSpecifier) {
               hasJsxImport = true
               local = jsxSpecifier.local.name
-              emotionCoreNode = x
             }
           }
         })
@@ -58,6 +58,14 @@ export default {
                 )
               }
               if (hasSetPragma) {
+                if (emotionCoreNode) {
+                  let lastSpecifier =
+                    emotionCoreNode.specifiers[
+                      emotionCoreNode.specifiers.length - 1
+                    ]
+                  return fixer.insertTextAfter(lastSpecifier, ', jsx')
+                }
+
                 return fixer.insertTextBefore(
                   sourceCode.ast.body[0],
                   `import { jsx } from '@emotion/core'\n`

--- a/packages/eslint-plugin-emotion/test/rules/jsx-import.test.js
+++ b/packages/eslint-plugin-emotion/test/rules/jsx-import.test.js
@@ -55,6 +55,24 @@ let ele = <div css={{}} />
     },
     {
       code: `
+// @jsx jsx
+import { css } from '@emotion/core'
+let ele = <div css={{}} />
+      `.trim(),
+      errors: [
+        {
+          message:
+            'The css prop can only be used if jsx from @emotion/core is imported and it is set as the jsx pragma'
+        }
+      ],
+      output: `
+// @jsx jsx
+import { css, jsx } from '@emotion/core'
+let ele = <div css={{}} />
+            `.trim()
+    },
+    {
+      code: `
 let ele = <div css={{}} />
       `.trim(),
       errors: [

--- a/packages/eslint-plugin-emotion/test/rules/jsx-import.test.js
+++ b/packages/eslint-plugin-emotion/test/rules/jsx-import.test.js
@@ -73,6 +73,41 @@ let ele = <div css={{}} />
     },
     {
       code: `
+// @jsx jsx
+import DefaultExport from '@emotion/core'
+let ele = <div css={{}} />
+      `.trim(),
+      errors: [
+        {
+          message:
+            'The css prop can only be used if jsx from @emotion/core is imported and it is set as the jsx pragma'
+        }
+      ],
+      output: `
+// @jsx jsx
+import DefaultExport, { jsx } from '@emotion/core'
+let ele = <div css={{}} />
+            `.trim()
+    },
+    {
+      code: `
+import * as Emotion from '@emotion/core'
+let ele = <div css={{}} />
+      `.trim(),
+      errors: [
+        {
+          message:
+            'The css prop can only be used if jsx from @emotion/core is imported and it is set as the jsx pragma'
+        }
+      ],
+      output: `
+/** @jsx Emotion.jsx */
+import * as Emotion from '@emotion/core'
+let ele = <div css={{}} />
+            `.trim()
+    },
+    {
+      code: `
 let ele = <div css={{}} />
       `.trim(),
       errors: [


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: When auto-fixing a missing `jsx` import, the rule currently adds a new import declaration even when there is already an import declaration from @emotion/core. This change adds the `jsx` specifier to that import when it exists. 

<!-- Why are these changes necessary? -->
**Why**: To prevent duplicate import declarations from @emotion/core.

<!-- How were these changes implemented? -->
**How**:

1. Assign the existing `emotionCoreNode` variable a value when the import is found, instead of only assigning it when the jsx specifier exists
2. Add the jsx specifier after the last specifier of the emotionCoreNode

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation **N/A**
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
