### PR TITLE
chore(ci): GH Actions to yarn frozen-lockfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm install --global yarn
 
       - name: Install Dependencies
-        run: yarn
+        run: yarn --frozen-lockfile
 
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@master


### PR DESCRIPTION
What:
GitHub actions yarn install should be running the `frozen-lockfile` flag.

Why:
Because the lockfile _might_ not be listened too.

