### PR TITLE
Add `fragment` option to handle fragment shorthand

### DIFF
--- a/.changeset/two-coins-grab.md
+++ b/.changeset/two-coins-grab.md
@@ -1,0 +1,6 @@
+---
+'@emotion/babel-plugin-jsx-pragmatic': minor
+'@emotion/babel-preset-css-prop': minor
+---
+
+Add new option, `fragment`, to automatically import React when shorthand fragments are used. Previously, using a shorthand fragment would cause `React.Fragment` to be used in the output, but this could cause a runtime error if React was not manually imported.

--- a/packages/babel-plugin-jsx-pragmatic/README.md
+++ b/packages/babel-plugin-jsx-pragmatic/README.md
@@ -163,6 +163,24 @@ String. The export that you want to import as `import` from `module`. Default va
 // import {something as x} from "whatever"
 ```
 
+### `fragment`
+
+Object. Disabled by default. Adds a React import when fragment shorthand appears in the source. By default, the shorthand is transpiled to `React.Fragment`, and if this is not enabled, React must be manually imported to use fragment shorthand (otherwise, a runtime error will be thrown).
+
+```js
+{
+  fragment: {
+    module: "react"
+    import: "React",
+  },
+  // other options
+  module: "whatever",
+  import: "x",
+}
+// import {default as x} from "whatever"
+// import {default as React} from "react"
+```
+
 # Known Issues
 
 - Doesn't do anything special in the case that the file being transformed

--- a/packages/babel-plugin-jsx-pragmatic/__tests__/__fixtures__/fragment-only-no-import.js
+++ b/packages/babel-plugin-jsx-pragmatic/__tests__/__fixtures__/fragment-only-no-import.js
@@ -1,0 +1,6 @@
+// When using Emotion, React does not need to be in scope except
+// when using fragment shorthand. This plugin should add a react
+// import when using the `fragment` option, so we can ignore the
+// linting error here.
+// eslint-disable-next-line react/react-in-jsx-scope
+const F = () => <></>

--- a/packages/babel-plugin-jsx-pragmatic/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-jsx-pragmatic/__tests__/__snapshots__/index.js.snap
@@ -38,6 +38,28 @@ import { jsx as ___EmotionJSX } from \\"@emotion/core\\";
 const F = () => <></>;"
 `;
 
+exports[`@emotion/babel-plugin-jsx-pragmatic fragment-only-no-import 1`] = `
+"// When using Emotion, React does not need to be in scope except
+// when using fragment shorthand. This plugin should add a react
+// import when using the \`fragment\` option, so we can ignore the
+// linting error here.
+// eslint-disable-next-line react/react-in-jsx-scope
+const F = () => <></>
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { jsx as ___EmotionJSX } from \\"@emotion/core\\";
+import { default as React } from \\"react\\";
+
+// When using Emotion, React does not need to be in scope except
+// when using fragment shorthand. This plugin should add a react
+// import when using the \`fragment\` option, so we can ignore the
+// linting error here.
+// eslint-disable-next-line react/react-in-jsx-scope
+const F = () => <></>;"
+`;
+
 exports[`@emotion/babel-plugin-jsx-pragmatic minimal 1`] = `
 "import * as React from 'react'
 

--- a/packages/babel-plugin-jsx-pragmatic/__tests__/index.js
+++ b/packages/babel-plugin-jsx-pragmatic/__tests__/index.js
@@ -9,7 +9,11 @@ babelTester('@emotion/babel-plugin-jsx-pragmatic', __dirname, {
       {
         export: 'jsx',
         module: '@emotion/core',
-        import: '___EmotionJSX'
+        import: '___EmotionJSX',
+        fragment: {
+          module: 'react',
+          import: 'React'
+        }
       }
     ]
   ]
@@ -23,5 +27,22 @@ test('babel-plugin-jsx-pragmatic should throw error when invalid options', () =>
     })
   }).toThrow(
     '@emotion/babel-plugin-jsx-pragmatic: You must specify `module` and `import`'
+  )
+  expect(() => {
+    transformSync('<></>', {
+      filename: __filename,
+      plugins: [
+        [
+          jsxPragmatic,
+          {
+            import: '___EmotionJSX',
+            module: '@emotion/core',
+            fragment: { export: 'default' }
+          }
+        ]
+      ]
+    })
+  }).toThrow(
+    '@emotion/babel-plugin-jsx-pragmatic: You must specify `fragment.module` and `fragment.import`'
   )
 })

--- a/packages/babel-plugin-jsx-pragmatic/src/index.js
+++ b/packages/babel-plugin-jsx-pragmatic/src/index.js
@@ -8,30 +8,30 @@ const findLast = (arr, predicate) => {
   }
 }
 
-export default function jsxPragmatic(babel) {
-  const t = babel.types
-
-  function addPragmaImport(path, state) {
-    const importDeclar = t.importDeclaration(
-      [
-        t.importSpecifier(
-          t.identifier(state.opts.import),
-          t.identifier(state.opts.export || 'default')
-        )
-      ],
-      t.stringLiteral(state.opts.module)
-    )
-
-    const targetPath = findLast(path.get('body'), p => p.isImportDeclaration())
-
-    if (targetPath) {
-      targetPath.insertAfter([importDeclar])
-    } else {
-      // Apparently it's now safe to do this even if Program begins with directives.
-      path.unshiftContainer('body', importDeclar)
-    }
+const insertImport = (path, declaration) => {
+  const last = findLast(path.get('body'), p => p.isImportDeclaration())
+  if (last) {
+    last.insertAfter(declaration)
+  } else {
+    // Apparently it's now safe to do this even if Program begins with directives.
+    path.unshiftContainer('body', declaration)
   }
+}
 
+const createImport = (babel, options) => {
+  const t = babel.types
+  return t.importDeclaration(
+    [
+      t.importSpecifier(
+        t.identifier(options.import),
+        t.identifier(options.export || 'default')
+      )
+    ],
+    t.stringLiteral(options.module)
+  )
+}
+
+export default function jsxPragmatic(babel) {
   return {
     inherits: syntaxJsx,
     pre: function() {
@@ -40,12 +40,36 @@ export default function jsxPragmatic(babel) {
           '@emotion/babel-plugin-jsx-pragmatic: You must specify `module` and `import`'
         )
       }
+      if (
+        this.opts.fragment &&
+        !(this.opts.fragment.module && this.opts.fragment.import)
+      ) {
+        throw new Error(
+          '@emotion/babel-plugin-jsx-pragmatic: You must specify `fragment.module` and `fragment.import`'
+        )
+      }
     },
     visitor: {
       Program: {
         exit: function(path, state) {
-          if (!state.get('jsxDetected')) return
-          addPragmaImport(path, state)
+          if (state.get('jsxDetected')) {
+            insertImport(
+              path,
+              createImport(babel, {
+                import: state.opts.import,
+                export: state.opts.export,
+                module: state.opts.module
+              })
+            )
+          }
+
+          if (
+            state.get('jsxFragmentDetected') &&
+            state.opts.fragment &&
+            !state.get('fragmentImportDetected')
+          ) {
+            insertImport(path, createImport(babel, state.opts.fragment))
+          }
         }
       },
 
@@ -54,6 +78,20 @@ export default function jsxPragmatic(babel) {
       },
       JSXFragment: function(path, state) {
         state.set('jsxDetected', true)
+        state.set('jsxFragmentDetected', true)
+      },
+      ImportDeclaration: function(path, state) {
+        if (state.opts.fragment) {
+          if (
+            // This looks for imports that already have imported `fragment.import`
+            // like `import React from 'react'` or `import * as React from 'react'`.
+            path.node.specifiers.find(
+              specifier => specifier.local.name === state.opts.fragment.import
+            )
+          ) {
+            state.set('fragmentImportDetected', true)
+          }
+        }
       }
     }
   }

--- a/packages/babel-preset-css-prop/README.md
+++ b/packages/babel-preset-css-prop/README.md
@@ -139,6 +139,8 @@ Options for both `babel-plugin-emotion` and `@babel/plugin-transform-react-jsx` 
 >
 > - [`@babel/plugin-transform-react-jsx`](https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx)
 
+Also supports a `fragment` option (boolean, default `false`). This automatically adds React imports when JSX fragment shorthand is detected via `@emotion/babel-plugin-jsx-pragmatic`. See https://www.npmjs.com/package/@emotion/babel-plugin-jsx-pragmatic.
+
 ### Examples
 
 ```json
