### PR TITLE
Attempt to fix rewritten links

### DIFF
--- a/site/docs-yaml.js
+++ b/site/docs-yaml.js
@@ -3,8 +3,21 @@ const path = require('path')
 const yaml = require('js-yaml')
 const packageYamlPath = path.resolve(__dirname, '../docs/docs.yaml')
 
-module.exports = () => {
+const loadDocsYaml = () => {
   const yamlString = fs.readFileSync(packageYamlPath).toString()
 
   return yaml.safeLoad(yamlString)
+}
+
+module.exports = loadDocsYaml
+
+module.exports.getPackagesDirs = () => {
+  const packages = loadDocsYaml().filter(({ title }) => title === 'Packages')[0]
+    .items
+
+  return packages.reduce((pkgMap, pkgName) => {
+    const pkgDirname = pkgName.replace('@emotion/', '')
+    pkgMap[pkgDirname] = path.resolve(`${__dirname}/../packages/${pkgDirname}`)
+    return pkgMap
+  }, {})
 }

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -1,19 +1,13 @@
 const path = require('path')
-const packages = require('./docs-yaml')().filter(
-  ({ title }) => title === 'Packages'
-)[0].items
+const packages = require('./docs-yaml').getPackagesDirs()
 
 module.exports = {
   siteMetadata: {
     siteUrl: 'https://emotion.sh',
     title: `emotion`
   },
-  plugins: packages
-    .map(pkg =>
-      path.resolve(
-        `${__dirname}/../packages/${pkg.replace('@emotion/', '')}/README.md`
-      )
-    )
+  plugins: Object.entries(packages)
+    .map(([pkgDirname, pkgPath]) => path.join(pkgPath, 'README.md'))
     .map(file => ({
       resolve: 'gatsby-source-filesystem',
       options: {

--- a/site/plugins/gatsby-remark-fix-links/index.js
+++ b/site/plugins/gatsby-remark-fix-links/index.js
@@ -1,4 +1,5 @@
 const visit = require('unist-util-visit')
+const packages = require('../../docs-yaml').getPackagesDirs()
 
 module.exports = ({ markdownAST }) => {
   visit(markdownAST, 'link', node => {
@@ -8,7 +9,11 @@ module.exports = ({ markdownAST }) => {
         .replace(/\.md(#.*)?$/, (match, hash) => {
           return hash || ''
         })
-        .replace(/^\/packages\//, '/docs/')
+        .replace(/^\/packages\/(.+)(?:\/)/, (match, p1) => {
+          return `/docs/${
+            require(path.join(packages[p1], 'package.json')).name
+          }`
+        })
     }
   })
 }


### PR DESCRIPTION
Just a showcase of my quick attempt to fix the situation - it fails on GraphQL query though:
<details>
<summary>Error</summary>

```
The GraphQL query from /Users/mateuszburzynski/Desktop/emotion/site/src/templates/doc.js failed.

Errors:
  path is not defined
  
  GraphQL request (5:5)
  4:   doc: markdownRemark(fields: {slug: {eq: $slug}}) {
  5:     htmlAst
         ^
  6:     frontmatter {
  
URL path:
  /docs/install
Context:
  {
    "slug": "install"
  }
Plugin:
  none
Query:
  query DocBySlug(
    $slug: String!
  ) {
    doc: markdownRemark(fields: {slug: {eq: $slug}}) {
      htmlAst
      frontmatter {
        title
      }
    }
    avatar: file(name: {eq: "emotion"}) {
      childImageSharp {
        resolutions(width: 96, height: 96) {
          src
        }
      }
    }
  }
```
</details>

The problem is with links to packages which have a scope in their name because their directories dont have this scope included, but docs URLs have it in the path and we have to map between those to make it work.

I.e. https://emotion.sh/docs/create-emotion#options links to https://emotion.sh/docs/cache#options but in fact it should link to https://emotion.sh/docs/@emotion/cache#options

cc @mitchellhamilton 