### PR TITLE
Update to jest-emotion installation instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm install --global yarn
 
       - name: Install Dependencies
-        run: yarn
+        run: yarn --frozen-lockfile
 
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@master

--- a/packages/jest-emotion/README.md
+++ b/packages/jest-emotion/README.md
@@ -16,7 +16,7 @@ The easiest way to test React components with emotion is with the snapshot seria
 // jest.config.js
 module.exports = {
   // ... other config
-  snapshotSerializers: ['jest-emotion']
+  snapshotSerializers: ['jest-emotion', /* ... other snapshotSerializers */ ]
 }
 ```
 

--- a/packages/jest-emotion/README.md
+++ b/packages/jest-emotion/README.md
@@ -16,7 +16,7 @@ The easiest way to test React components with emotion is with the snapshot seria
 // jest.config.js
 module.exports = {
   // ... other config
-  snapshotSerializers: ['jest-emotion', /* ... other snapshotSerializers */ ]
+  snapshotSerializers: ['jest-emotion', /* if needed other snapshotSerializers should go here */ ]
 }
 ```
 


### PR DESCRIPTION
The way the instructions are, it's not clear that other snapshot serializers should be included, such as enzyme's.

**What**:
Change the jest-emotion installation instructions to make it obvious that other snapshot serializers, such as enzyme's, should be included.

**Why**:
When following the instructions, it's too easy to change:
```
snapshotSerializers: ['enzyme-to-json/serializer'],
```
to be:
```
snapshotSerializers: ['jest-emotion'],
```
instead of:
```
snapshotSerializers: ['jest-emotion', 'enzyme-to-json/serializer'],
```

**How**:
The installation instructions have been modified to include a comment instructing users where the original snapshot serializers should go.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
