### PR TITLE
Should forward props options

### DIFF
--- a/.changeset/angry-dancers-develop.md
+++ b/.changeset/angry-dancers-develop.md
@@ -1,0 +1,7 @@
+---
+'@emotion/primitives-core': minor
+'@emotion/primitives': minor
+'@emotion/styled': minor
+---
+
+Add options object for shouldForwardProp to specify props to include or exclude rather than always providing a custom function

--- a/docs/typescript.mdx
+++ b/docs/typescript.mdx
@@ -178,7 +178,33 @@ const App = () => (
 
 Sometimes you want to wrap an existing component and override the type of a prop. Emotion allows you to specify a `shouldForwardProp` hook to filter properties which should be passed to the wrapped component.
 
-If you make should `shouldForwardProp` a [type guard](https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards) then only the props from the type guard will be exposed.
+NOTE: If possible, Emotion will only expose forwarded props as props on the styled component. If you want specify filtered component props add them as additional styled props.
+
+#### Filter Options
+
+You can pass an options object to shouldForwardProp instructing emotion which props to include and exclude.
+
+``` ts
+// Include specified props
+const StyledOriginal = styled(Original, {
+  shouldForwardProp: { include: ['prop1'] }
+})<StyledOriginalExtraProps>(props => {
+  // props.prop2 will be `number`
+  return {}
+})
+
+// Exclude specified props
+const StyledOriginal = styled(Original, {
+  shouldForwardProp: { exclude: ['prop2'] }
+})<StyledOriginalExtraProps>(props => {
+  // props.prop2 will be `number`
+  return {}
+})
+```
+
+#### Custom filter
+
+If you make should `shouldForwardProp` a [type guard](https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards) then only the props from the type guard will be exposed. Emotion also supports plain functions, though will provide a bit less type safety for your components.
 
 For example:
 
@@ -201,33 +227,6 @@ const StyledOriginal = styled(Original, {
 ;<StyledOriginal prop1="1" prop2={2} />
 ```
 
-#### Filter props helper
-
-You can use this helper in your project if you want a more concise forward prop syntax
-
-``` ts
-/**
- * Use `createPropFilter` with shouldForwardProp to filter out props. Will automatically filter out `theme`
- * since this prop is passed via emotion's context.
- */
-
-export function createPropFilter<ComponentProps extends {}>() {
-    return function<Omitted extends PropertyKey>(propsToOmit: Omitted[], stripNonHTML?: boolean) {
-        return function(prop: PropertyKey): prop is Exclude<keyof ComponentProps, Omitted> {
-            return stripNonHTML
-                ? isPropValid(prop) && propsToOmit.indexOf(prop as any) === -1
-                : propsToOmit.indexOf(prop as any) === -1
-        }
-    }
-}
-
-```
-
-It's usage is:
-
-``` ts
-createPropFilter<ComponentProps>()('filterThis')
-```
 
 ### Passing props when styling a React component
 

--- a/docs/typescript.mdx
+++ b/docs/typescript.mdx
@@ -172,6 +172,8 @@ const App = () => (
 )
 ```
 
+**NOTE** Specify your props *after* the styled function call to allow emotion to correctly infer the types for you. ie `styled(Component)<Additional>` not `styled<Additional>(Component)`. v11 of emotion fixed a number of issues with type inference, if you are having trouble upgrading, remove any manually specified types.
+
 ### Forwarding props
 
 Sometimes you want to wrap an existing component and override the type of a prop. Emotion allows you to specify a `shouldForwardProp` hook to filter properties which should be passed to the wrapped component.
@@ -197,6 +199,34 @@ const StyledOriginal = styled(Original, {
 
 // No more type conflict error
 ;<StyledOriginal prop1="1" prop2={2} />
+```
+
+#### Filter props helper
+
+You can use this helper in your project if you want a more concise forward prop syntax
+
+``` ts
+/**
+ * Use `createPropFilter` with shouldForwardProp to filter out props. Will automatically filter out `theme`
+ * since this prop is passed via emotion's context.
+ */
+
+export function createPropFilter<ComponentProps extends {}>() {
+    return function<Omitted extends PropertyKey>(propsToOmit: Omitted[], stripNonHTML?: boolean) {
+        return function(prop: PropertyKey): prop is Exclude<keyof ComponentProps, Omitted> {
+            return stripNonHTML
+                ? isPropValid(prop) && propsToOmit.indexOf(prop as any) === -1
+                : propsToOmit.indexOf(prop as any) === -1
+        }
+    }
+}
+
+```
+
+It's usage is:
+
+``` ts
+createPropFilter<ComponentProps>()('filterThis')
 ```
 
 ### Passing props when styling a React component
@@ -285,7 +315,7 @@ const Button = styled('button')`
 export default Button
 ```
 
-If you were previously relying on `theme` being an `any` type, you have to restore compatibility with:
+If you were previously relying on `theme` being an `any` type (pre v11), you have to restore compatibility with:
 
 _emotion.d.ts_
 

--- a/docs/typescript.mdx
+++ b/docs/typescript.mdx
@@ -326,7 +326,7 @@ declare module '@emotion/core' {
 
 ### TypeScript < 2.9
 
-For Typescript <2.9, the generic type version only works with object styles due to https://github.com/Microsoft/TypeScript/issues/11947.
+For TypeScript <2.9, the generic type version only works with object styles due to https://github.com/Microsoft/TypeScript/issues/11947.
 
 You can work around this by specifying the prop types in your style callback:
 

--- a/packages/primitives/src/styled.js
+++ b/packages/primitives/src/styled.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import { StyleSheet, View, Text, Image } from 'react-primitives'
-import { createStyled } from '@emotion/primitives-core'
+import { createStyled, StyledOptions } from '@emotion/primitives-core'
 import {
   testPickPropsOnPrimitiveComponent,
   testPickPropsOnOtherComponent
@@ -24,7 +24,10 @@ function getShouldForwardProp(component: React.ElementType) {
 
 type CreateStyledComponent = (...styles: any) => React.ElementType
 
-type BaseStyled = (tag: React.ElementType) => CreateStyledComponent
+type BaseStyled = (
+  tag: React.ElementType,
+  options?: StyledOptions
+) => CreateStyledComponent
 
 export type Styled = BaseStyled & {
   View: CreateStyledComponent,

--- a/packages/primitives/test/__snapshots__/emotion-primitives.test.js.snap
+++ b/packages/primitives/test/__snapshots__/emotion-primitives.test.js.snap
@@ -1,17 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Emotion primitives custom shouldForwardProp works 1`] = `
-<Text
-  style={
-    Object {
-      "color": "hotpink",
-    }
-  }
->
-  Emotion
-</Text>
-`;
-
 exports[`Emotion primitives primitive should work with \`withComponent\` 1`] = `
 <Text
   style={

--- a/packages/primitives/test/emotion-primitives.test.js
+++ b/packages/primitives/test/emotion-primitives.test.js
@@ -188,18 +188,86 @@ describe('Emotion primitives', () => {
   })
 
   test('custom shouldForwardProp works', () => {
-    const Text = styled.Text``
-    const Title = props => <Text {...props} />
-    // $FlowFixMe
+    let forwardedProps: any
+    const Title = props => {
+      forwardedProps = props
+      return null
+    }
     const StyledTitle = styled(Title, {
       shouldForwardProp: prop => prop !== 'color' && prop !== 'theme'
     })`
       color: ${props => props.color};
     `
 
-    const tree = renderer
-      .create(<StyledTitle color="hotpink">{'Emotion'}</StyledTitle>)
-      .toJSON()
-    expect(tree).toMatchSnapshot()
+    renderer.create(
+      // $FlowFixMe
+      <StyledTitle color="hotpink" disabled>
+        {'Emotion'}
+      </StyledTitle>
+    )
+
+    expect(forwardedProps).toEqual({
+      children: 'Emotion',
+      disabled: true,
+      style: {
+        color: 'hotpink'
+      }
+    })
+  })
+
+  test('shouldForwardProp exclude option works', () => {
+    let forwardedProps: any
+    const Title = props => {
+      forwardedProps = props
+      return null
+    }
+    const StyledTitle = styled(Title, {
+      shouldForwardProp: { exclude: ['color', 'theme'] }
+    })`
+      color: ${props => props.color};
+    `
+
+    renderer.create(
+      // $FlowFixMe
+      <StyledTitle color="hotpink" disabled>
+        {'Emotion'}
+      </StyledTitle>
+    )
+
+    expect(forwardedProps).toEqual({
+      children: 'Emotion',
+      disabled: true,
+      style: {
+        color: 'hotpink'
+      }
+    })
+  })
+
+  test('shouldForwardProp include option works', () => {
+    let forwardedProps: any
+    const Title = props => {
+      forwardedProps = props
+      return null
+    }
+    const StyledTitle = styled(Title, {
+      shouldForwardProp: { include: ['disabled'] }
+    })`
+      color: ${props => props.color};
+    `
+
+    renderer.create(
+      // $FlowFixMe
+      <StyledTitle color="hotpink" disabled>
+        {'Emotion'}
+      </StyledTitle>
+    )
+
+    expect(forwardedProps).toEqual({
+      children: 'Emotion',
+      disabled: true,
+      style: {
+        color: 'hotpink'
+      }
+    })
   })
 })

--- a/packages/primitives/test/emotion-primitives.test.js
+++ b/packages/primitives/test/emotion-primitives.test.js
@@ -270,4 +270,33 @@ describe('Emotion primitives', () => {
       }
     })
   })
+
+  test('shouldForwardProp with no options works', () => {
+    let forwardedProps: any
+    const Title = props => {
+      forwardedProps = props
+      return null
+    }
+    const StyledTitle = styled(Title, {
+      shouldForwardProp: {}
+    })`
+      color: ${props => props.color};
+    `
+
+    renderer.create(
+      // $FlowFixMe
+      <StyledTitle color="hotpink" disabled>
+        {'Emotion'}
+      </StyledTitle>
+    )
+
+    expect(forwardedProps).toEqual({
+      children: 'Emotion',
+      color: 'hotpink',
+      disabled: true,
+      style: {
+        color: 'hotpink'
+      }
+    })
+  })
 })

--- a/packages/styled/src/base.js
+++ b/packages/styled/src/base.js
@@ -4,6 +4,7 @@ import type { ElementType } from 'react'
 import {
   getDefaultShouldForwardProp,
   type StyledOptions,
+  type ShouldForwardPropsOptions,
   type CreateStyled,
   type PrivateStyledComponent
 } from './utils'
@@ -32,13 +33,20 @@ let createStyled: CreateStyled = (tag: any, options?: StyledOptions) => {
   if (options !== undefined) {
     identifierName = options.label
     targetClassName = options.target
+
+    const userShouldForwardProp = options.shouldForwardProp
+      ? typeof options.shouldForwardProp === 'function'
+        ? options.shouldForwardProp
+        : createPropFilter(options.shouldForwardProp)
+      : options.shouldForwardProp
+
     shouldForwardProp =
-      tag.__emotion_forwardProp && options.shouldForwardProp
+      tag.__emotion_forwardProp && userShouldForwardProp
         ? propName =>
             tag.__emotion_forwardProp(propName) &&
             // $FlowFixMe
-            options.shouldForwardProp(propName)
-        : options.shouldForwardProp
+            userShouldForwardProp(propName)
+        : userShouldForwardProp
   }
   const isReal = tag.__emotion_real === tag
   const baseTag = (isReal && tag.__emotion_base) || tag
@@ -206,6 +214,20 @@ let createStyled: CreateStyled = (tag: any, options?: StyledOptions) => {
 
     return Styled
   }
+}
+
+const defaultInclude = ['children']
+function createPropFilter({ include, exclude }: ShouldForwardPropsOptions) {
+  if (include) {
+    return (prop: string) =>
+      defaultInclude.indexOf(prop) !== -1 || include.indexOf(prop) !== -1
+  }
+
+  if (exclude) {
+    return (prop: string) => exclude.indexOf(prop) === -1
+  }
+
+  return undefined
 }
 
 export default createStyled

--- a/packages/styled/src/utils.js
+++ b/packages/styled/src/utils.js
@@ -4,9 +4,15 @@ import isPropValid from '@emotion/is-prop-valid'
 
 export type Interpolations = Array<any>
 
+export type ShouldForwardPropsOptions = {
+  /** If specified, exclude will not be used */
+  include?: Array<string>,
+  exclude?: Array<string>
+}
+
 export type StyledOptions = {
   label?: string,
-  shouldForwardProp?: string => boolean,
+  shouldForwardProp?: ShouldForwardPropsOptions | ((prop: string) => boolean),
   target?: string
 }
 

--- a/packages/styled/test/__snapshots__/prop-filtering.test.js.snap
+++ b/packages/styled/test/__snapshots__/prop-filtering.test.js.snap
@@ -104,6 +104,56 @@ exports[`prop filtering on composed styled components that are string tags 1`] =
 </a>
 `;
 
+exports[`shouldForwardProp exclude option works 1`] = `
+.emotion-0,
+.emotion-0 * {
+  fill: #0000ff;
+}
+
+<svg
+  className="emotion-0 emotion-1"
+  height="100px"
+  width="100px"
+>
+  <rect
+    height="100"
+    style={
+      Object {
+        "stroke": "#ff0000",
+      }
+    }
+    width="100"
+    x="10"
+    y="10"
+  />
+</svg>
+`;
+
+exports[`shouldForwardProp include option works 1`] = `
+.emotion-0,
+.emotion-0 * {
+  fill: #0000ff;
+}
+
+<svg
+  className="emotion-0 emotion-1"
+  height="100px"
+  width="100px"
+>
+  <rect
+    height="100"
+    style={
+      Object {
+        "stroke": "#ff0000",
+      }
+    }
+    width="100"
+    x="10"
+    y="10"
+  />
+</svg>
+`;
+
 exports[`shouldForwardProp should get inherited for wrapped styled components 1`] = `
 Array [
   .emotion-0 {

--- a/packages/styled/test/__snapshots__/prop-filtering.test.js.snap
+++ b/packages/styled/test/__snapshots__/prop-filtering.test.js.snap
@@ -174,3 +174,29 @@ Array [
   />,
 ]
 `;
+
+exports[`shouldForwardProp with no options works 1`] = `
+.emotion-0,
+.emotion-0 * {
+  fill: #0000ff;
+}
+
+<svg
+  className="emotion-0 emotion-1"
+  color="#0000ff"
+  height="100px"
+  width="100px"
+>
+  <rect
+    height="100"
+    style={
+      Object {
+        "stroke": "#ff0000",
+      }
+    }
+    width="100"
+    x="10"
+    y="10"
+  />
+</svg>
+`;

--- a/packages/styled/test/prop-filtering.test.js
+++ b/packages/styled/test/prop-filtering.test.js
@@ -105,6 +105,34 @@ test('shouldForwardProp include option works', () => {
   expect(tree).toMatchSnapshot()
 })
 
+test('shouldForwardProp with no options works', () => {
+  const Svg = props => (
+    <svg {...props}>
+      <rect
+        x="10"
+        y="10"
+        height="100"
+        width="100"
+        style={{ stroke: '#ff0000' }}
+      />
+    </svg>
+  )
+
+  const StyledSvg = styled(Svg, {
+    shouldForwardProp: {}
+  })`
+    &,
+    & * {
+      fill: ${({ color }) => color};
+    }
+  `
+
+  const tree = renderer
+    .create(<StyledSvg color="#0000ff" width="100px" height="100px" />)
+    .toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
 test('shouldForwardProp should get inherited for wrapped styled components', () => {
   const Div1 = styled('div', {
     shouldForwardProp: prop => prop !== 'color'

--- a/packages/styled/test/prop-filtering.test.js
+++ b/packages/styled/test/prop-filtering.test.js
@@ -48,6 +48,63 @@ test('custom shouldForwardProp works', () => {
   expect(tree).toMatchSnapshot()
 })
 
+test('shouldForwardProp exclude option works', () => {
+  const Svg = props => (
+    <svg {...props}>
+      <rect
+        x="10"
+        y="10"
+        height="100"
+        width="100"
+        style={{ stroke: '#ff0000' }}
+      />
+    </svg>
+  )
+
+  const StyledSvg = styled(Svg, {
+    shouldForwardProp: { exclude: ['color'] }
+  })`
+    &,
+    & * {
+      fill: ${({ color }) => color};
+    }
+  `
+
+  const tree = renderer
+    .create(<StyledSvg color="#0000ff" width="100px" height="100px" />)
+    .toJSON()
+  // color should not be passed
+  expect(tree).toMatchSnapshot()
+})
+
+test('shouldForwardProp include option works', () => {
+  const Svg = props => (
+    <svg {...props}>
+      <rect
+        x="10"
+        y="10"
+        height="100"
+        width="100"
+        style={{ stroke: '#ff0000' }}
+      />
+    </svg>
+  )
+
+  const StyledSvg = styled(Svg, {
+    shouldForwardProp: { include: ['className', 'width', 'height'] }
+  })`
+    &,
+    & * {
+      fill: ${({ color }) => color};
+    }
+  `
+
+  const tree = renderer
+    .create(<StyledSvg color="#0000ff" width="100px" height="100px" />)
+    .toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
 test('shouldForwardProp should get inherited for wrapped styled components', () => {
   const Div1 = styled('div', {
     shouldForwardProp: prop => prop !== 'color'

--- a/packages/styled/types/base.d.ts
+++ b/packages/styled/types/base.d.ts
@@ -19,6 +19,16 @@ export interface FilteringStyledOptions<
   ForwardedProps extends keyof Props = keyof Props
 > {
   label?: string
+  /**
+   * Type guarded version of should forward prop
+   *
+   * See https://emotion.sh/docs/typescript#filter-props-helper for a helper to make these easier to writes
+   *
+   * @param propName The name of the prop
+   * @returns true if the prop should be forwarded to the underlying component
+   * @example (propName): propName is Exclude<keyof ComponentProps, 'color'> => propName !== 'color'
+   * @example (propName: string): propName is Exclude<keyof ComponentProps, 'color' | 'other'> => !['color', 'other'].includes(propName)
+   */
   shouldForwardProp?(propName: PropertyKey): propName is ForwardedProps
   target?: string
 }
@@ -44,6 +54,14 @@ export interface StyledComponent<
     tag: Tag
   ): StyledComponent<ComponentProps, JSX.IntrinsicElements[Tag]>
 }
+
+/**
+ * NOTE The reason AdditionalProps is separated from the below is the outer generics
+ * are inferred by the styled function, AdditionalProps can then be specified
+ * by the user separately.
+ * For now you can't mix specified and inferred generics. There is a proposal exploring this at:
+ * https://github.com/microsoft/TypeScript/issues/26242
+ */
 
 /**
  * @typeparam ComponentProps  Props which will be included when withComponent is called

--- a/packages/styled/types/tests-base.tsx
+++ b/packages/styled/types/tests-base.tsx
@@ -98,6 +98,18 @@ const Canvas0 = styled('canvas', {
 })`
   width: 200px;
 `
+const Canvas2 = styled('canvas', {
+  shouldForwardProp: { include: ['width', 'height'] }
+})`
+  width: 200px;
+`
+
+const Canvas3 = styled('canvas', {
+  shouldForwardProp: { exclude: ['id'] }
+})`
+  width: 200px;
+`
+
 const Canvas1 = styled('canvas', {
   shouldForwardProp(propName) {
     return propName === 'width' || propName === 'height'
@@ -105,10 +117,27 @@ const Canvas1 = styled('canvas', {
 })({
   width: '200px'
 })
-;<Canvas0 />
+;<Canvas0 width="1">
+  <div />
+</Canvas0>
+// While techinically we could expose the component props here to be available to the styles
+// we only expose forwarded props, and expect the user to either forward those component props
+// or add them explicitly as props for the styles.
+// Otherwise the user may pass inbuilt component props and wonder why they are not forwarded
 // $ExpectError
-;<Canvas0 id="id-should-be-filtered" />
-;<Canvas1 />
+;<Canvas0 id="id-should-be-filtered" width="1">
+  <div />
+</Canvas0>
+// $ExpectError
+;<Canvas2 id="id-should-be-filtered" width="1">
+  <div />
+</Canvas2>
+;<Canvas1 width="1" id="canv">
+  <div />
+</Canvas1>
+;<Canvas3 width="1" id="canv">
+  <div />
+</Canvas3>
 
 const styledWithForwardedExtraProp = styled('div', {
   shouldForwardProp: prop => prop !== 'priority' && isPropValid(prop)


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Add options object to shouldForwardProp which takes include and exclude.

<!-- Why are these changes necessary? -->
**Why**: Most of the time we just want to either include a subset of props or exclude a few props and have to write a custom filter function. This allows an options object to be specified instead making it much easier.

Also writing type guards to prevent prop collisions is a little painful in TypeScript, I started putting a helper function in the docs but then thought why not just add support into the library.

<!-- How were these changes implemented? -->
**How**: In both the react native and normal create styled functions, if a function is not specified assume it's an options object and inspect the includes/excludes keys to generate the appropriate forwarding function.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset 

This replaces #1682, I changed the approach after the initial feedback, so there are a few docs changes in here too.