### PR TITLE
feat: improve type definition of styled

### DIFF
--- a/.changeset/spicy-dogs-shop/changes.json
+++ b/.changeset/spicy-dogs-shop/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "@emotion/styled", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/spicy-dogs-shop/changes.md
+++ b/.changeset/spicy-dogs-shop/changes.md
@@ -1,0 +1,1 @@
+improve TypeScript definition

--- a/packages/styled-base/types/index.d.ts
+++ b/packages/styled-base/types/index.d.ts
@@ -47,7 +47,7 @@ export interface StyledComponent<InnerProps, StyleProps, Theme extends object>
   withComponent<NewTag extends keyof JSXInEl>(
     tag: NewTag
   ): StyledComponent<JSXInEl[NewTag], StyleProps, Theme>
-  withComponent<Tag extends React.ComponentType<any>>(
+  withComponent<Tag extends React.ComponentType<PropsOf<Tag>>>(
     tag: Tag
   ): StyledComponent<PropsOf<Tag>, StyleProps, Theme>
 }
@@ -120,7 +120,7 @@ export type CreateStyledComponentIntrinsic<
   Theme extends object
 > = CreateStyledComponentBase<JSXInEl[Tag], ExtraProps, Theme>
 export type CreateStyledComponentExtrinsic<
-  Tag extends React.ComponentType<any>,
+  Tag extends React.ComponentType<PropsOf<Tag>>,
   ExtraProps,
   Theme extends object
 > = CreateStyledComponentBase<PropsOf<Tag>, ExtraProps, Theme>
@@ -136,7 +136,7 @@ export type CreateStyledComponentExtrinsic<
  * it could be more efficient.
  */
 export interface CreateStyled<Theme extends object = any> {
-  <Tag extends React.ComponentType<any>, ExtraProps = {}>(
+  <Tag extends React.ComponentType<PropsOf<Tag>>, ExtraProps = {}>(
     tag: Tag,
     options?: StyledOptions
   ): CreateStyledComponentExtrinsic<Tag, ExtraProps, Theme>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Fix a potential issue of TypeScript definition in emotion. See issue https://github.com/ant-design/ant-design/issues/18868 for an example.


<!-- Why are these changes necessary? -->
**Why**:
When a component has any static lifecycle defined and when this component has required props, `React.ComponentType<any>` will not be enough. `React.ComponentType<any>` has static definition of `GetDerivedStateFromProps<any, {}>`, while a component with required props might have a static API looks like `GetDerivedStateFromProps<{ title: string >, {}>`, types will not be assignable and TypeScript will throw out an error.

<!-- How were these changes implemented? -->
**How**:
Explicitly defines how props of this given component should look like. 

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Code complete N/A
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
