### PR TITLE
Created additional overload to prevent AdditionalProps getting inferr…

### DIFF
--- a/.changeset/lucky-swans-kneel.md
+++ b/.changeset/lucky-swans-kneel.md
@@ -1,0 +1,5 @@
+---
+'@emotion/styled': patch
+---
+
+Fixed issue when composing components using interpolations the wrong type would be inferred

--- a/.changeset/lucky-swans-kneel.md
+++ b/.changeset/lucky-swans-kneel.md
@@ -2,4 +2,4 @@
 '@emotion/styled': patch
 ---
 
-Fixed issue when composing components using interpolations the wrong type would be inferred
+Fixed issue when using "component as selector" in styled interpolations which caused the wrong type to be inferred.

--- a/packages/styled/types/base.d.ts
+++ b/packages/styled/types/base.d.ts
@@ -77,10 +77,18 @@ export interface CreateStyledComponent<
       >
     >
   ): StyledComponent<ComponentProps & AdditionalProps, SpecificComponentProps>
+
+  (
+    template: TemplateStringsArray,
+    ...styles: Array<
+      Interpolation<ComponentProps & SpecificComponentProps & StyleProps>
+    >
+  ): StyledComponent<ComponentProps, SpecificComponentProps>
+
   /**
    * @typeparam AdditionalProps  Additional props to add to your styled component
    */
-  <AdditionalProps extends {} = {}>(
+  <AdditionalProps extends {}>(
     template: TemplateStringsArray,
     ...styles: Array<
       Interpolation<

--- a/packages/styled/types/tests.tsx
+++ b/packages/styled/types/tests.tsx
@@ -86,3 +86,40 @@ const StyledOriginal = styled(Original, {
 
 // No more type conflict error
 ;<StyledOriginal prop1="1" prop2={2} />
+
+const Label = styled.label``
+const Button = styled.button``
+const Input = styled.input`
+  & + ${Label}: {
+    margin-left: 3px;
+  }
+`
+const Input2 = styled.input`
+  & + ${Label}: {
+    margin-left: 3px;
+  }
+  & + ${Button}: {
+    margin-left: 3px;
+  }
+`
+
+const Input3 = styled.input({
+  [`& + ${Label}`]: {
+    marginLeft: '3px'
+  }
+})
+;<Input
+  onChange={(evt: React.ChangeEvent<HTMLInputElement>) =>
+    console.log(evt.target.value)
+  }
+/>
+;<Input2
+  onChange={(evt: React.ChangeEvent<HTMLInputElement>) =>
+    console.log(evt.target.value)
+  }
+/>
+;<Input3
+  onChange={(evt: React.ChangeEvent<HTMLInputElement>) =>
+    console.log(evt.target.value)
+  }
+/>

--- a/packages/styled/types/tests.tsx
+++ b/packages/styled/types/tests.tsx
@@ -94,6 +94,7 @@ const Input = styled.input`
     margin-left: 3px;
   }
 `
+
 const Input2 = styled.input`
   & + ${Label}: {
     margin-left: 3px;
@@ -108,6 +109,15 @@ const Input3 = styled.input({
     marginLeft: '3px'
   }
 })
+
+interface AdditionalTest {
+  left: string
+}
+const Input4 = styled.input<AdditionalTest>`
+  & + ${Label}: ${props => ({
+  marginLeft: props.left
+})}
+`
 ;<Input
   onChange={(evt: React.ChangeEvent<HTMLInputElement>) =>
     console.log(evt.target.value)
@@ -119,6 +129,12 @@ const Input3 = styled.input({
   }
 />
 ;<Input3
+  onChange={(evt: React.ChangeEvent<HTMLInputElement>) =>
+    console.log(evt.target.value)
+  }
+/>
+;<Input4
+  left="3px"
   onChange={(evt: React.ChangeEvent<HTMLInputElement>) =>
     console.log(evt.target.value)
   }


### PR DESCRIPTION
**What**:

Previously this issue was prevented with a mapped type on the interpolation union, instead of restoring the old fix I have added an additional overload to the styled interpolation functions which use used when the user doesn't specify a generic type of AdditionalProps. 

<!-- Why are these changes necessary? -->
**Why**:

The composed component type gets used for the AdditionalProps generic argument when it's inferred rather than {}.

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
- [] Documentation N/A
- [x] Tests
- [x] Code complete
- [x] Changeset 

