### PR TITLE
Fixed missing type from the interpolation intersection type

### DIFF
--- a/.changeset/tricky-cameras-notice.md
+++ b/.changeset/tricky-cameras-notice.md
@@ -1,0 +1,5 @@
+---
+'@emotion/styled': patch
+---
+
+Fix issue with one of TypeScript overloads for `styled`. It pass `StyleProps` to `Interpolation` correctly now.

--- a/packages/core/types/tests.tsx
+++ b/packages/core/types/tests.tsx
@@ -112,7 +112,7 @@ interface TestTheme1 {
         </span>
         <span
           className={css`
-            color: theme.secondaryColor;
+            color: ${theme.secondaryColor};
           `}
         >
           Snd Text

--- a/packages/styled/types/base.d.ts
+++ b/packages/styled/types/base.d.ts
@@ -73,7 +73,9 @@ export interface CreateStyledComponent<
   <AdditionalProps extends {} = {}>(
     template: TemplateStringsArray,
     ...styles: Array<
-      Interpolation<ComponentProps & SpecificComponentProps & AdditionalProps>
+      Interpolation<
+        ComponentProps & SpecificComponentProps & AdditionalProps & StyleProps
+      >
     >
   ): StyledComponent<ComponentProps & AdditionalProps, SpecificComponentProps>
 }

--- a/packages/styled/types/tests.tsx
+++ b/packages/styled/types/tests.tsx
@@ -13,7 +13,7 @@ styled.svg
 {
   styled.div<{ bar: string }>`
     color: ${props => {
-      // $ExpectType { theme?: any; } & ClassAttributes<HTMLDivElement> & HTMLAttributes<HTMLDivElement> & { bar: string; }
+      // $ExpectType { theme?: any; } & ClassAttributes<HTMLDivElement> & HTMLAttributes<HTMLDivElement> & { bar: string; } & { theme: any; }
       props
 
       return {}
@@ -26,6 +26,10 @@ const StyledDiv = styled.div({})
 
 // can specify theme for StyledTags
 const themedStyled = styled as CreateStyled<{ themeProp: string }>
+const StyledDiv3 = themedStyled.div`
+  color: ${props => props.theme.themeProp}
+`
+;<StyledDiv3 />
 const StyledDiv2 = themedStyled.div(props => {
   // $ExpectType { themeProp: string; }
   props.theme


### PR DESCRIPTION
**What**: when consuming theme in the string interpolation overloads the theme property was optional instead of required.

- [x] Tests
- [x] Code complete

This is just a bug fix in v11 so no changelog needed