### PR TITLE
Upgrade node action input name to node-version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js 10.x
         uses: actions/setup-node@master
         with:
-          version: 10.x
+          node-version: 10.x
 
       - name: Install Yarn
         run: npm install --global yarn


### PR DESCRIPTION
`version` has been deprecated