### PR TITLE
Change latest @emotion/is-prop-valid changeset to be patch

### DIFF
--- a/.changeset/shiny-bottles-itch.md
+++ b/.changeset/shiny-bottles-itch.md
@@ -1,5 +1,5 @@
 ---
-'@emotion/is-prop-valid': minor
+'@emotion/is-prop-valid': patch
 ---
 
 Added Flow types to the package.


### PR DESCRIPTION
IMHO we don't have to bump a minor here - especially that this is 0.x and such minors are treated by npm's semver sort of like a major bump