### PR TITLE
Move registeredStyles declaration to the point where its first element can be put directly in the declaration

### DIFF
--- a/packages/core/src/jsx.js
+++ b/packages/core/src/jsx.js
@@ -17,11 +17,6 @@ let labelPropName = '__EMOTION_LABEL_PLEASE_DO_NOT_USE__'
 let hasOwnProperty = Object.prototype.hasOwnProperty
 
 let render = (cache, props, theme: null | Object, ref) => {
-  let type = props[typePropName]
-  let registeredStyles = []
-
-  let className = ''
-
   let cssProp = theme === null ? props.css : props.css(theme)
 
   // so that using `css` from `emotion` and passing the result to the css prop works
@@ -31,7 +26,9 @@ let render = (cache, props, theme: null | Object, ref) => {
     cssProp = cache.registered[cssProp]
   }
 
-  registeredStyles.push(cssProp)
+  let type = props[typePropName]
+  let registeredStyles = [cssProp]
+  let className = ''
 
   if (props.className !== undefined) {
     className = getRegisteredStyles(


### PR DESCRIPTION
Just a minor code tweak - `.push(cssProp)` was unconditional etc and it could be moved directly into `registeredStyles` declaration. In addition to that I've moved 2 other variables with it as it seemed to make sense to group them together after `cssProp` gets "resolved"