### PR TITLE
Amended docs to highlight there are 2 approaches to SSR

### DIFF
--- a/packages/cache/src/index.js
+++ b/packages/cache/src/index.js
@@ -207,7 +207,7 @@ let createCache = (options?: Options): EmotionCache => {
             /(:first|:nth|:nth-last)-child/g
           )
 
-          if (unsafePseudoClasses) {
+          if (unsafePseudoClasses && cache.compat !== true) {
             unsafePseudoClasses.forEach(unsafePseudoClass => {
               const ignoreRegExp = new RegExp(
                 `${unsafePseudoClass}.*\\/\\* ${flag} \\*\\/`


### PR DESCRIPTION
Also do not warn about nth child selectors if using direct API integrations.

Opening this as a discussion on how to fix #1178. 

I have a question though which will help me finish this PR off properly, I really do not understand the section in the docs with the CacheProvider for migration, if you do this you end up with 2 versions of the cache, the one which is created automatically and the one I create. This would not work with the fix I have implemented afaik?

// @mitchellhamilton 