### PR TITLE
Change labelFormat example to show as a string value

### DIFF
--- a/packages/babel-plugin-emotion/README.md
+++ b/packages/babel-plugin-emotion/README.md
@@ -236,7 +236,7 @@ be prepended automatically.
 ```javascript
 // BrownView.js
 // autoLabel: true
-// labelFormat: [filename]--[local]
+// labelFormat: '[filename]--[local]'
 const brownStyles = css({ color: 'brown' })
 ```
 


### PR DESCRIPTION
**What**:
Changes the readme to be more clear about the `labelFormat` example

**Why**:
Folks that copy paste the code will run into a build error

**How**:
Simple change, added single quotes around so people will recognize it as a string value.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A
- [ ] Changeset N/A
