### PR TITLE
Fix to what location generated source maps are pointing in case of composed styles

### DIFF
--- a/.changeset/lazy-elephants-stare.md
+++ b/.changeset/lazy-elephants-stare.md
@@ -1,0 +1,6 @@
+---
+'@emotion/core': patch
+'@emotion/serialize': patch
+---
+
+Fix to what location generated source maps are pointing in case of composed styles.

--- a/packages/serialize/src/index.js
+++ b/packages/serialize/src/index.js
@@ -332,7 +332,7 @@ let labelPattern = /label:\s*([^\s;\n{]+)\s*;/g
 
 let sourceMapPattern
 if (process.env.NODE_ENV !== 'production') {
-  sourceMapPattern = /\/\*#\ssourceMappingURL=data:application\/json;\S+\s+\*\//
+  sourceMapPattern = /\/\*#\ssourceMappingURL=data:application\/json;\S+\s+\*\//g
 }
 
 // this is the cursor for keyframes


### PR DESCRIPTION
Currently we get first encountered source maps, but actually more interesting is the last one. Taking first can lead to some unexpected results - like in this example `background-color: red` styles would point to `background-color: green;` and it could be even defined in a completely different file.

```js
const StyledText = styled.div`
  @media (min-width: 1040px) {
    ${css`
      background-color: green;
    `}
  }

  background-color: red;
`;
```

I have no idea right now what kind of a test we should write for this and I'm not sure if it's worth it, so I've skipped it for now.

This actually would also, by accident - sort of, help to workaround the stylis bug: https://github.com/thysultan/stylis.js/issues/154