### PR TITLE
[typescript] Add `T` param to Matchers interface

### DIFF
--- a/.changeset/mean-deers-confess.md
+++ b/.changeset/mean-deers-confess.md
@@ -2,4 +2,4 @@
 'jest-emotion': major
 ---
 
-Added the `T` parameter to the `Matchers` interface in the typescript definitions for jest-emotion
+Added the `T` parameter to the `Matchers` interface in the TypeScript definitions to make this module compatible with `@types/jest@^24.0.20`.

--- a/.changeset/mean-deers-confess.md
+++ b/.changeset/mean-deers-confess.md
@@ -1,0 +1,5 @@
+---
+'jest-emotion': major
+---
+
+Added the `T` parameter to the `Matchers` interface in the typescript definitions for jest-emotion

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "@mdx-js/react": "^1.0.27",
     "@preconstruct/cli": "^1.1.1",
     "@testing-library/react": "^9.3.2",
-    "@types/jest": "^23.0.2",
+    "@types/jest": "^24.0.22",
     "@types/node": "^10.11.4",
     "@types/react": "^16.9.11",
     "babel-check-duplicated-nodes": "^1.0.0",

--- a/packages/jest-emotion/package.json
+++ b/packages/jest-emotion/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@types/jest": "^23.0.2",
+    "@types/jest": "^24.0.22",
     "chalk": "^2.4.1",
     "css": "^2.2.1",
     "specificity": "^0.4.1"

--- a/packages/jest-emotion/types/index.d.ts
+++ b/packages/jest-emotion/types/index.d.ts
@@ -1,5 +1,5 @@
 // Definitions by: Junyoung Clare Jang <https://github.com/Ailrun>
-// TypeScript Version: 2.4
+// TypeScript Version: 2.9
 
 /// <reference types="jest" />
 export interface EmotionMatchers extends jest.ExpectExtendMap {
@@ -30,7 +30,7 @@ export default serializer
 
 declare global {
   namespace jest {
-    interface Matchers<R> {
+    interface Matchers<R, T> {
       toHaveStyleRule(
         property: string,
         value: any,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2688,10 +2688,17 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^23.0.2":
-  version "23.3.14"
-  resolved "https://registry.npmjs.org/@types/jest/-/jest-23.3.14.tgz#37daaf78069e7948520474c87b80092ea912520a"
-  integrity sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug==
+"@types/jest-diff@*":
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
+  integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
+
+"@types/jest@^24.0.22":
+  version "24.0.22"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.22.tgz#08a50be08e78aba850a1185626e71d31e2336145"
+  integrity sha512-t2OvhNZnrNjlzi2i0/cxbLVM59WN15I2r1Qtb7wDv28PnV9IzrPtagFRey/S9ezdLD0zyh1XGMQIEQND2YEfrw==
+  dependencies:
+    "@types/jest-diff" "*"
 
 "@types/minimatch@*":
   version "3.0.3"
@@ -9554,7 +9561,7 @@ expand-template@^2.0.3:
   resolved "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
   integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
 
-expand-tilde@^2.0.0:
+expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
   integrity sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=
@@ -11297,6 +11304,12 @@ global-prefix@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
   integrity sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=
+  dependencies:
+    expand-tilde "^2.0.2"
+    homedir-polyfill "^1.0.1"
+    ini "^1.3.4"
+    is-windows "^1.0.1"
+    which "^1.2.14"
 
 global@^4.3.0:
   version "4.4.0"
@@ -24986,7 +24999,7 @@ which-pm-runs@^1.0.0:
   resolved "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
   integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
-which@1, which@^1.2.10, which@^1.2.12, which@^1.2.9, which@^1.3.0, which@^1.3.1:
+which@1, which@^1.2.10, which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==


### PR DESCRIPTION
This fixes typescript type definitions when using jest-emotion with jest 24.

I simply added a parameter to the Matchers interface in the typescript types file for jest-emotion.

In Jest 24 they added a second generic parameter to the `Matchers` interface. Typescript requires interfaces to have the same parameters, so jest-emotion needs to add it also.

See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/39982

<!-- Have you done all of these things?  -->
**Checklist**:
- [N/A] Documentation
- [N/A] Tests
- [x] Code complete
- [x] Changeset