### PR TITLE
Push source maps & labels to cooked/raw arrays in TS-transpiled tagged template expressions

### DIFF
--- a/.changeset/many-worms-beam/changes.json
+++ b/.changeset/many-worms-beam/changes.json
@@ -1,0 +1,4 @@
+{
+  "releases": [{ "name": "babel-plugin-emotion", "type": "patch" }],
+  "dependents": []
+}

--- a/.changeset/many-worms-beam/changes.md
+++ b/.changeset/many-worms-beam/changes.md
@@ -1,0 +1,1 @@
+Push source maps & labels to cooked/raw arrays in TS-transpiled tagged template expressions

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ package-lock.json
 public/
 !playgrounds/cra/public
 .env
+.vscode

--- a/packages/babel-plugin-emotion/__tests__/__snapshots__/css-requires-options.js.snap
+++ b/packages/babel-plugin-emotion/__tests__/__snapshots__/css-requires-options.js.snap
@@ -91,6 +91,16 @@ let cls = /*#__PURE__*/_css(process.env.NODE_ENV === 'production' ? {
 });"
 `;
 
+exports[`babel css inline babel 6 label on code transpiled by TS 1`] = `
+"import _css from '@emotion/css';
+
+import { __makeTemplateObject } from 'tslib';
+
+var templateObject_1;
+
+const someVar = /*#__PURE__*/_css(templateObject_1 || (templateObject_1 = __makeTemplateObject(['\\\\n  color: hotpink;\\\\nlabel:someVar;'], ['\\\\n  color: hotpink;\\\\nlabel:someVar;'])));"
+`;
+
 exports[`babel css inline babel 7 custom instance 1`] = `
 "import { css as _css } from \\"my-emotion-instance\\";
 
@@ -191,4 +201,14 @@ _css(process.env.NODE_ENV === \\"production\\" ? {
   styles: \\"color:hotpink;label:my-css-cls;\\",
   map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImNzcy1yZXF1aXJlcy1vcHRpb25zLmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVjIiwiZmlsZSI6ImNzcy1yZXF1aXJlcy1vcHRpb25zLmpzIiwic291cmNlc0NvbnRlbnQiOlsiXG4gICAgaW1wb3J0IHtjc3N9IGZyb20gJ2Vtb3Rpb24nXG4gICAgbGV0IGNscyA9IGNzcyh7Y29sb3I6J2hvdHBpbmsnfSlcbiAgICAiXX0= */\\"
 });"
+`;
+
+exports[`babel css inline babel 7 label on code transpiled by TS 1`] = `
+"import _css from \\"@emotion/css\\";
+import { __makeTemplateObject } from 'tslib';
+var templateObject_1;
+
+const someVar =
+/*#__PURE__*/
+_css(templateObject_1 || (templateObject_1 = __makeTemplateObject([\\"\\\\n  color: hotpink;\\\\nlabel:someVar;\\"], [\\"\\\\n  color: hotpink;\\\\nlabel:someVar;\\"])));"
 `;

--- a/packages/babel-plugin-emotion/__tests__/__snapshots__/css.js.snap
+++ b/packages/babel-plugin-emotion/__tests__/__snapshots__/css.js.snap
@@ -374,6 +374,32 @@ const thing = {
 };"
 `;
 
