### PR TITLE
Add Gatsby SSR custom cache example

### DIFF
--- a/docs/ssr.mdx
+++ b/docs/ssr.mdx
@@ -104,13 +104,12 @@ module.exports = {
 
 If using a [custom cache](./cache-provider), ensure you are creating a new cache per server render within `gatsby-ssr.js`. This will differ from the implementation within `gatsby-browser.js`.
 
-gatsby-ssr.js
+create-emotion-cache.js
 
 ```jsx
-import { CacheProvider } from '@emotion/core'
 import createCache from '@emotion/cache'
 
-const myCache = () =>
+export const createMyCache = () =>
   createCache({
     key: 'my-prefix-key',
     stylisPlugins: [
@@ -128,8 +127,18 @@ const myCache = () =>
     }
   })
 
+export const myCache = createMyCache()
+```
+
+gatsby-ssr.js
+
+```jsx
+import { CacheProvider } from '@emotion/core'
+
+import { createMyCache } from './create-emotion-cache'
+
 export const wrapRootElement = ({ element }) => (
-  <CacheProvider value={myCache()}>{element}</CacheProvider>
+  <CacheProvider value={createMyCache()}>{element}</CacheProvider>
 )
 ```
 
@@ -137,24 +146,8 @@ gatsby-browser.js
 
 ```jsx
 import { CacheProvider } from '@emotion/core'
-import createCache from '@emotion/cache'
 
-const myCache = createCache({
-  key: 'my-prefix-key',
-  stylisPlugins: [
-    /* your plugins here */
-  ],
-  // prefix based on the css property
-  prefix: key => {
-    switch (key) {
-      case 'flex':
-        return false
-      case 'transform':
-      default:
-        return true
-    }
-  }
-})
+import { myCache } from './create-emotion-cache'
 
 export const wrapRootElement = ({ element }) => (
   <CacheProvider value={myCache}>{element}</CacheProvider>

--- a/docs/ssr.mdx
+++ b/docs/ssr.mdx
@@ -53,9 +53,7 @@ import { renderToNodeStream } from 'react-dom/server'
 import { renderStylesToNodeStream } from 'emotion-server'
 import App from './App'
 
-const stream = renderToNodeStream(<App />).pipe(
-  renderStylesToNodeStream()
-)
+const stream = renderToNodeStream(<App />).pipe(renderStylesToNodeStream())
 ```
 
 ### extractCritical
@@ -67,9 +65,7 @@ import { renderToString } from 'react-dom/server'
 import { extractCritical } from 'emotion-server'
 import App from './App'
 
-const { html, ids, css } = extractCritical(
-  renderToString(<App />)
-)
+const { html, ids, css } = extractCritical(renderToString(<App />))
 ```
 
 #### hydrate
@@ -104,6 +100,65 @@ gatsby-config.js
 module.exports = {
   plugins: [...otherGatsbyPlugins, 'gatsby-plugin-emotion']
 }
+```
+
+If using a [custom cache](./cache-provider), ensure you are creating a new cache per server render within `gatsby-ssr.js`. This will differ from the implementation within `gatsby-browser.js`.
+
+gatsby-ssr.js
+
+```jsx
+import { CacheProvider } from '@emotion/core'
+import createCache from '@emotion/cache'
+
+const myCache = () =>
+  createCache({
+    key: 'my-prefix-key',
+    stylisPlugins: [
+      /* your plugins here */
+    ],
+    // prefix based on the css property
+    prefix: key => {
+      switch (key) {
+        case 'flex':
+          return false
+        case 'transform':
+        default:
+          return true
+      }
+    }
+  })
+
+export const wrapRootElement = ({ element }) => (
+  <CacheProvider value={myCache()}>{element}</CacheProvider>
+)
+```
+
+gatsby-browser.js
+
+```jsx
+import { CacheProvider } from '@emotion/core'
+import createCache from '@emotion/cache'
+
+const myCache = createCache({
+  key: 'my-prefix-key',
+  stylisPlugins: [
+    /* your plugins here */
+  ],
+  // prefix based on the css property
+  prefix: key => {
+    switch (key) {
+      case 'flex':
+        return false
+      case 'transform':
+      default:
+        return true
+    }
+  }
+})
+
+export const wrapRootElement = ({ element }) => (
+  <CacheProvider value={myCache}>{element}</CacheProvider>
+)
 ```
 
 > Note:


### PR DESCRIPTION
**What**:

Documentation updates to go along with [this super helpful comment](https://github.com/gatsbyjs/gatsby/issues/17894#issuecomment-538555130) that resolved a frustrating GatsbyJS issue I was facing.

**Why**:

While Emotion was still "technically" functioning, SSR was not working as expected due to an incorrect assumption of how I should be handling SSR with a custom cache. This should help clear up confusion for others.

**How**:

Updated docs with example.

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A
- [ ] Changeset N/A
