### PR TITLE
Update enzyme snapshots

### DIFF
--- a/.changeset/great-bears-sing.md
+++ b/.changeset/great-bears-sing.md
@@ -2,4 +2,4 @@
 'jest-emotion': patch
 ---
 
-Fix naming of shallow rendered components
+Fix printing names of nested shallow-rendered components.

--- a/.changeset/great-bears-sing.md
+++ b/.changeset/great-bears-sing.md
@@ -1,0 +1,5 @@
+---
+'jest-emotion': patch
+---
+
+Fix naming of shallow rendered components

--- a/packages/jest-emotion/src/index.js
+++ b/packages/jest-emotion/src/index.js
@@ -103,13 +103,17 @@ export function createSerializer({
           .concat(expectedClassNames)
           .filter(Boolean)
           .join(' ')
+        let emotionType = val.props.__EMOTION_TYPE_PLEASE_DO_NOT_USE__
+        // emotionType will be a string for DOM elements
+        let type =
+          typeof emotionType === 'string' ? emotionType : emotionType.name
         return printer({
           ...val,
           props: filterEmotionProps({
             ...val.props,
             className
           }),
-          type: val.props.__EMOTION_TYPE_PLEASE_DO_NOT_USE__
+          type
         })
       } else {
         return val.children.map(printer).join('\n')

--- a/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
+++ b/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
@@ -18,6 +18,28 @@ exports[`enzyme mount basic 1`] = `
 </Greeting>
 `;
 
+exports[`enzyme mount nested 1`] = `
+.emotion-0 {
+  background-color: red;
+}
+
+.emotion-0 {
+  background-color: red;
+}
+
+<div>
+  <Greeting
+    className="emotion-0"
+  >
+    <div
+      className="emotion-0"
+    >
+      Hello
+    </div>
+  </Greeting>
+</div>
+`;
+
 exports[`enzyme mount with prop containing css element 1`] = `
 .emotion-0 {
   background-color: blue;
@@ -158,6 +180,29 @@ exports[`enzyme shallow basic 1`] = `
   css="unknown styles"
 >
   hello
+</div>
+`;
+
+exports[`enzyme shallow nested 1`] = `
+<div>
+  <function Greeting(_ref3) {
+        var children = _ref3.children,
+            className = _ref3.className;
+        return (0, _core.jsx)("div", {
+          className: className
+        }, children);
+      }
+    className=""
+    css="unknown styles"
+  >
+    Hello
+  </function Greeting(_ref3) {
+        var children = _ref3.children,
+            className = _ref3.className;
+        return (0, _core.jsx)("div", {
+          className: className
+        }, children);
+      }>
 </div>
 `;
 

--- a/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
+++ b/packages/jest-emotion/test/__snapshots__/react-enzyme.test.js.snap
@@ -185,24 +185,12 @@ exports[`enzyme shallow basic 1`] = `
 
 exports[`enzyme shallow nested 1`] = `
 <div>
-  <function Greeting(_ref3) {
-        var children = _ref3.children,
-            className = _ref3.className;
-        return (0, _core.jsx)("div", {
-          className: className
-        }, children);
-      }
+  <Greeting
     className=""
     css="unknown styles"
   >
     Hello
-  </function Greeting(_ref3) {
-        var children = _ref3.children,
-            className = _ref3.className;
-        return (0, _core.jsx)("div", {
-          className: className
-        }, children);
-      }>
+  </Greeting>
 </div>
 `;
 

--- a/packages/jest-emotion/test/react-enzyme.test.js
+++ b/packages/jest-emotion/test/react-enzyme.test.js
@@ -18,6 +18,18 @@ const cases = {
       return <Greeting>hello</Greeting>
     }
   },
+  nested: {
+    render() {
+      const Greeting = ({ children, className }) => (
+        <div className={className}>{children}</div>
+      )
+      return (
+        <div>
+          <Greeting css={{ backgroundColor: 'red' }}>Hello</Greeting>
+        </div>
+      )
+    }
+  },
   'with prop containing css element': {
     render() {
       const Greeting = ({ children, content }) => (


### PR DESCRIPTION
**What**:
Support for shallow rendering in #1648 introduced an issue where the name of the component could be set to the actual code for that component. This resolves that issue.

**Why**:
The snapshot becomes too large to be useful, as well as brittle.

**How**:
We use the component's `name` property as its name.

**Checklist**:
- [ ] Documentation N/A
- [x] Tests
- [x] Code complete
- [x] Changeset
