### PR TITLE
Change which interface gets extended with css prop support

### DIFF
--- a/.changeset/tidy-ghosts-smile.md
+++ b/.changeset/tidy-ghosts-smile.md
@@ -1,0 +1,5 @@
+---
+'@emotion/react': patch
+---
+
+Changed the interface to which support for `css` prop is being added. It's now `React.Attributes` instead of `React.DOMAttributes<T>` and `JSX.IntrinsicAttributes`. This change is really minor and shouldn't affect any consuming code.

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -95,20 +95,7 @@ export interface ClassNamesProps {
 export function ClassNames(props: ClassNamesProps): ReactElement
 
 declare module 'react' {
-  interface DOMAttributes<T> {
+  interface Attributes {
     css?: Interpolation<Theme>
-  }
-}
-
-declare global {
-  namespace JSX {
-    /**
-     * Do we need to modify `LibraryManagedAttributes` too,
-     * to make `className` props optional when `css` props is specified?
-     */
-
-    interface IntrinsicAttributes {
-      css?: Interpolation<Theme>
-    }
   }
 }


### PR DESCRIPTION
At the moment this is just a placeholder PR/remainder fo myself - Jessica has mentioned [here](https://github.com/emotion-js/emotion/issues/693#issuecomment-448085783) that we should be able to extend `Attributes` rather than `DOMAttributes`. Need to dig deeper to see what's the difference and what kind of an issue does it solve.