+exports[`@emotion/babel-plugin-core css label-transpiled-by-ts 1`] = `
+"import css from '@emotion/css'
+import { __makeTemplateObject } from 'tslib'
+
+var templateObject_1
+
+const someVar = css(
+  templateObject_1 ||
+    (templateObject_1 = __makeTemplateObject(
+      ['\\\\n  color: hotpink;\\\\n'],
+      ['\\\\n  color: hotpink;\\\\n']
+    ))
+)
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _css from \\"@emotion/css\\";
+import { __makeTemplateObject } from 'tslib';
+var templateObject_1;
+
+const someVar =
+/*#__PURE__*/
+_css(templateObject_1 || (templateObject_1 = __makeTemplateObject([\\"\\\\n  color: hotpink;\\\\nlabel:someVar;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImxhYmVsLXRyYW5zcGlsZWQtYnktdHMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBS2dCIiwiZmlsZSI6ImxhYmVsLXRyYW5zcGlsZWQtYnktdHMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgY3NzIGZyb20gJ0BlbW90aW9uL2NzcydcbmltcG9ydCB7IF9fbWFrZVRlbXBsYXRlT2JqZWN0IH0gZnJvbSAndHNsaWInXG5cbnZhciB0ZW1wbGF0ZU9iamVjdF8xXG5cbmNvbnN0IHNvbWVWYXIgPSBjc3MoXG4gIHRlbXBsYXRlT2JqZWN0XzEgfHxcbiAgICAodGVtcGxhdGVPYmplY3RfMSA9IF9fbWFrZVRlbXBsYXRlT2JqZWN0KFxuICAgICAgWydcXG4gIGNvbG9yOiBob3RwaW5rO1xcbiddLFxuICAgICAgWydcXG4gIGNvbG9yOiBob3RwaW5rO1xcbiddXG4gICAgKSlcbilcbiJdfQ== */\\")], [\\"\\\\n  color: hotpink;\\\\nlabel:someVar;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImxhYmVsLXRyYW5zcGlsZWQtYnktdHMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBS2dCIiwiZmlsZSI6ImxhYmVsLXRyYW5zcGlsZWQtYnktdHMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgY3NzIGZyb20gJ0BlbW90aW9uL2NzcydcbmltcG9ydCB7IF9fbWFrZVRlbXBsYXRlT2JqZWN0IH0gZnJvbSAndHNsaWInXG5cbnZhciB0ZW1wbGF0ZU9iamVjdF8xXG5cbmNvbnN0IHNvbWVWYXIgPSBjc3MoXG4gIHRlbXBsYXRlT2JqZWN0XzEgfHxcbiAgICAodGVtcGxhdGVPYmplY3RfMSA9IF9fbWFrZVRlbXBsYXRlT2JqZWN0KFxuICAgICAgWydcXG4gIGNvbG9yOiBob3RwaW5rO1xcbiddLFxuICAgICAgWydcXG4gIGNvbG9yOiBob3RwaW5rO1xcbiddXG4gICAgKSlcbilcbiJdfQ== */\\")])));"
+`;
+
 exports[`@emotion/babel-plugin-core css multiple-calls 1`] = `
 "import css from '@emotion/css'
 

--- a/packages/babel-plugin-emotion/__tests__/css-macro/__fixtures__/label-transpiled-by-ts.js
+++ b/packages/babel-plugin-emotion/__tests__/css-macro/__fixtures__/label-transpiled-by-ts.js
@@ -1,0 +1,12 @@
+import css from '@emotion/css/macro'
+import { __makeTemplateObject } from 'tslib'
+
+var templateObject_1
+
+const someVar = css(
+  templateObject_1 ||
+    (templateObject_1 = __makeTemplateObject(
+      ['\n  color: hotpink;\n'],
+      ['\n  color: hotpink;\n']
+    ))
+)

--- a/packages/babel-plugin-emotion/__tests__/css-macro/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-emotion/__tests__/css-macro/__snapshots__/index.js.snap
@@ -374,6 +374,32 @@ const thing = {
 };"
 `;
 
