### PR TITLE
Remove modularScale usage from tests

### DIFF
--- a/packages/styled/test/__snapshots__/composition.test.js.snap
+++ b/packages/styled/test/__snapshots__/composition.test.js.snap
@@ -87,15 +87,15 @@ exports[`composition of nested pseudo selectors 1`] = `
 exports[`composition with objects 1`] = `
 .emotion-0 {
   color: #333;
-  font-size: 1.333em;
+  font-size: 1em;
   height: 64px;
-  font-size: 3.157334518321em;
+  font-size: 4em;
   font-size: 32px;
 }
 
 @media only screen and (-webkit-min-device-pixel-ratio:1.5), only screen and (min--moz-device-pixel-ratio:1.5), only screen and (-o-min-device-pixel-ratio:1.5/1), only screen and (min-resolution:144dpi), only screen and (min-resolution:1.5dppx) {
   .emotion-0 {
-    font-size: 1.4323121856191332em;
+    font-size: 1.25em;
   }
 }
 

--- a/packages/styled/test/composition.test.js
+++ b/packages/styled/test/composition.test.js
@@ -5,7 +5,7 @@ import * as renderer from 'react-test-renderer'
 import { jsx, css } from '@emotion/core'
 import styled from '@emotion/styled'
 
-import { lighten, hiDPI, modularScale } from 'polished'
+import { lighten, hiDPI } from 'polished'
 
 test('composition', () => {
   const fontSize = '20px'
@@ -43,10 +43,10 @@ test('composition', () => {
 test('composition with objects', () => {
   const cssA = {
     color: lighten(0.2, '#000'),
-    fontSize: modularScale(1),
+    fontSize: '1em',
     [hiDPI(1.5)
       .replace('\n', ' ')
-      .trim()]: { fontSize: modularScale(1.25) }
+      .trim()]: { fontSize: '1.25em' }
   }
 
   const cssB = css`
@@ -56,7 +56,7 @@ test('composition with objects', () => {
 
   const H1 = styled('h1')`
     ${cssB};
-    font-size: ${modularScale(4)};
+    font-size: 4em;
   `
 
   const H2 = styled(H1)`


### PR DESCRIPTION
Funny thing - `modularScale` uses transpiled `**` under the hood, so basically `Math.pow`. And this yields "incorrect" values (rounded differently) on Node 10. I often use Node 12 and this test has been failing on my machine, because of snapshot mismatch. As this test doesn't have to use this helper I'd like to remove it to make tests less flaky for me.

Node 10:
```
$ nvm use 10
Now using node v10.16.3 (npm v6.9.0)
$ node
> 1.333 ** 4
3.1573345183209995
> Math.pow(1.333, 4)
3.157334518321
```

Node 12:
```
$ nvm use 12
Now using node v12.7.0 (npm v6.10.0)
$ node
> 1.333 ** 4
3.1573345183209995
> Math.pow(1.333, 4)
3.1573345183209995
```