### PR TITLE
Add dev warning about keyframes being interpolated into plain strings.

### DIFF
--- a/.changeset/nine-tips-design/changes.json
+++ b/.changeset/nine-tips-design/changes.json
@@ -1,0 +1,8 @@
+{
+  "releases": [
+    { "name": "@emotion/core", "type": "patch" },
+    { "name": "@emotion/serialize", "type": "patch" },
+    { "name": "@emotion/styled", "type": "patch" }
+  ],
+  "dependents": []
+}

--- a/.changeset/nine-tips-design/changes.md
+++ b/.changeset/nine-tips-design/changes.md
@@ -1,0 +1,1 @@
+Add dev warning about keyframes being interpolated into plain strings.

--- a/packages/core/__tests__/warnings.js
+++ b/packages/core/__tests__/warnings.js
@@ -2,7 +2,7 @@
 /** @jsx jsx */
 import 'test-utils/next-env'
 import css from '@emotion/css'
-import { jsx, Global } from '@emotion/core'
+import { jsx, Global, keyframes } from '@emotion/core'
 import renderer from 'react-test-renderer'
 
 // $FlowFixMe
@@ -162,15 +162,15 @@ test('kebab-case', () => {
   css({ '--primary-color': 'hotpink' })
   css({ ':last-of-type': null })
   expect(console.error.mock.calls).toMatchInlineSnapshot(`
-Array [
-  Array [
-    "Using kebab-case for css properties in objects is not supported. Did you mean backgroundColor?",
-  ],
-  Array [
-    "Using kebab-case for css properties in objects is not supported. Did you mean msFilter?",
-  ],
-]
-`)
+        Array [
+          Array [
+            "Using kebab-case for css properties in objects is not supported. Did you mean backgroundColor?",
+          ],
+          Array [
+            "Using kebab-case for css properties in objects is not supported. Did you mean msFilter?",
+          ],
+        ]
+    `)
 })
 
 test('unterminated comments', () => {
@@ -205,4 +205,40 @@ test('unterminated comments', () => {
   ).toThrowErrorMatchingInlineSnapshot(
     `"Your styles have an unterminated comment (\\"/*\\" without corresponding \\"*/\\")."`
   )
+})
+
+test('keyframes interpolated into plain string', () => {
+  const animateColor = keyframes({
+    'from,to': { color: 'green' },
+    '50%': { color: 'hotpink' }
+  })
+  const rotate360 = keyframes({
+    from: {
+      transform: 'rotate(0deg)'
+    },
+    to: {
+      transform: 'rotate(360deg)'
+    }
+  })
+
+  renderer.create(
+    <div css={[`animation: ${animateColor} 10s ${rotate360} 5s;`]} />
+  )
+  expect(console.error.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        "\`keyframes\` output got interpolated into plain string, please wrap it with \`css\`.
+
+    Instead of doing this:
+
+    const animation0 = keyframes\`{from,to{color:green;}50%{color:hotpink;}}\`
+    const animation1 = keyframes\`{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}\`
+    \`animation: \${animation0} 10s \${animation1} 5s;\`
+
+    You should wrap it with \`css\` like this:
+
+    css\`animation: \${animation0} 10s \${animation1} 5s;\`",
+      ],
+    ]
+  `)
 })


### PR DESCRIPTION
Arguably the preferred way to write this would be to wrap the thing in `css` call which can handle interpolated `keyframes` without falling back into regexp extraction. 

It's slightly weird to me though that this is allowed when using object styles but it is not when using plain strings. I can think of an argument for this (object values being shorter and not needing `css` wrapping beside this one thing), but this looks inconsistent as part of the API. So if we decide not to merge this because of performance reasons we should at least add a dev warning about this.

EDIT:// changed the PR to introduce a dev warning instead of regexp matching all strings