+exports[`@emotion/css/macro label-transpiled-by-ts 1`] = `
+"import css from '@emotion/css/macro'
+import { __makeTemplateObject } from 'tslib'
+
+var templateObject_1
+
+const someVar = css(
+  templateObject_1 ||
+    (templateObject_1 = __makeTemplateObject(
+      ['\\\\n  color: hotpink;\\\\n'],
+      ['\\\\n  color: hotpink;\\\\n']
+    ))
+)
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _css from \\"@emotion/css\\";
+import { __makeTemplateObject } from 'tslib';
+var templateObject_1;
+
+const someVar =
+/*#__PURE__*/
+_css(templateObject_1 || (templateObject_1 = __makeTemplateObject([\\"\\\\n  color: hotpink;\\\\nlabel:someVar;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImxhYmVsLXRyYW5zcGlsZWQtYnktdHMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBS2dCIiwiZmlsZSI6ImxhYmVsLXRyYW5zcGlsZWQtYnktdHMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgY3NzIGZyb20gJ0BlbW90aW9uL2Nzcy9tYWNybydcbmltcG9ydCB7IF9fbWFrZVRlbXBsYXRlT2JqZWN0IH0gZnJvbSAndHNsaWInXG5cbnZhciB0ZW1wbGF0ZU9iamVjdF8xXG5cbmNvbnN0IHNvbWVWYXIgPSBjc3MoXG4gIHRlbXBsYXRlT2JqZWN0XzEgfHxcbiAgICAodGVtcGxhdGVPYmplY3RfMSA9IF9fbWFrZVRlbXBsYXRlT2JqZWN0KFxuICAgICAgWydcXG4gIGNvbG9yOiBob3RwaW5rO1xcbiddLFxuICAgICAgWydcXG4gIGNvbG9yOiBob3RwaW5rO1xcbiddXG4gICAgKSlcbilcbiJdfQ== */\\")], [\\"\\\\n  color: hotpink;\\\\nlabel:someVar;\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImxhYmVsLXRyYW5zcGlsZWQtYnktdHMuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBS2dCIiwiZmlsZSI6ImxhYmVsLXRyYW5zcGlsZWQtYnktdHMuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgY3NzIGZyb20gJ0BlbW90aW9uL2Nzcy9tYWNybydcbmltcG9ydCB7IF9fbWFrZVRlbXBsYXRlT2JqZWN0IH0gZnJvbSAndHNsaWInXG5cbnZhciB0ZW1wbGF0ZU9iamVjdF8xXG5cbmNvbnN0IHNvbWVWYXIgPSBjc3MoXG4gIHRlbXBsYXRlT2JqZWN0XzEgfHxcbiAgICAodGVtcGxhdGVPYmplY3RfMSA9IF9fbWFrZVRlbXBsYXRlT2JqZWN0KFxuICAgICAgWydcXG4gIGNvbG9yOiBob3RwaW5rO1xcbiddLFxuICAgICAgWydcXG4gIGNvbG9yOiBob3RwaW5rO1xcbiddXG4gICAgKSlcbilcbiJdfQ== */\\")])));"
+`;
+
 exports[`@emotion/css/macro multiple-calls 1`] = `
 "import css from '@emotion/css/macro'
 

--- a/packages/babel-plugin-emotion/__tests__/css-requires-options.js
+++ b/packages/babel-plugin-emotion/__tests__/css-requires-options.js
@@ -50,6 +50,30 @@ const inline = {
     filename: __filename
   },
 
+  // this test has better readability for label alone than other ones which include source maps
+  'label on code transpiled by TS': {
+    code: `
+    import { __makeTemplateObject } from 'tslib'
+
+    import css from '@emotion/css'
+
+    var templateObject_1
+
+    const someVar = css(
+      templateObject_1 ||
+        (templateObject_1 = __makeTemplateObject(
+          ['\\n  color: hotpink;\\n'],
+          ['\\n  color: hotpink;\\n']
+        ))
+    )
+    `,
+    opts: {
+      autoLabel: true,
+      sourceMap: false
+    },
+    filename: __filename
+  },
+
   'custom instance': {
     code: `
     import {css as lol} from 'my-emotion-instance'

--- a/packages/babel-plugin-emotion/__tests__/source-maps/__fixtures__/css-transpiled-by-ts.js
+++ b/packages/babel-plugin-emotion/__tests__/source-maps/__fixtures__/css-transpiled-by-ts.js
@@ -1,0 +1,13 @@
+import { __makeTemplateObject } from 'tslib'
+
+import css from '@emotion/css'
+
+var templateObject_1
+
+css(
+  templateObject_1 ||
+    (templateObject_1 = __makeTemplateObject(
+      ['\n  color: hotpink;\n'],
+      ['\n  color: hotpink;\n']
+    ))
+)

