### PR TITLE
Specify `@emotion/react` as optional peer dependency of `@emotion/serialize`

### DIFF
--- a/.changeset/six-moons-deliver.md
+++ b/.changeset/six-moons-deliver.md
@@ -1,0 +1,5 @@
+---
+'@emotion/serialize': patch
+---
+
+Specify `@emotion/react` as optional peer dependency as it's used by TS types.

--- a/packages/serialize/package.json
+++ b/packages/serialize/package.json
@@ -20,6 +20,14 @@
     "@emotion/utils": "0.11.2",
     "csstype": "^2.6.7"
   },
+  "peerDependencies": {
+    "@emotion/react": "^11.0.0-next.10"
+  },
+  "peerDependenciesMeta": {
+    "@emotion/react": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "dtslint": "^0.3.0"
   },


### PR DESCRIPTION
fixes #1718

Lack of this has caused `@emotion/serialize` not being released along with the pkg-renaming stuff.

This is causing a `many-pkg` error:
> @emotion/css the package @emotion/css depends on @emotion/serialize which has a peerDependency on @emotion/react but @emotion/react is not specified in the dependencies or peerDependencies of @emotion/css. please add @emotion/react to the dependencies or peerDependencies of @emotion/css

And it's right about the error, but it would also be weird to specify `@emotion/react` as a peer of `@emotion/css`. On the other hand, due to the current dependency graph structure, this is needed, unless we want to restructure stuff so this could be avoided - I'm not sure how this could be done though (but I also don't have much time right now to think this through).