### PR TITLE
Add createTheme helper to emotion-theming

### DIFF
--- a/packages/emotion-theming/src/index.js
+++ b/packages/emotion-theming/src/index.js
@@ -1,4 +1,11 @@
 // @flow
-export { default as ThemeProvider } from './theme-provider'
+
+import { ThemeContext } from '@emotion/core'
+import createTheme from './create-theme'
+
+const { ThemeProvider, useTheme } = /* #__PURE__ */ createTheme(
+  undefined,
+  ThemeContext
+)
+export { ThemeProvider, useTheme }
 export { default as withTheme } from './with-theme'
-export { default as useTheme } from './use-theme'

--- a/packages/emotion-theming/src/use-theme.js
+++ b/packages/emotion-theming/src/use-theme.js
@@ -1,7 +1,0 @@
-// @flow
-import React from 'react'
-import { ThemeContext } from '@emotion/core'
-
-export default function useTheme() {
-  return React.useContext(ThemeContext)
-}


### PR DESCRIPTION
Something we could incorporate into v11 - so it's easier for people to use their own themes which don't conflict with default, libraries built on top of emotion etc