### PR TITLE
Remove unused support for this.mergedProps from bare emotion's css

### DIFF
--- a/packages/create-emotion/src/index.js
+++ b/packages/create-emotion/src/index.js
@@ -75,12 +75,8 @@ let createEmotion = (options: *): Emotion => {
   }
   cache.compat = true
 
-  let css = function(...args) {
-    let serialized = serializeStyles(
-      args,
-      cache.registered,
-      this !== undefined ? this.mergedProps : undefined
-    )
+  let css = (...args) => {
+    let serialized = serializeStyles(args, cache.registered, undefined)
     insertStyles(cache, serialized, false)
     return `${cache.key}-${serialized.name}`
   }


### PR DESCRIPTION
I couldn't find usage of this pattern inside our codebase and there seems to be no test case covering this which leads me to believe that this is some unused leftover code.