### PR TITLE
fix: Remove warn when using nth selector with extract critical

### DIFF
--- a/.changeset/ten-bulldogs-kick/changes.json
+++ b/.changeset/ten-bulldogs-kick/changes.json
@@ -1,0 +1,7 @@
+{
+  "releases": [
+    { "name": "@emotion/cache", "type": "patch" },
+    { "name": "emotion-server", "type": "patch" }
+  ],
+  "dependents": []
+}

--- a/.changeset/ten-bulldogs-kick/changes.md
+++ b/.changeset/ten-bulldogs-kick/changes.md
@@ -1,0 +1,1 @@
+nth selector will no longer warn when using extract critical

--- a/packages/cache/src/index.js
+++ b/packages/cache/src/index.js
@@ -211,7 +211,7 @@ let createCache = (options?: Options): EmotionCache => {
             /(:first|:nth|:nth-last)-child/g
           )
 
-          if (unsafePseudoClasses) {
+          if (unsafePseudoClasses && cache.compat !== true) {
             unsafePseudoClasses.forEach(unsafePseudoClass => {
               const ignoreRegExp = new RegExp(
                 `${unsafePseudoClass}.*\\/\\* ${flag} \\*\\/`

--- a/packages/emotion-server/test/index.test.js
+++ b/packages/emotion-server/test/index.test.js
@@ -7,6 +7,7 @@ import React from 'react'
 import { renderToString } from 'react-dom/server'
 import { getComponents, prettyifyCritical, getInjectedRules } from './util'
 import { JSDOM } from 'jsdom'
+import { ignoreConsoleErrors } from 'test-utils'
 
 let emotion = require('emotion')
 let reactEmotion = require('@emotion/styled')
@@ -25,6 +26,18 @@ describe('extractCritical', () => {
         emotionServer.extractCritical(renderToString(<Page2 />))
       )
     ).toMatchSnapshot()
+  })
+
+  test('does not warn when using extract critical', () => {
+    const WithNthSelector = reactEmotion.default('div')({
+      ':nth-child(1)': {}
+    })
+
+    ignoreConsoleErrors(() => {
+      emotionServer.extractCritical(renderToString(<WithNthSelector />))
+
+      expect(console.error.mock.calls).toMatchObject([])
+    })
   })
 })
 describe('hydration', () => {

--- a/packages/emotion-server/test/index.test.js
+++ b/packages/emotion-server/test/index.test.js
@@ -29,12 +29,19 @@ describe('extractCritical', () => {
   })
 
   test('does not warn when using extract critical', () => {
+    let Provider = require('@emotion/core').CacheProvider
     const WithNthSelector = reactEmotion.default('div')({
       ':nth-child(1)': {}
     })
 
     ignoreConsoleErrors(() => {
-      emotionServer.extractCritical(renderToString(<WithNthSelector />))
+      emotionServer.extractCritical(
+        renderToString(
+          <Provider value={emotion.cache}>
+            <WithNthSelector />
+          </Provider>
+        )
+      )
 
       expect(console.error.mock.calls).toMatchObject([])
     })


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Removing the nth selector warn when using extract critical. I am separating the docs changes because this change will be useful separate to improving the docs.
Relates to #1178

<!-- Why are these changes necessary? -->
**Why**: The warning is incorrect

<!-- How were these changes implemented? -->
**How**: 

**Checklist**:
- [x] Documentation (NA)
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

Failing test before the change:
<img width="1066" alt="image" src="https://user-images.githubusercontent.com/453152/63782998-d5855e00-c91e-11e9-836e-1f84370d203c.png">
