### PR TITLE
Remove react native bundles for core and cache in favour of different isBrowser detection

### DIFF
--- a/.changeset/popular-mayflies-sell/changes.json
+++ b/.changeset/popular-mayflies-sell/changes.json
@@ -1,0 +1,7 @@
+{
+  "releases": [
+    { "name": "@emotion/cache", "type": "patch" },
+    { "name": "@emotion/core", "type": "patch" }
+  ],
+  "dependents": []
+}

--- a/.changeset/popular-mayflies-sell/changes.md
+++ b/.changeset/popular-mayflies-sell/changes.md
@@ -1,0 +1,1 @@
+Remove react native bundles in favour of different isBrowser detection

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -8,14 +8,6 @@
     "./dist/cache.cjs.js": "./dist/cache.browser.cjs.js",
     "./dist/cache.esm.js": "./dist/cache.browser.esm.js"
   },
-  "react-native": {
-    "./dist/cache.cjs.js": "./dist/cache.native.cjs.js",
-    "./dist/cache.esm.js": "./dist/cache.native.esm.js"
-  },
-  "sketch": {
-    "./dist/cache.cjs.js": "./dist/cache.native.cjs.js",
-    "./dist/cache.esm.js": "./dist/cache.native.esm.js"
-  },
   "types": "types/index.d.ts",
   "license": "MIT",
   "repository": "https://github.com/emotion-js/emotion/tree/master/packages/cache",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,14 +7,6 @@
     "./dist/core.cjs.js": "./dist/core.browser.cjs.js",
     "./dist/core.esm.js": "./dist/core.browser.esm.js"
   },
-  "react-native": {
-    "./dist/core.cjs.js": "./dist/core.native.cjs.js",
-    "./dist/core.esm.js": "./dist/core.native.esm.js"
-  },
-  "sketch": {
-    "./dist/core.cjs.js": "./dist/core.native.cjs.js",
-    "./dist/core.esm.js": "./dist/core.native.esm.js"
-  },
   "types": "types/index.d.ts",
   "files": [
     "src",

--- a/packages/core/src/context.js
+++ b/packages/core/src/context.js
@@ -5,7 +5,13 @@ import createCache from '@emotion/cache'
 import { isBrowser } from './utils'
 
 let EmotionCacheContext: React.Context<EmotionCache | null> = React.createContext(
-  isBrowser ? createCache() : null
+  // we're doing this to avoid preconstruct's dead code elimination in this one case
+  // because this module is primarily intended for the browser and node
+  // but it's also required in react native and similar environments sometimes
+  // and we could have a special build just for that
+  // but this is much easier and the native packages
+  // might use a different theme context in the future anyway
+  typeof HTMLElement !== 'undefined' ? createCache() : null
 )
 
 export let ThemeContext = React.createContext<Object>({})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Remove react native bundles for core and cache in favour of different isBrowser detection
<!-- Why are these changes necessary? -->
**Why**:
I want to rethink what support for the react-native field should look like in preconstruct and didn't want to have this usage of it.
<!-- How were these changes implemented? -->
**How**:
Change the only isBrowser check to something that preconstruct doesn't replace for browsers which in this case, I chose typeof HTMLElement
<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
