### PR TITLE
Allow inert attribute

### DIFF
--- a/.changeset/six-cows-tie.md
+++ b/.changeset/six-cows-tie.md
@@ -1,0 +1,5 @@
+---
+'@emotion/is-prop-valid': patch
+---
+
+Adds inert to the list of allowed props

--- a/packages/is-prop-valid/src/props.js
+++ b/packages/is-prop-valid/src/props.js
@@ -184,6 +184,8 @@ const props = {
   autoSave: true,
   // color is for Safari mask-icon link
   color: true,
+  // https://html.spec.whatwg.org/multipage/interaction.html#inert
+  inert: true,
   // itemProp, itemScope, itemType are for
   // Microdata support. See http://schema.org/docs/gs.html
   itemProp: true,


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: 
Allow inert attribute

<!-- Why are these changes necessary? -->
**Why**:
When an element has an attribute `inert="true"`, browser may "ignore" it from assistive technologies, page search and text selection. This can be useful when building UIs such as modals where you would want to "trap" the focus inside the modal when it's visible.
See https://html.spec.whatwg.org/multipage/interaction.html#inert and https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert

<!-- How were these changes implemented? -->
**How**:
Adds `inert: true` to the list of allowed props

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Code complete N/A
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
