### PR TITLE
Add missing /* #__PURE__ */ annotation to creation of EmotionCssPropInternal

### DIFF
--- a/.changeset/slow-apricots-hunt/changes.json
+++ b/.changeset/slow-apricots-hunt/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@emotion/core", "type": "patch" }], "dependents": [] }

--- a/.changeset/slow-apricots-hunt/changes.md
+++ b/.changeset/slow-apricots-hunt/changes.md
@@ -1,1 +1,1 @@
-Add missing /_ #**PURE** _/ annotation to creation of EmotionCssPropInternal
+Add missing `/* #__PURE__ */` annotation to creation of EmotionCssPropInternal

--- a/.changeset/slow-apricots-hunt/changes.md
+++ b/.changeset/slow-apricots-hunt/changes.md
@@ -1,0 +1,1 @@
+Add missing /_ #**PURE** _/ annotation to creation of EmotionCssPropInternal

--- a/packages/core/src/jsx.js
+++ b/packages/core/src/jsx.js
@@ -93,7 +93,7 @@ let render = (cache, props, theme: null | Object, ref) => {
   return ele
 }
 
-let Emotion = withEmotionCache((props, cache, ref) => {
+let Emotion = /* #__PURE__ */ withEmotionCache((props, cache, ref) => {
   // use Context.read for the theme when it's stable
   if (typeof props.css === 'function') {
     return (


### PR DESCRIPTION
We could automate adding those with my https://github.com/Andarist/babel-plugin-annotate-pure-calls - but not sure how do you feel about it, so I've added this inline for now.