### PR TITLE
PropsOf<C> TypeScript utilities - Support defaultProps

### DIFF
--- a/.changeset/tasty-hornets-taste/changes.json
+++ b/.changeset/tasty-hornets-taste/changes.json
@@ -1,0 +1,7 @@
+{
+  "releases": [
+    { "name": "emotion-theming", "type": "patch" },
+    { "name": "@emotion/styled-base", "type": "patch" }
+  ],
+  "dependents": []
+}

--- a/.changeset/tasty-hornets-taste/changes.md
+++ b/.changeset/tasty-hornets-taste/changes.md
@@ -1,0 +1,1 @@
+PropsOf<C> TypeScript utilities - Support defaultProps by delegating to new JSX and React types.

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "@changesets/get-github-info": "^0.1.2",
     "@types/jest": "^23.0.2",
     "@types/node": "^10.11.4",
-    "@types/react": "16.3.18",
+    "@types/react": "^16.8.20",
     "babel-check-duplicated-nodes": "^1.0.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,19 +27,19 @@
     "test:typescript": "dtslint types"
   },
   "dependencies": {
+    "@babel/runtime": "^7.4.3",
     "@emotion/cache": "^10.0.9",
     "@emotion/css": "^10.0.9",
     "@emotion/serialize": "^0.11.6",
     "@emotion/sheet": "0.9.2",
-    "@emotion/utils": "0.11.1",
-    "@babel/runtime": "^7.4.3"
+    "@emotion/utils": "0.11.1"
   },
   "peerDependencies": {
     "react": ">=16.3.0"
   },
   "devDependencies": {
     "@emotion/styled": "^10.0.10",
-    "@types/react": "16.3.18",
+    "@types/react": "^16.8.20",
     "dtslint": "^0.3.0",
     "emotion": "^10.0.9",
     "emotion-server": "^10.0.9",

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -45,9 +45,7 @@ export interface GlobalProps<Theme> {
  * @desc
  * JSX generic are supported only after TS@2.9
  */
-export function Global<Theme = any>(
-  props: GlobalProps<Theme>
-): ReactElement<any>
+export function Global<Theme = any>(props: GlobalProps<Theme>): ReactElement
 
 export function keyframes(
   template: TemplateStringsArray,
@@ -79,7 +77,7 @@ export interface ClassNamesProps<Theme> {
  */
 export function ClassNames<Theme = any>(
   props: ClassNamesProps<Theme>
-): ReactElement<any>
+): ReactElement
 
 declare module 'react' {
   interface DOMAttributes<T> {

--- a/packages/core/types/tslint.json
+++ b/packages/core/types/tslint.json
@@ -1,25 +1,22 @@
 {
-    "extends": "dtslint/dtslint.json",
-    "rules": {
-        "array-type": [
-            true,
-            "generic"
-        ],
-        "import-spacing": false,
-        "semicolon": false,
-        "whitespace": [
-            true,
-            "check-branch",
-            "check-decl",
-            "check-operator",
-            "check-module",
-            "check-rest-spread",
-            "check-type",
-            "check-typecast",
-            "check-type-operator",
-            "check-preblock"
-        ],
-
-        "no-unnecessary-generics": false
-    }
+  "extends": "dtslint/dtslint.json",
+  "rules": {
+    "array-type": [true, "generic"],
+    "import-spacing": false,
+    "semicolon": false,
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-module",
+      "check-rest-spread",
+      "check-type",
+      "check-typecast",
+      "check-type-operator",
+      "check-preblock"
+    ],
+    "no-null-undefined-union": false,
+    "no-unnecessary-generics": false
+  }
 }

--- a/packages/emotion-theming/package.json
+++ b/packages/emotion-theming/package.json
@@ -34,17 +34,17 @@
   "devDependencies": {
     "@emotion/core": "^10.0.10",
     "@emotion/styled": "^10.0.10",
-    "@types/react": "16.3.18",
+    "@types/react": "^16.8.20",
     "dtslint": "^0.3.0"
   },
   "dependencies": {
+    "@babel/runtime": "^7.4.3",
     "@emotion/weak-memoize": "0.2.2",
-    "hoist-non-react-statics": "^3.3.0",
-    "@babel/runtime": "^7.4.3"
+    "hoist-non-react-statics": "^3.3.0"
   },
   "peerDependencies": {
-    "react": ">=16.3.0",
-    "@emotion/core": "^10.0.0"
+    "@emotion/core": "^10.0.0",
+    "react": ">=16.3.0"
   },
   "umd:main": "dist/emotion-theming.umd.min.js",
   "browser": {

--- a/packages/emotion-theming/types/helper.d.ts
+++ b/packages/emotion-theming/types/helper.d.ts
@@ -1,14 +1,8 @@
 import * as React from 'react'
 
-export type PropsOf<C extends React.ComponentType<any>> = C extends React.SFC<
-  infer P
->
-  ? P & React.Attributes
-  : C extends React.ComponentClass<infer P>
-    ? (C extends new (...args: Array<any>) => infer I
-        ? P & React.ClassAttributes<I>
-        : never)
-    : never
+export type PropsOf<
+  C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
+> = JSX.LibraryManagedAttributes<C, React.ComponentPropsWithRef<C>>
 
 export type Omit<T, U> = T extends any ? Pick<T, Exclude<keyof T, U>> : never
 export type AddOptionalTo<T, U> = Omit<T, U> &

--- a/packages/emotion-theming/types/index.d.ts
+++ b/packages/emotion-theming/types/index.d.ts
@@ -1,5 +1,5 @@
 // Definitions by: Junyoung Clare Jang <https://github.com/Ailrun>
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 import * as React from 'react'
 
@@ -12,7 +12,7 @@ export interface ThemeProviderProps<Theme> {
 
 export function ThemeProvider<Theme>(
   props: ThemeProviderProps<Theme>
-): React.ReactElement<any>
+): React.ReactElement
 
 /**
  * @todo Add more constraint to C so that
@@ -23,7 +23,7 @@ export function withTheme<C extends React.ComponentType<any>>(
 ): React.SFC<AddOptionalTo<PropsOf<C>, 'theme'>>
 
 export interface EmotionTheming<Theme> {
-  ThemeProvider(props: ThemeProviderProps<Theme>): React.ReactElement<any>
+  ThemeProvider(props: ThemeProviderProps<Theme>): React.ReactElement
   withTheme<C extends React.ComponentType<any>>(
     component: C
   ): React.SFC<AddOptionalTo<PropsOf<C>, 'theme'>>

--- a/packages/emotion-theming/types/tests.tsx
+++ b/packages/emotion-theming/types/tests.tsx
@@ -29,6 +29,23 @@ const ThemedComp = withTheme(CompC)
 ;<ThemedComp prop />
 ;<ThemedComp prop theme={theme} />
 
+const CompSFCWithDefault = ({ prop }: Props) => (prop ? <span /> : <div />)
+CompSFCWithDefault.defaultProps = { prop: false }
+class CompCWithDefault extends React.Component<Props> {
+  static defaultProps = { prop: false }
+  render() {
+    return this.props.prop ? <span /> : <div />
+  }
+}
+
+const ThemedSFCWithDefault = withTheme(CompSFCWithDefault)
+;<ThemedSFCWithDefault />
+;<ThemedSFCWithDefault theme={theme} />
+
+const ThemedCompWithDefault = withTheme(CompCWithDefault)
+;<ThemedCompWithDefault />
+;<ThemedCompWithDefault theme={theme} />
+
 const {
   ThemeProvider: TypedThemeProvider,
   withTheme: typedWithTheme

--- a/packages/emotion-theming/types/tslint.json
+++ b/packages/emotion-theming/types/tslint.json
@@ -15,7 +15,7 @@
             "check-type-operator",
             "check-preblock"
         ],
-
+        "no-null-undefined-union": false,
         "no-unnecessary-generics": false
     }
 }

--- a/packages/styled-base/package.json
+++ b/packages/styled-base/package.json
@@ -21,7 +21,7 @@
     "@emotion/utils": "0.11.1"
   },
   "devDependencies": {
-    "@types/react": "16.3.18",
+    "@types/react": "^16.8.20",
     "dtslint": "^0.3.0"
   },
   "peerDependencies": {

--- a/packages/styled-base/types/helper.d.ts
+++ b/packages/styled-base/types/helper.d.ts
@@ -4,14 +4,8 @@ import * as React from 'react'
  * @desc Utility type for getting props type of React component.
  */
 export type PropsOf<
-  Tag extends React.ComponentType<any>
-> = Tag extends React.SFC<infer Props>
-  ? Props & React.Attributes
-  : Tag extends React.ComponentClass<infer Props>
-    ? (Tag extends new (...args: Array<any>) => infer Instance
-        ? Props & React.ClassAttributes<Instance>
-        : never)
-    : never
+  C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
+> = JSX.LibraryManagedAttributes<C, React.ComponentPropsWithRef<C>>
 
 export type Omit<T, U> = T extends any ? Pick<T, Exclude<keyof T, U>> : never
 export type Overwrapped<T, U> = Pick<T, Extract<keyof T, keyof U>>

--- a/packages/styled-base/types/index.d.ts
+++ b/packages/styled-base/types/index.d.ts
@@ -1,5 +1,5 @@
 // Definitions by: Junyoung Clare Jang <https://github.com/Ailrun>
-// TypeScript Version: 2.8
+// TypeScript Version: 3.1
 
 /**
  * @desc

--- a/packages/styled-base/types/tests.tsx
+++ b/packages/styled-base/types/tests.tsx
@@ -272,3 +272,27 @@ declare const ref3_2: (element: HTMLDivElement | null) => void
   ;<Readable kind="magazine" author="Hejlsberg" /> // $ExpectError
   ;<StyledReadable kind="magazine" author="Hejlsberg" /> // $ExpectError
 }
+
+interface Props {
+  prop: boolean
+}
+class ClassWithDefaultProps extends React.Component<Props> {
+  static defaultProps = { prop: false }
+  render() {
+    return this.props.prop ? <Button0 /> : <Button1 />
+  }
+}
+const StyledClassWithDefaultProps = styled(ClassWithDefaultProps)`
+  background-color: red;
+`
+const classInstance = <StyledClassWithDefaultProps />
+
+const FCWithDefaultProps = ({ prop }: Props) =>
+  prop ? <Button0 /> : <Button1 />
+FCWithDefaultProps.defaultProps = {
+  prop: false
+}
+const StyledFCWithDefaultProps = styled(FCWithDefaultProps)`
+  background-color: red;
+`
+const fcInstance = <StyledFCWithDefaultProps />

--- a/packages/styled-base/types/tslint.json
+++ b/packages/styled-base/types/tslint.json
@@ -18,7 +18,7 @@
             "check-type-operator",
             "check-preblock"
         ],
-
+        "no-null-undefined-union": false,
         "no-unnecessary-generics": false
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1478,6 +1478,14 @@
   dependencies:
     csstype "^2.2.0"
 
+"@types/react@^16.8.20":
+  version "16.8.20"
+  resolved "https://artifactory.intcx.net/artifactory/api/npm/npm-virtual/@types/react/-/react-16.8.20.tgz#4f633ecbd0a4d56d0ccc50fff6f9321bbcd7d583"
+  integrity sha1-T2M+y9Ck1W0MzFD/9vkyG7zX1YM=
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 "@types/resolve@0.0.8":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
@@ -4428,13 +4436,38 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist@3.2.8, browserslist@^1.3.6, browserslist@^1.4.0, browserslist@^1.5.2, browserslist@^1.7.6, browserslist@^2.1.2, browserslist@^2.1.3, browserslist@^2.5.1, browserslist@^3.2.8, browserslist@^4.0.0, browserslist@^4.1.0, browserslist@^4.4.1:
+browserslist@3.2.8:
   version "3.2.8"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
   integrity sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==
   dependencies:
     caniuse-lite "^1.0.30000844"
     electron-to-chromium "^1.3.47"
+
+browserslist@^1.3.6, browserslist@^1.4.0, browserslist@^1.5.2, browserslist@^1.7.6:
+  version "1.7.7"
+  resolved "https://artifactory.intcx.net/artifactory/api/npm/npm-virtual/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
+  integrity sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=
+  dependencies:
+    caniuse-db "^1.0.30000639"
+    electron-to-chromium "^1.2.7"
+
+browserslist@^2.1.2, browserslist@^2.1.3, browserslist@^2.5.1:
+  version "2.11.3"
+  resolved "https://artifactory.intcx.net/artifactory/api/npm/npm-virtual/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
+  integrity sha1-/jYWeu0bvN5IJ+v+cTR6LMcLmbI=
+  dependencies:
+    caniuse-lite "^1.0.30000792"
+    electron-to-chromium "^1.3.30"
+
+browserslist@^4.0.0, browserslist@^4.1.0, browserslist@^4.4.1:
+  version "4.6.2"
+  resolved "https://artifactory.intcx.net/artifactory/api/npm/npm-virtual/browserslist/-/browserslist-4.6.2.tgz#574c665950915c2ac73a4594b8537a9eba26203f"
+  integrity sha1-V0xmWVCRXCrHOkWUuFN6nromID8=
+  dependencies:
+    caniuse-lite "^1.0.30000974"
+    electron-to-chromium "^1.3.150"
+    node-releases "^1.1.23"
 
 bser@1.0.2:
   version "1.0.2"
@@ -4786,6 +4819,11 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634:
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000885.tgz#cdc98dd168ed59678650071f7f6a70910e275bc8"
   integrity sha512-Hy1a+UIXooG+tRlt3WnT9avMf+l999bR9J1MqlQdYKgbsYjKxV4a4rgcmiyMmdCLPBFsiRoDxdl9tnNyaq2RXw==
 
+caniuse-db@^1.0.30000639:
+  version "1.0.30000974"
+  resolved "https://artifactory.intcx.net/artifactory/api/npm/npm-virtual/caniuse-db/-/caniuse-db-1.0.30000974.tgz#ffc887e57e7db7067da203b102071a1d2477c5c8"
+  integrity sha1-/8iH5X59twZ9ogOxAgcaHSR3xcg=
+
 caniuse-lite@^1.0.0:
   version "1.0.30000865"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000865.tgz#70026616e8afe6e1442f8bb4e1092987d81a2f25"
@@ -4800,6 +4838,11 @@ caniuse-lite@^1.0.30000748, caniuse-lite@^1.0.30000844:
   version "1.0.30000885"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000885.tgz#e889e9f8e7e50e769f2a49634c932b8aee622984"
   integrity sha512-cXKbYwpxBLd7qHyej16JazPoUacqoVuDhvR61U7Fr5vSxMUiodzcYa1rQYRYfZ5GexV03vGZHd722vNPLjPJGQ==
+
+caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000974:
+  version "1.0.30000974"
+  resolved "https://artifactory.intcx.net/artifactory/api/npm/npm-virtual/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz#b7afe14ee004e97ce6dc73e3f878290a12928ad8"
+  integrity sha1-t6/hTuAE6Xzm3HPj+HgpChKSitg=
 
 caniuse-lite@^1.0.30000932:
   version "1.0.30000936"
@@ -7215,6 +7258,11 @@ ejs@^2.5.7:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
   integrity sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==
+
+electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.150, electron-to-chromium@^1.3.30:
+  version "1.3.164"
+  resolved "https://artifactory.intcx.net/artifactory/api/npm/npm-virtual/electron-to-chromium/-/electron-to-chromium-1.3.164.tgz#8680b875577882c1572c42218d53fa9ba5f71d5d"
+  integrity sha1-hoC4dVd4gsFXLEIhjVP6m6X3HV0=
 
 electron-to-chromium@^1.3.47:
   version "1.3.67"
@@ -15527,6 +15575,13 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
+node-releases@^1.1.23:
+  version "1.1.23"
+  resolved "https://artifactory.intcx.net/artifactory/api/npm/npm-virtual/node-releases/-/node-releases-1.1.23.tgz#de7409f72de044a2fa59c097f436ba89c39997f0"
+  integrity sha1-3nQJ9y3gRKL6WcCX9Da6icOZl/A=
+  dependencies:
+    semver "^5.3.0"
+
 node-rest-client@^1.5.1:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/node-rest-client/-/node-rest-client-1.8.0.tgz#8d3c566b817e27394cb7273783a41caefe3e5955"
@@ -18225,7 +18280,7 @@ react-devtools-core@^3.4.2:
     shell-quote "^1.6.1"
     ws "^3.3.1"
 
-react-dom@16.8.1, "react-dom@^15 || ^16", react-dom@^16.5.2:
+"react-dom@^15 || ^16", react-dom@^16.5.2:
   version "16.8.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.1.tgz#ec860f98853d09d39bafd3a6f1e12389d283dbb4"
   integrity sha512-N74IZUrPt6UiDjXaO7UbDDFXeUXnVhZzeRLy/6iqqN1ipfjrhR60Bp5NuBK+rv3GMdqdIuwIl22u1SYwf330bg==
@@ -18536,7 +18591,7 @@ react-transform-hmr@^1.0.4:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@16.8.1, "react@^15 || ^16", react@^16.5.2:
+"react@^15 || ^16", react@^16.5.2:
   version "16.8.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.1.tgz#ae11831f6cb2a05d58603a976afc8a558e852c4a"
   integrity sha512-wLw5CFGPdo7p/AgteFz7GblI2JPOos0+biSoxf1FPsGxWQZdN/pj6oToJs1crn61DL3Ln7mN86uZ4j74p31ELQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1471,13 +1471,6 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
-"@types/react@16.3.18":
-  version "16.3.18"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.18.tgz#bf195aed4d77dc86f06e4c9bb760214a3b822b8d"
-  integrity sha512-aWTvLHzKqbVWCiee8huwf5x7Ob4n4gxDwgJT/X31HqjGVZpeUeFeSFYH5Gvi5Dmm5HKF+s+dQkwa/nnEVVzzzg==
-  dependencies:
-    csstype "^2.2.0"
-
 "@types/react@^16.8.20":
   version "16.8.20"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.20.tgz#4f633ecbd0a4d56d0ccc50fff6f9321bbcd7d583"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,8 +1480,8 @@
 
 "@types/react@^16.8.20":
   version "16.8.20"
-  resolved "https://artifactory.intcx.net/artifactory/api/npm/npm-virtual/@types/react/-/react-16.8.20.tgz#4f633ecbd0a4d56d0ccc50fff6f9321bbcd7d583"
-  integrity sha1-T2M+y9Ck1W0MzFD/9vkyG7zX1YM=
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.20.tgz#4f633ecbd0a4d56d0ccc50fff6f9321bbcd7d583"
+  integrity sha512-ZLmI+ubSJpfUIlQuULDDrdyuFQORBuGOvNnMue8HeA0GVrAJbWtZQhcBvnBPNRBI/GrfSfrKPFhthzC2SLEtLQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -4446,7 +4446,7 @@ browserslist@3.2.8:
 
 browserslist@^1.3.6, browserslist@^1.4.0, browserslist@^1.5.2, browserslist@^1.7.6:
   version "1.7.7"
-  resolved "https://artifactory.intcx.net/artifactory/api/npm/npm-virtual/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
   integrity sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=
   dependencies:
     caniuse-db "^1.0.30000639"
@@ -4454,19 +4454,19 @@ browserslist@^1.3.6, browserslist@^1.4.0, browserslist@^1.5.2, browserslist@^1.7
 
 browserslist@^2.1.2, browserslist@^2.1.3, browserslist@^2.5.1:
   version "2.11.3"
-  resolved "https://artifactory.intcx.net/artifactory/api/npm/npm-virtual/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
-  integrity sha1-/jYWeu0bvN5IJ+v+cTR6LMcLmbI=
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
+  integrity sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==
   dependencies:
     caniuse-lite "^1.0.30000792"
     electron-to-chromium "^1.3.30"
 
 browserslist@^4.0.0, browserslist@^4.1.0, browserslist@^4.4.1:
-  version "4.6.2"
-  resolved "https://artifactory.intcx.net/artifactory/api/npm/npm-virtual/browserslist/-/browserslist-4.6.2.tgz#574c665950915c2ac73a4594b8537a9eba26203f"
-  integrity sha1-V0xmWVCRXCrHOkWUuFN6nromID8=
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.6.3.tgz#0530cbc6ab0c1f3fc8c819c72377ba55cf647f05"
+  integrity sha512-CNBqTCq22RKM8wKJNowcqihHJ4SkI8CGeK7KOR9tPboXUuS5Zk5lQgzzTbs4oxD8x+6HUshZUa2OyNI9lR93bQ==
   dependencies:
-    caniuse-lite "^1.0.30000974"
-    electron-to-chromium "^1.3.150"
+    caniuse-lite "^1.0.30000975"
+    electron-to-chromium "^1.3.164"
     node-releases "^1.1.23"
 
 bser@1.0.2:
@@ -4820,9 +4820,9 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634:
   integrity sha512-Hy1a+UIXooG+tRlt3WnT9avMf+l999bR9J1MqlQdYKgbsYjKxV4a4rgcmiyMmdCLPBFsiRoDxdl9tnNyaq2RXw==
 
 caniuse-db@^1.0.30000639:
-  version "1.0.30000974"
-  resolved "https://artifactory.intcx.net/artifactory/api/npm/npm-virtual/caniuse-db/-/caniuse-db-1.0.30000974.tgz#ffc887e57e7db7067da203b102071a1d2477c5c8"
-  integrity sha1-/8iH5X59twZ9ogOxAgcaHSR3xcg=
+  version "1.0.30000975"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000975.tgz#c8910e6b9343c4e771e9901f4b768dae7cc40b12"
+  integrity sha512-4Ht47eUW0uaOhuCs7bc7BhWqhP7ix3QCxcY7VLRLmw81AOz8S9A6pjTajxTDakQc+T/zTnUdy4iSmt5brSNxxw==
 
 caniuse-lite@^1.0.0:
   version "1.0.30000865"
@@ -4839,10 +4839,10 @@ caniuse-lite@^1.0.30000748, caniuse-lite@^1.0.30000844:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000885.tgz#e889e9f8e7e50e769f2a49634c932b8aee622984"
   integrity sha512-cXKbYwpxBLd7qHyej16JazPoUacqoVuDhvR61U7Fr5vSxMUiodzcYa1rQYRYfZ5GexV03vGZHd722vNPLjPJGQ==
 
-caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000974:
-  version "1.0.30000974"
-  resolved "https://artifactory.intcx.net/artifactory/api/npm/npm-virtual/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz#b7afe14ee004e97ce6dc73e3f878290a12928ad8"
-  integrity sha1-t6/hTuAE6Xzm3HPj+HgpChKSitg=
+caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000975:
+  version "1.0.30000975"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000975.tgz#d4e7131391dddcf2838999d3ce75065f65f1cdfc"
+  integrity sha512-ZsXA9YWQX6ATu5MNg+Vx/cMQ+hM6vBBSqDeJs8ruk9z0ky4yIHML15MoxcFt088ST2uyjgqyUGRJButkptWf0w==
 
 caniuse-lite@^1.0.30000932:
   version "1.0.30000936"
@@ -7259,10 +7259,10 @@ ejs@^2.5.7:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
   integrity sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==
 
-electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.150, electron-to-chromium@^1.3.30:
+electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.164, electron-to-chromium@^1.3.30:
   version "1.3.164"
-  resolved "https://artifactory.intcx.net/artifactory/api/npm/npm-virtual/electron-to-chromium/-/electron-to-chromium-1.3.164.tgz#8680b875577882c1572c42218d53fa9ba5f71d5d"
-  integrity sha1-hoC4dVd4gsFXLEIhjVP6m6X3HV0=
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.164.tgz#8680b875577882c1572c42218d53fa9ba5f71d5d"
+  integrity sha512-VLlalqUeduN4+fayVtRZvGP2Hl1WrRxlwzh2XVVMJym3IFrQUS29BFQ1GP/BxOJXJI1OFCrJ5BnFEsAe8NHtOg==
 
 electron-to-chromium@^1.3.47:
   version "1.3.67"
@@ -15577,8 +15577,8 @@ node-pre-gyp@^0.10.0:
 
 node-releases@^1.1.23:
   version "1.1.23"
-  resolved "https://artifactory.intcx.net/artifactory/api/npm/npm-virtual/node-releases/-/node-releases-1.1.23.tgz#de7409f72de044a2fa59c097f436ba89c39997f0"
-  integrity sha1-3nQJ9y3gRKL6WcCX9Da6icOZl/A=
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.23.tgz#de7409f72de044a2fa59c097f436ba89c39997f0"
+  integrity sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==
   dependencies:
     semver "^5.3.0"
 


### PR DESCRIPTION
**What**:
Upgrade the `PropsOf<C>` TypeScript utilities to support `defaultProps` by delegating to new JSX and React types.

**Why**:
The `PropsOf<C>` utilities in _@emotion/styled-base_ and _emotion/theming_ currently result in a TypeScript error when using `styled` or `withTheme` with a component that has a `defaultProp` that is made optional by defaulting the prop value, yet is required on the Props interface and no value is passed to the component instance.

```fsh
Error: /src/emotion/packages/styled-base/types/tests.tsx:288:24
ERROR: 288:24  expect  TypeScript@next compile error:
Property 'prop' is missing in type '{}' but required in type 'Props'.
ERROR: 297:21  expect  TypeScript@next compile error:
Property 'prop' is missing in type '{}' but required in type 'Props'.
```
See tests in this PR for both class-based and function-based component scenarios.

**How**:
The solution provided here uses some newer typings for JSX and React (requiring some TypeScript and _@types/react_ upgrades).

Complexity is reduced by adapting a library-provided interface that is parameterized by both a component and its props (`JSX.LibraryManagedAttributes<C, P>`) to our utility interface parameterized by only a component (`PropsOf<C>`).

The `React.ComponentProps<C>` type utility is the key that allows us to extract Props (P) from the component (C).

The `JSX.LibraryManagedAttributes<C, P>` type utility ensures `props` with associated `defaultProps` are made optional (also see `ReactManagedAttributes` and `Defaultize` utilities in _@types/react_).

The type parameter `C` is constrained to match that of `React.ComponentProps<C>`: `keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>`.

A primary benefit of adapting to standard interfaces is reduced type maintenance over time.  I haven't tested it, but also noticed that Issue https://github.com/emotion-js/emotion/issues/991 may be resolved by this change as well since union prop types should be supported by these standard interfaces.

**Note:** Upon running `yarn test:typescript` with a clean build from master, I encountered TypeScript errors related to `React.ReactNode`'s use of a [union with both null and undefined](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L192) included.  I have suppressed the error by turning off the `no-null-undefined-union` flag in tslint; however, you may prefer a different approach.

**Checklist**:
- [ ] Documentation N/A
- [x] Tests
- [x] Code complete
- [x] Changeset