--- a/packages/babel-plugin-emotion/__tests__/source-maps/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-emotion/__tests__/source-maps/__snapshots__/index.js.snap
@@ -92,6 +92,32 @@ process.env.NODE_ENV === \\"production\\" ? {
 };"
 `;
 
+exports[`source maps css-transpiled-by-ts 1`] = `
+"import { __makeTemplateObject } from 'tslib'
+
+import css from '@emotion/css'
+
+var templateObject_1
+
+css(
+  templateObject_1 ||
+    (templateObject_1 = __makeTemplateObject(
+      ['\\\\n  color: hotpink;\\\\n'],
+      ['\\\\n  color: hotpink;\\\\n']
+    ))
+)
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import _css from \\"@emotion/css\\";
+import { __makeTemplateObject } from 'tslib';
+var templateObject_1;
+
+/*#__PURE__*/
+_css(templateObject_1 || (templateObject_1 = __makeTemplateObject(['\\\\n  color: hotpink;\\\\n' + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNvdXJjZS1tYXAudGVzdC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFNQSIsImZpbGUiOiJzb3VyY2UtbWFwLnRlc3QuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBfX21ha2VUZW1wbGF0ZU9iamVjdCB9IGZyb20gJ3RzbGliJ1xuXG5pbXBvcnQgY3NzIGZyb20gJ0BlbW90aW9uL2NzcydcblxudmFyIHRlbXBsYXRlT2JqZWN0XzFcblxuY3NzKFxuICB0ZW1wbGF0ZU9iamVjdF8xIHx8XG4gICAgKHRlbXBsYXRlT2JqZWN0XzEgPSBfX21ha2VUZW1wbGF0ZU9iamVjdChcbiAgICAgIFsnXFxuICBjb2xvcjogaG90cGluaztcXG4nXSxcbiAgICAgIFsnXFxuICBjb2xvcjogaG90cGluaztcXG4nXVxuICAgICkpXG4pXG4iXX0= */\\")], ['\\\\n  color: hotpink;\\\\n' + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNvdXJjZS1tYXAudGVzdC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFNQSIsImZpbGUiOiJzb3VyY2UtbWFwLnRlc3QuanMiLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgeyBfX21ha2VUZW1wbGF0ZU9iamVjdCB9IGZyb20gJ3RzbGliJ1xuXG5pbXBvcnQgY3NzIGZyb20gJ0BlbW90aW9uL2NzcydcblxudmFyIHRlbXBsYXRlT2JqZWN0XzFcblxuY3NzKFxuICB0ZW1wbGF0ZU9iamVjdF8xIHx8XG4gICAgKHRlbXBsYXRlT2JqZWN0XzEgPSBfX21ha2VUZW1wbGF0ZU9iamVjdChcbiAgICAgIFsnXFxuICBjb2xvcjogaG90cGluaztcXG4nXSxcbiAgICAgIFsnXFxuICBjb2xvcjogaG90cGluaztcXG4nXVxuICAgICkpXG4pXG4iXX0= */\\")])));"
+`;
+
 exports[`source maps styled-object 1`] = `
 "import styled from '@emotion/styled'
 

--- a/packages/babel-plugin-emotion/src/utils/checks.js
+++ b/packages/babel-plugin-emotion/src/utils/checks.js
@@ -1,0 +1,27 @@
+// @flow
+
+export function isTaggedTemplateExpressionTranspiledByTypeScript(path: *) {
+  if (path.node.arguments.length !== 1) {
+    return false
+  }
+
+  const argPath = path.get('arguments')[0]
+
+  return (
+    argPath.isLogicalExpression() &&
+    argPath.get('left').isIdentifier() &&
+    argPath.node.left.name.includes('templateObject') &&
+    argPath.get('right').isAssignmentExpression() &&
+    argPath
+      .get('right')
+      .get('right')
+      .isCallExpression() &&
+    argPath
+      .get('right')
+      .get('right')
+      .get('callee')
+      .isIdentifier() &&
+    argPath.node.right.right.callee.name.includes('makeTemplateObject') &&
+    argPath.node.right.right.arguments.length === 2
+  )
+}

--- a/packages/babel-plugin-emotion/src/utils/index.js
+++ b/packages/babel-plugin-emotion/src/utils/index.js
@@ -8,4 +8,4 @@ export {
   transformExpressionWithStyles
 } from './transform-expression-with-styles'
 export { getStyledOptions } from './get-styled-options'
-export { appendStringToExpressions, joinStringLiterals } from './strings'
+export { appendStringToArguments, joinStringLiterals } from './strings'


### PR DESCRIPTION
This outputs code as if source maps were added to tagged template expression itself - instead of pushing new arguments to `__makeTemplateObject` and causing strings & values length mismatch.

Fixes issue reported in https://github.com/emotion-js/emotion/issues/1354#issuecomment-534793492