### PR TITLE
ThemeOverride to make define custom theme type

### DIFF
--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -26,7 +26,22 @@ export {
 
 export { EmotionCache, Interpolation, SerializedStyles, css }
 
-export const ThemeContext: Context<object>
+/**
+ *
+ * ```
+ * declare module "@emotion/core" {
+ *   export interface ThemeOverride {
+ *     theme(): TTheme; // my custom theme
+ *   }
+ * }
+ * ```
+ */
+export interface ThemeOverride {
+  theme(): any;
+}
+type ThemeObject = ReturnType<ThemeOverride["theme"]>
+
+export const ThemeContext: Context<ThemeObject>
 export const CacheProvider: Provider<EmotionCache>
 export function withEmotionCache<Props, RefType = any>(
   func: (props: Props, context: EmotionCache, ref: Ref<RefType>) => ReactNode
@@ -45,7 +60,7 @@ export interface GlobalProps<Theme> {
  * @desc
  * JSX generic are supported only after TS@2.9
  */
-export function Global<Theme = any>(props: GlobalProps<Theme>): ReactElement
+export function Global<Theme = ThemeObject>(props: GlobalProps<Theme>): ReactElement<any>
 
 export function keyframes(
   template: TemplateStringsArray,
@@ -68,6 +83,7 @@ export interface ClassNamesContent<Theme> {
   cx(...args: Array<ClassNamesArg>): string
   theme: Theme
 }
+
 export interface ClassNamesProps<Theme> {
   children(content: ClassNamesContent<Theme>): ReactNode
 }
@@ -75,13 +91,13 @@ export interface ClassNamesProps<Theme> {
  * @desc
  * JSX generic are supported only after TS@2.9
  */
-export function ClassNames<Theme = any>(
+export function ClassNames<Theme = ThemeObject>(
   props: ClassNamesProps<Theme>
 ): ReactElement
 
 declare module 'react' {
   interface DOMAttributes<T> {
-    css?: InterpolationWithTheme<any>
+    css?: InterpolationWithTheme<ThemeObject>
   }
 }
 
@@ -93,7 +109,7 @@ declare global {
      */
 
     interface IntrinsicAttributes {
-      css?: InterpolationWithTheme<any>
+      css?: InterpolationWithTheme<ThemeObject>
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

We need to define project theme type to make theme parameters clear.

<!-- Why are these changes necessary? -->
**Why**:

we could not do this by 
```ts
declare module 'react' {
  interface DOMAttributes<T> {
    css?: InterpolationWithTheme<ThemeObject>
  }
}

declare global {
  namespace JSX {
    /**
     * Do we need to modify `LibraryManagedAttributes` too,
     * to make `className` props optional when `css` props is specified?
     */

    interface IntrinsicAttributes {
      css?: InterpolationWithTheme<ThemeObject>
    }
  }
}
```

<!-- How were these changes implemented? -->
**How**:

after new changes. we could do like this.

```ts
declare module "@emotion/core" {
  export interface ThemeOverride {
    theme(): { 
       color: { primary: "#000" } 
    }; 
  }
}
```

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