@@ -149,7 +151,8 @@ Options for both `babel-plugin-emotion` and `@babel/plugin-transform-react-jsx` 
       "autoLabel": true,
       "labelFormat": "[local]",
       "useBuiltIns": false,
-      "throwIfNamespace": true
+      "throwIfNamespace": true,
+      "fragment": true
     }
   ]
 }

--- a/packages/babel-preset-css-prop/src/index.js
+++ b/packages/babel-preset-css-prop/src/index.js
@@ -11,7 +11,15 @@ let pragmaName = '___EmotionJSX'
 
 export default (
   api,
-  { pragma, sourceMap, autoLabel, labelFormat, instances, ...options } = {}
+  {
+    pragma,
+    sourceMap,
+    autoLabel,
+    labelFormat,
+    instances,
+    fragment,
+    ...options
+  } = {}
 ) => {
   return {
     plugins: [
@@ -20,7 +28,8 @@ export default (
         {
           export: 'jsx',
           module: '@emotion/core',
-          import: pragmaName
+          import: pragmaName,
+          fragment: fragment && { module: 'react', import: 'React' }
         }
       ],
       [jsx, { pragma: pragmaName, pragmaFrag: 'React.Fragment', ...options }],


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Added a new option, `fragment`. This is a new opt-in feature for `@emotion/babel-plugin-jsx-pragmatic` that will add `import { default as React } from 'react'` when a JSX fragment is detected.

`babel-plugin-jsx-pragmatic`
In:
```js
const F = () => <>Test</>
```

Out:
```js
import { jsx as ___EmotionJSX } from "@emotion/core";
import { default as React } from "react";

const F = () => <>Test</>;
```

<!-- Why are these changes necessary? -->
**Why**: Without this option, all JSX is transformed to Emotion's JSX function which means React does not need to be in scope (unlike normal JSX). However, fragments `<></>` compile to `React.Fragment` by default, which causes a runtime error if React is not imported.

This new option is opt-in, and can be specified in `@emotion/babel-preset-css-prop`. I made it opt-in because it might be considered a breaking change. Let me know if you think this should be enabled by default.

Also, if you think there is a better way to do this, let me know! I decided to just open a PR first because this was a pretty simple change.

<!-- How were these changes implemented? -->
**How**: I added a new state key, `jsxFragmentDetected`, which causes an additional import to be inserted by the plugin. I refactored the plugin a tiny bit to support two declarations instead of one.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
related: https://github.com/emotion-js/emotion/issues/1549