### PR TITLE
Fix issue with rehydrated style tags not taking into account prepend option

### DIFF
--- a/.changeset/odd-geese-matter.md
+++ b/.changeset/odd-geese-matter.md
@@ -1,0 +1,5 @@
+---
+'@emotion/sheet': minor
+---
+
+Added `rehydrate` method which can be used for SSRed styles. They become a part of a sheet and can be flushed.

--- a/.changeset/wicked-dolphins-cough.md
+++ b/.changeset/wicked-dolphins-cough.md
@@ -1,0 +1,5 @@
+---
+'@emotion/cache': patch
+---
+
+Use sheet's `rehydrate` method for SSRed styles which inserts rehydrated styles at correct position when used in combination with `prepend` option.

--- a/packages/cache/src/index.js
+++ b/packages/cache/src/index.js
@@ -66,6 +66,7 @@ let createCache = (options?: Options): EmotionCache => {
   let inserted = {}
   // $FlowFixMe
   let container: HTMLElement
+  const nodesToRehydrate = []
   if (isBrowser) {
     container = options.container || document.head
 
@@ -78,7 +79,7 @@ let createCache = (options?: Options): EmotionCache => {
         inserted[id] = true
       })
       if (node.parentNode !== container) {
-        container.appendChild(node)
+        nodesToRehydrate.push(node)
       }
     })
   }
@@ -249,6 +250,9 @@ let createCache = (options?: Options): EmotionCache => {
     registered: {},
     insert
   }
+
+  cache.sheet.rehydrate(nodesToRehydrate)
+
   return cache
 }
 

--- a/packages/sheet/README.md
+++ b/packages/sheet/README.md
@@ -61,6 +61,10 @@ This method inserts a single rule into the document. It **must** be a single rul
 
 This method will remove all style tags that were inserted into the document.
 
+#### rehydrate
+
+This method moves given style elements into sheet's container and put them into internal tags collection. It's can be used for SSRed styles.
+
 ### Example with all options
 
 ```jsx

--- a/packages/sheet/__tests__/__snapshots__/index.js.snap
+++ b/packages/sheet/__tests__/__snapshots__/index.js.snap
@@ -23,6 +23,84 @@ exports[`StyleSheet should accept prepend option 1`] = `
 </html>
 `;
 
+exports[`StyleSheet should be able to rehydrate styles 1`] = `
+<html>
+  <head />
+  <body>
+    <style>
+      .foo { color: hotpink; }
+    </style>
+    <style>
+      .bar { background-color: green; }
+    </style>
+  </body>
+</html>
+`;
+
+exports[`StyleSheet should be able to rehydrate styles 2`] = `
+<html>
+  <head>
+    <style>
+      .foo { color: hotpink; }
+    </style>
+    <style>
+      .bar { background-color: green; }
+    </style>
+  </head>
+  <body />
+</html>
+`;
+
+exports[`StyleSheet should correctly position rehydrated styles when used with \`prepend\` option 1`] = `
+<html>
+  <head>
+    <style>
+      .foo { color: hotpink; }
+    </style>
+    <style>
+      .bar { background-color: green; }
+    </style>
+    <style
+      id="other"
+    />
+  </head>
+  <body />
+</html>
+`;
+
+exports[`StyleSheet should flush rehydrated styles 1`] = `
+<html>
+  <head>
+    <style>
+      .foo { color: hotpink; }
+    </style>
+    <style>
+      .bar { background-color: green; }
+    </style>
+    <style
+      data-emotion=""
+    >
+      
+      html { color: hotpink; }
+    </style>
+    <style
+      data-emotion=""
+    >
+      
+      * { box-sizing: border-box; }
+    </style>
+  </head>
+  <body />
+</html>
+`;
+
+exports[`StyleSheet should flush rehydrated styles 2`] = `
+<html>
+  <head />
+  <body />
+</html>
+`;
+
 exports[`StyleSheet should insert a rule into the DOM when not in speedy 1`] = `
 <html>
   <head>

--- a/packages/sheet/__tests__/index.js
+++ b/packages/sheet/__tests__/index.js
@@ -126,4 +126,69 @@ describe('StyleSheet', () => {
     sheet.flush()
     head.removeChild(otherStyle)
   })
+
+  it('should be able to rehydrate styles', () => {
+    const fooStyle = document.createElement('style')
+    fooStyle.textContent = '.foo { color: hotpink; }'
+    const barStyle = document.createElement('style')
+    barStyle.textContent = '.bar { background-color: green; }'
+    const body = safeQuerySelector('body')
+    body.appendChild(fooStyle)
+    body.appendChild(barStyle)
+
+    const sheet = new StyleSheet(defaultOptions)
+    expect(document.documentElement).toMatchSnapshot()
+
+    sheet.rehydrate([fooStyle, barStyle])
+    expect(document.documentElement).toMatchSnapshot()
+
+    sheet.flush()
+  })
+
+  it('should flush rehydrated styles', () => {
+    const fooStyle = document.createElement('style')
+    fooStyle.textContent = '.foo { color: hotpink; }'
+    const barStyle = document.createElement('style')
+    barStyle.textContent = '.bar { background-color: green; }'
+    const body = safeQuerySelector('body')
+    body.appendChild(fooStyle)
+    body.appendChild(barStyle)
+
+    const sheet = new StyleSheet(defaultOptions)
+
+    sheet.rehydrate([fooStyle, barStyle])
+
+    sheet.insert(rule)
+    sheet.insert(rule2)
+    expect(document.documentElement).toMatchSnapshot()
+
+    sheet.flush()
+    expect(document.documentElement).toMatchSnapshot()
+  })
+
+  it('should correctly position rehydrated styles when used with `prepend` option', () => {
+    const head = safeQuerySelector('head')
+    const otherStyle = document.createElement('style')
+    otherStyle.setAttribute('id', 'other')
+    head.appendChild(otherStyle)
+
+    const fooStyle = document.createElement('style')
+    fooStyle.textContent = '.foo { color: hotpink; }'
+    const barStyle = document.createElement('style')
+    barStyle.textContent = '.bar { background-color: green; }'
+    const body = safeQuerySelector('body')
+    body.appendChild(fooStyle)
+    body.appendChild(barStyle)
+
+    const sheet = new StyleSheet({
+      ...defaultOptions,
+      prepend: true
+    })
+
+    sheet.rehydrate([fooStyle, barStyle])
+    expect(document.documentElement).toMatchSnapshot()
+
+    sheet.flush()
+    head.removeChild(otherStyle)
+  })
 })

--- a/packages/sheet/types/index.d.ts
+++ b/packages/sheet/types/index.d.ts
@@ -21,4 +21,5 @@ export class StyleSheet {
   constructor(options?: Options)
   insert(rule: string): void
   flush(): void
+  rehydrate(nodes: Array<HTMLStyleElement>): void
 }


### PR DESCRIPTION
This fixes an issue with rehydrated tags always being appended - regardless of `prepend` option.

It also makes sheet own "its" rehydrated styles - which seems like a good change, because without that `flush` didn't affect those.