### PR TITLE
Fix `composition of nested pseudo selectors` test

### DIFF
--- a/packages/styled/__tests__/__snapshots__/styled.js.snap
+++ b/packages/styled/__tests__/__snapshots__/styled.js.snap
@@ -141,21 +141,33 @@ exports[`styled composition based on props 2`] = `
 `;
 
 exports[`styled composition of nested pseudo selectors 1`] = `
-.emotion-0 {
+.emotion-1 {
   font-size: 2rem;
   padding: 16px;
 }
 
-.emotion-0:hover {
+.emotion-1:hover {
   color: blue;
 }
 
-.emotion-0:hover:active {
+.emotion-1:hover:active {
   color: red;
 }
 
+.emotion-0:hover {
+  color: pink;
+}
+
+.emotion-0:hover:active {
+  color: purple;
+}
+
+.emotion-0:hover.some-class {
+  color: yellow;
+}
+
 <button
-  className="emotion-0"
+  className="emotion-0 emotion-1"
 >
   Should be purple
 </button>

--- a/packages/styled/__tests__/styled.js
+++ b/packages/styled/__tests__/styled.js
@@ -7,6 +7,7 @@ import styled from '@emotion/styled'
 import { ThemeProvider } from 'emotion-theming'
 import { keyframes } from '@emotion/core'
 import css from '@emotion/css'
+import { css as emotionCss } from 'emotion'
 
 describe('styled', () => {
   test('no dynamic', () => {
@@ -401,7 +402,7 @@ describe('styled', () => {
     const tree = renderer
       .create(
         <Button
-          css={css({
+          className={emotionCss({
             '&:hover': {
               color: 'pink',
               '&:active': {


### PR DESCRIPTION
I'm actually not sure if this is how it should get fixed - because I'm not sure what the exact intention of this test is. Seems to me that the applied fix might be incorrect, because this doesn't any composition - just that 2 classes can be applied to the same element. This is what a "sibling" test does though:
https://github.com/emotion-js/emotion/blob/c3f0bc101833fff1ee4e27c7a730b821a7df4a15/packages/styled/test/composition.test.js#L142
So maybe actually both should be adjusted to use `jsx` + `css` prop?