### PR TITLE
Add type definition for useTheme from emotion-theming

### DIFF
--- a/.changeset/dirty-owls-remain/changes.json
+++ b/.changeset/dirty-owls-remain/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "emotion-theming", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/dirty-owls-remain/changes.md
+++ b/.changeset/dirty-owls-remain/changes.md
@@ -1,0 +1,1 @@
+Add TypeScript type definition for the useTheme hook in emotion-theming

--- a/packages/emotion-theming/types/index.d.ts
+++ b/packages/emotion-theming/types/index.d.ts
@@ -14,6 +14,8 @@ export function ThemeProvider<Theme>(
   props: ThemeProviderProps<Theme>
 ): React.ReactElement
 
+export function useTheme<Theme>(): Theme
+
 /**
  * @todo Add more constraint to C so that
  * this function only accepts components with theme props.

--- a/packages/emotion-theming/types/tests.tsx
+++ b/packages/emotion-theming/types/tests.tsx
@@ -1,7 +1,7 @@
 import * as emotionTheming from 'emotion-theming'
 import * as React from 'react'
 
-const { ThemeProvider, withTheme } = emotionTheming
+const { ThemeProvider, withTheme, useTheme } = emotionTheming
 
 interface Theme {
   primary: string
@@ -36,6 +36,11 @@ class CompCWithDefault extends React.Component<Props> {
   render() {
     return this.props.prop ? <span /> : <div />
   }
+}
+
+{
+  const theme: Theme = useTheme<Theme>()
+  const themeFail: Theme = useTheme<number>() // $ExpectError
 }
 
 const ThemedSFCWithDefault = withTheme(CompSFCWithDefault)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
This PR is adding TypeScript type definition for `useTheme`hook.

<!-- Why are these changes necessary? -->
**Why**:
The type definition was completely missing which prevents us from using `useTheme` in a TypeScript project.

<!-- How were these changes implemented? -->
**How**:
Added the definition + attempted to write a test for it. Let me know if it looks OK.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
