### PR TITLE
Fixed label extraction from the stack traces in FireFox and Safari

### DIFF
--- a/.changeset/twelve-rocks-visit.md
+++ b/.changeset/twelve-rocks-visit.md
@@ -1,0 +1,5 @@
+---
+'@emotion/core': patch
+---
+
+Fixed label extraction from the stack traces in FireFox and Safari. We have failed to match a label in Emotion wrappers like Theme UI which caused SSR mismatches in mentioned browsers. This has affected only development builds.

--- a/packages/core/src/jsx.js
+++ b/packages/core/src/jsx.js
@@ -158,7 +158,7 @@ export const jsx: typeof React.createElement = function(
       )
       if (!match) {
         // safari and firefox
-        match = error.stack.match(/^.*\n([A-Z][A-Za-z$]+)@/)
+        match = error.stack.match(/.*\n([A-Z][A-Za-z$]+)@/)
       }
       if (match) {
         newProps[labelPropName] = sanitizeIdentifier(match[1])


### PR DESCRIPTION
fixes https://github.com/system-ui/theme-ui/issues/538