### PR TITLE
fix(core / styled): fix wrap the display name in styled and withEmotionCache

### DIFF
--- a/.changeset/loud-yaks-flow.md
+++ b/.changeset/loud-yaks-flow.md
@@ -1,0 +1,5 @@
+---
+'@emotion/core': patch
+---
+
+fix show correct styled component's name in HOC withEmotionCache for React DevTools

--- a/.changeset/six-doors-nail.md
+++ b/.changeset/six-doors-nail.md
@@ -1,0 +1,5 @@
+---
+'@emotion/styled-base': patch
+---
+
+inject styled component's name before HOC withEmotionCache

--- a/packages/core/src/context.js
+++ b/packages/core/src/context.js
@@ -18,10 +18,16 @@ export let ThemeContext = React.createContext<Object>({})
 export let CacheProvider = EmotionCacheContext.Provider
 
 /**
- * https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging 
+ * https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging
  */
-function getDisplayName(WrappedComponent) {
-  return WrappedComponent.displayName || WrappedComponent.name || 'EmotionCacheRender';
+function getDisplayName<Props>(
+  WrappedComponent: React.ComponentType<Props>
+): string {
+  return (
+    WrappedComponent.displayName ||
+    WrappedComponent.name ||
+    'EmotionCacheRender'
+  )
 }
 
 let withEmotionCache = function withEmotionCache<Props>(
@@ -40,7 +46,7 @@ let withEmotionCache = function withEmotionCache<Props>(
     )
   }
 
-  render.displayName = getDisplayName(func)
+  render.displayName = getDisplayName<Props>(func)
 
   // $FlowFixMe
   return React.forwardRef(render)

--- a/packages/core/src/context.js
+++ b/packages/core/src/context.js
@@ -17,6 +17,13 @@ let EmotionCacheContext: React.Context<EmotionCache | null> = React.createContex
 export let ThemeContext = React.createContext<Object>({})
 export let CacheProvider = EmotionCacheContext.Provider
 
+/**
+ * https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging 
+ */
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'EmotionCacheRender';
+}
+
 let withEmotionCache = function withEmotionCache<Props>(
   func: (props: Props, cache: EmotionCache, ref: React.Ref<*>) => React.Node
 ): React.StatelessFunctionalComponent<Props> {
@@ -32,6 +39,9 @@ let withEmotionCache = function withEmotionCache<Props>(
       </EmotionCacheContext.Consumer>
     )
   }
+
+  render.displayName = getDisplayName(func)
+
   // $FlowFixMe
   return React.forwardRef(render)
 }

--- a/packages/styled-base/src/index.js
+++ b/packages/styled-base/src/index.js
@@ -43,6 +43,20 @@ let createStyled: CreateStyled = (tag: any, options?: StyledOptions) => {
   const isReal = tag.__emotion_real === tag
   const baseTag = (isReal && tag.__emotion_base) || tag
 
+  const displayName =
+    identifierName !== undefined
+      ? identifierName
+      : `Styled(${
+          typeof baseTag === 'string'
+            ? baseTag
+            : baseTag.displayName || baseTag.name || 'Component'
+        })`
+
+  const injectDisplayName = (Component) => {
+    Component.displayName = Component.displayName || displayName
+    return Component
+  }
+
   if (typeof shouldForwardProp !== 'function' && isReal) {
     shouldForwardProp = tag.__emotion_forwardProp
   }
@@ -78,8 +92,8 @@ let createStyled: CreateStyled = (tag: any, options?: StyledOptions) => {
     }
 
     // $FlowFixMe: we need to cast StatelessFunctionalComponent to our PrivateStyledComponent class
-    const Styled: PrivateStyledComponent<P> = withEmotionCache(
-      (props, context, ref) => {
+    const Styled: PrivateStyledComponent<P> = withEmotionCache<P>(
+      injectDisplayName((props, context, ref) => {
         return (
           <ThemeContext.Consumer>
             {theme => {
@@ -176,18 +190,10 @@ let createStyled: CreateStyled = (tag: any, options?: StyledOptions) => {
             }}
           </ThemeContext.Consumer>
         )
-      }
+      })
     )
 
-    Styled.displayName =
-      identifierName !== undefined
-        ? identifierName
-        : `Styled(${
-            typeof baseTag === 'string'
-              ? baseTag
-              : baseTag.displayName || baseTag.name || 'Component'
-          })`
-
+    Styled.displayName = displayName
     Styled.defaultProps = tag.defaultProps
     Styled.__emotion_real = Styled
     Styled.__emotion_base = baseTag

--- a/packages/styled-base/src/index.js
+++ b/packages/styled-base/src/index.js
@@ -52,7 +52,7 @@ let createStyled: CreateStyled = (tag: any, options?: StyledOptions) => {
             : baseTag.displayName || baseTag.name || 'Component'
         })`
 
-  const injectDisplayName = (Component) => {
+  const injectDisplayName = Component => {
     Component.displayName = Component.displayName || displayName
     return Component
   }


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: display correct styled component's name in React DevTools

<!-- Why are these changes necessary? -->
**Why**: 

`@emotion/styled` use `withEmotionCache` function which is a HOC but not wrap a [displayName](https://reactjs.org/docs/higher-order-components.html\#convention-wrap-the-display-name-for-easy-debugging).

So in [React DevTools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en), it will be always show only `render` string as component name.

Before wrap displayName:

![image](https://user-images.githubusercontent.com/15135943/70859806-06cc7d00-1f54-11ea-81b9-168357be8ef4.png)

<!-- How were these changes implemented? -->
**How**:

Follow React [displayName docs](https://reactjs.org/docs/higher-order-components.html\#convention-wrap-the-display-name-for-easy-debugging), inject `displayName` before and into `withEmotionCache`.

After wrap displayName:

![image](https://user-images.githubusercontent.com/15135943/70859820-48f5be80-1f54-11ea-8f46-bb75f19e13f5.png)

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
