### PR TITLE
Add preinstall script checking if yarn is being used for installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build:site": "cd site && yarn build:site",
     "flow": "flow",
     "flow:check": "flow check --flowconfig-name=.flowconfig-ci",
+    "preinstall": "node ./scripts/ensure-yarn.js",
     "postinstall": "opencollective postinstall && preconstruct dev && manypkg check",
     "changeset": "changeset",
     "version-packages": "changeset version",

--- a/scripts/ensure-yarn.js
+++ b/scripts/ensure-yarn.js
@@ -1,0 +1,3 @@
+if (!/yarn\//.test(process.env.npm_config_user_agent)) {
+  throw new Error('Please use `yarn` for installs.')
+}


### PR DESCRIPTION
Just a trick I've used elsewhere recently - seems like can be helpful here as well (for other contributors).