### PR TITLE
@emotion/cache readme: fix minor typos

### DIFF
--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -2,7 +2,7 @@
 
 ### createCache
 
-`createCache` allows for low level customization of how styles get inserted by emotion. It's intended to be used with the [`<CacheProvider/>`](https://emotion.sh/docs/cache-provider) component to override the default cache which is created with sensible defaults for most applications.
+`createCache` allows for low level customization of how styles get inserted by emotion. It's intended to be used with the [`<CacheProvider/>`](https://emotion.sh/docs/cache-provider) component to override the default cache, which is created with sensible defaults for most applications.
 
 ```javascript
 import createCache from '@emotion/cache'
@@ -21,7 +21,7 @@ export const myCache = createCache({
 
 - Setting a [nonce](#nonce-string) on any `<style/>` tag emotion creates for security purposes
 
-- Use emotion with a developer defined `<style/>` tag
+- Using emotion with a developer defined `<style/>` tag
 
 - Using emotion with custom stylis plugins
 
@@ -37,12 +37,12 @@ A Stylis plugin or plugins that will be run by stylis during preprocessing. [Rea
 
 ### prefix: boolean | Function
 
-Allows changing Stylis' prefixing settings, this defaults to `true`. It can be a boolean or a function to dynamicly set which properties are prefixed. [More information can be found in Stylis' docs](https://github.com/thysultan/stylis.js#vendor-prefixing)
+Allows changing Stylis' prefixing settings; defaults to `true`. It can be a boolean or a function to dynamically set which properties are prefixed. [More information can be found in Stylis' docs](https://github.com/thysultan/stylis.js#vendor-prefixing).
 
 ### key: string
 
-The prefix before class names, this defaults to `css`. It will also be set as the value of the `data-emotion` attribute on the style tags that emotion inserts and it's used in the attribute name that marks style elements in `renderStylesToString` and `renderStylesToNodeStream`. This is **required if using multiple emotion caches in the same app**.
+The prefix before class names; defaults to `css`. It will also be set as the value of the `data-emotion` attribute on the style tags that emotion inserts and it's used in the attribute name that marks style elements in `renderStylesToString` and `renderStylesToNodeStream`. This is **required if using multiple emotion caches in the same app**.
 
 ### container: HTMLElement
 
-A DOM Node that emotion will insert all of it's style tags into, this is useful for inserting styles into iframes.
+A DOM Node that emotion will insert all of its style tags into. This is useful for inserting styles into iframes.

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -23,26 +23,36 @@ export const myCache = createCache({
 
 - Using emotion with a developer defined `<style/>` tag
 
-- Using emotion with custom stylis plugins
+- Using emotion with custom Stylis plugins
 
 ## Options
 
-### nonce: string
+### `nonce`
+
+`string`
 
 A nonce that will be set on each style tag that emotion inserts for [Content Security Policies](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
 
-### stylisPlugins: Function | Array<Function>
+### `stylisPlugins`
 
-A Stylis plugin or plugins that will be run by stylis during preprocessing. [Read Stylis' docs to find out more](https://github.com/thysultan/stylis.js#plugins). This can for be used for many purposes such as RTL.
+`Function` | `Array<Function>`
 
-### prefix: boolean | Function
+A Stylis plugin or plugins that will be run by Stylis during preprocessing. [Read the Stylis docs to find out more](https://github.com/thysultan/stylis.js#plugins). This can be used for many purposes such as RTL.
 
-Allows changing Stylis' prefixing settings; defaults to `true`. It can be a boolean or a function to dynamically set which properties are prefixed. [More information can be found in Stylis' docs](https://github.com/thysultan/stylis.js#vendor-prefixing).
+### `prefix`
 
-### key: string
+`boolean` | `Function`, defaults to `true`
 
-The prefix before class names; defaults to `css`. It will also be set as the value of the `data-emotion` attribute on the style tags that emotion inserts and it's used in the attribute name that marks style elements in `renderStylesToString` and `renderStylesToNodeStream`. This is **required if using multiple emotion caches in the same app**.
+Allows changing Stylis's vendor prefixing settings. It can be a boolean or a function to dynamically set which properties are prefixed. [More information can be found in the Stylis docs](https://github.com/thysultan/stylis.js#vendor-prefixing).
 
-### container: HTMLElement
+### `key`
 
-A DOM Node that emotion will insert all of its style tags into. This is useful for inserting styles into iframes.
+`string`, defaults to `"css"`
+
+The prefix before class names. It will also be set as the value of the `data-emotion` attribute on the style tags that emotion inserts and it's used in the attribute name that marks style elements in `renderStylesToString` and `renderStylesToNodeStream`. This is **required if using multiple emotion caches in the same app**.
+
+### `container`
+
+`HTMLElement`
+
+A DOM node that emotion will insert all of its style tags into. This is useful for inserting styles into iframes.


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Minor copyedits to readme for @emotion/cache
- Add missing comma before non-restrictive 'which'
- Use gerunds consistently in 'Primary use cases' section
- Fix [comma splices](https://en.wikipedia.org/wiki/Comma_splice) in 'Options' section
- Correct the spelling of 'dynamically'
- Use proper form of possessive 'its'

<!-- Why are these changes necessary? -->
**Why**:
To align the readme copy with the quality and seriousness of this project's code.

<!-- How were these changes implemented? -->
**How**:
By keyboard, mainly! :)

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset --> N/A