### PR TITLE
Add warning if multiple versions are running (addresses #1470)

### DIFF
--- a/.changeset/sour-poets-move.md
+++ b/.changeset/sour-poets-move.md
@@ -1,0 +1,5 @@
+---
+'@emotion/core': patch
+---
+
+Warn if @emotion/core is initialized more than once in the same development environment.

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -6,3 +6,18 @@ export { keyframes } from './keyframes'
 export { ClassNames } from './class-names'
 export { ThemeContext, useTheme, ThemeProvider, withTheme } from './theming'
 export { default as css } from './css'
+
+if (process.env.NODE_ENV !== 'production') {
+  const isBrowser = typeof document !== 'undefined'
+  const globalKey = '__EMOTION_CORE__'
+  const globalContext = isBrowser ? window : global
+  if (globalContext[globalKey]) {
+    console.warn(
+      'You are loading @emotion/core when it is already loaded. Running ' +
+        'multiple instances may cause problems. This can happen if multiple ' +
+        'versions are used, or if multiple builds of the same version are ' +
+        'used.'
+    )
+  }
+  globalContext[globalKey] = true
+}

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -1,7 +1,7 @@
 // @flow
 import type { RegisteredCache, EmotionCache, SerializedStyles } from './types'
 
-let isBrowser = typeof document !== 'undefined'
+const isBrowser = typeof document !== 'undefined'
 
 export function getRegisteredStyles(
   registered: RegisteredCache,


### PR DESCRIPTION
**What**:
Add a register of all the `@emotion` packages, so that a warning can be displayed if the same package is registered with multiple versions.

**Why**:
Running multiple versions of the packages can cause hard to trace issues, see #1470.

**How**:
Each module "registers" itself providing its name and version into a global object. If that module name is already registered for a different version, a warning is displayed.

This is just a draft, for discussion on the approach.

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
