### PR TITLE
Accept custom context in ThemeProvider

### DIFF
--- a/packages/core/__tests__/__snapshots__/theme-provider.js.snap
+++ b/packages/core/__tests__/__snapshots__/theme-provider.js.snap
@@ -4,11 +4,23 @@ exports[`ThemeProvider throws the correct errors array 1`] = `"[ThemeProvider] P
 
 exports[`ThemeProvider throws the correct errors boolean 1`] = `"[ThemeProvider] Please make your theme prop a plain object"`;
 
-exports[`ThemeProvider throws the correct errors func to undefined 1`] = `"[ThemeProvider] Please return an object from your theme function, i.e. theme={() => ({})}!"`;
+exports[`ThemeProvider throws the correct errors func to undefined 1`] = `"[ThemeProvider] Please return an object from your theme function, e.g. theme={() => ({})}!"`;
 
 exports[`ThemeProvider throws the correct errors null 1`] = `"[ThemeProvider] Please make your theme prop a plain object"`;
 
 exports[`ThemeProvider throws the correct errors undefined 1`] = `"[ThemeProvider] Please make your theme prop a plain object"`;
+
+exports[`basic 1`] = `
+.emotion-0 {
+  color: hotpink;
+  padding: 4px;
+  background-color: darkgreen;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
 
 exports[`nested provider 1`] = `
 .emotion-0 {
@@ -26,6 +38,18 @@ exports[`nested provider with function 1`] = `
 .emotion-0 {
   color: hotpink;
   padding: 8px;
+  background-color: darkgreen;
+}
+
+<div
+  className="emotion-0"
+/>
+`;
+
+exports[`with custom context 1`] = `
+.emotion-0 {
+  color: hotpink;
+  padding: 4px;
   background-color: darkgreen;
 }
 

--- a/packages/core/__tests__/theme-provider.js
+++ b/packages/core/__tests__/theme-provider.js
@@ -1,10 +1,30 @@
 // @flow
 /** @jsx jsx */
 import 'test-utils/next-env'
+import * as React from 'react'
 import { ignoreConsoleErrors } from 'test-utils'
 import { jsx, ThemeProvider } from '@emotion/core'
 import renderer from 'react-test-renderer'
 import cases from 'jest-in-case'
+
+test('basic', () => {
+  const tree = renderer
+    .create(
+      <ThemeProvider
+        theme={{ color: 'hotpink', backgroundColor: 'darkgreen', padding: 4 }}
+      >
+        <div
+          css={({ color, padding, backgroundColor }) => ({
+            color,
+            padding,
+            backgroundColor
+          })}
+        />
+      </ThemeProvider>
+    )
+    .toJSON()
+  expect(tree).toMatchSnapshot()
+})
 
 test('nested provider', () => {
   const tree = renderer
@@ -44,6 +64,33 @@ test('nested provider with function', () => {
             })}
           />
         </ThemeProvider>
+      </ThemeProvider>
+    )
+    .toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('with custom context', () => {
+  const CustomTheme = React.createContext({
+    color: 'hotpink',
+    backgroundColor: 'darkgreen',
+    padding: 4
+  })
+  const tree = renderer
+    .create(
+      <ThemeProvider context={CustomTheme}>
+        <div
+          css={() => {
+            const { color, padding, backgroundColor } = React.useContext(
+              CustomTheme
+            )
+            return {
+              color,
+              padding,
+              backgroundColor
+            }
+          }}
+        />
       </ThemeProvider>
     )
     .toJSON()

--- a/packages/core/src/theming.js
+++ b/packages/core/src/theming.js
@@ -7,28 +7,18 @@ export const ThemeContext = React.createContext<Object>({})
 
 export const useTheme = () => React.useContext(ThemeContext)
 
+const validateTheme = theme =>
+  theme != null && typeof theme === 'object' && !Array.isArray(theme)
+
 const getTheme = (outerTheme: Object, theme: Object | (Object => Object)) => {
   if (typeof theme === 'function') {
     const mergedTheme = theme(outerTheme)
-    if (
-      process.env.NODE_ENV !== 'production' &&
-      (mergedTheme == null ||
-        typeof mergedTheme !== 'object' ||
-        Array.isArray(mergedTheme))
-    ) {
+    if (process.env.NODE_ENV !== 'production' && !validateTheme(mergedTheme)) {
       throw new Error(
-        '[ThemeProvider] Please return an object from your theme function, i.e. theme={() => ({})}!'
+        '[ThemeProvider] Please return an object from your theme function, e.g. theme={() => ({})}!'
       )
     }
     return mergedTheme
-  }
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    (theme == null || typeof theme !== 'object' || Array.isArray(theme))
-  ) {
-    throw new Error(
-      '[ThemeProvider] Please make your theme prop a plain object'
-    )
   }
 
   return { ...outerTheme, ...theme }
@@ -46,16 +36,27 @@ type ThemeProviderProps = {
 }
 
 export const ThemeProvider = (props: ThemeProviderProps) => {
-  let theme = React.useContext(ThemeContext)
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    'theme' in props &&
+    typeof props.theme !== 'function' &&
+    !validateTheme(props.theme)
+  ) {
+    throw new Error(
+      '[ThemeProvider] Please make your theme prop a plain object'
+    )
+  }
 
-  if (props.theme !== theme) {
+  let theme = React.useContext(props.context || ThemeContext)
+
+  if (props.theme && props.theme !== theme) {
     theme = createCacheWithTheme(theme)(props.theme)
   }
-  return (
-    <ThemeContext.Provider value={theme}>
-      {props.children}
-    </ThemeContext.Provider>
-  )
+
+  const Provider = props.context
+    ? props.context.Provider
+    : ThemeContext.Provider
+  return <Provider value={theme}>{props.children}</Provider>
 }
 
 export function withTheme<Config: {}>(


### PR DESCRIPTION
It's a followup to https://github.com/emotion-js/emotion/pull/1577 - it probably indeed didn't make much sense, but I believe there is some benefit in accepting a custom context prop in `ThemeProvider`

If we are going to decide to merge this in then I'd like to wait for https://github.com/emotion-js/emotion/pull/1609 to land first, so I can add final TS types in here - based on the work from that other PR.
