### PR TITLE
Change a console.warn to console.error for reporting bad rule insertion attempt in speedy mode

### DIFF
--- a/packages/css/test/sheet.dom.test.js
+++ b/packages/css/test/sheet.dom.test.js
@@ -31,7 +31,7 @@ describe('sheet', () => {
 
   test('throws', () => {
     sheet.speedy(true)
-    const spy = jest.spyOn(global.console, 'warn')
+    const spy = jest.spyOn(global.console, 'error')
     sheet.insert('.asdfasdf4###112121211{')
     expect(spy).toHaveBeenCalled()
   })

--- a/packages/sheet/__tests__/index.js
+++ b/packages/sheet/__tests__/index.js
@@ -62,16 +62,16 @@ describe('StyleSheet', () => {
 
   it('should throw when inserting a bad rule in speedy mode', () => {
     const sheet = new StyleSheet({ ...defaultOptions, speedy: true })
-    const oldConsoleWarn = console.warn
+    const oldConsoleError = console.error
     // $FlowFixMe
-    console.warn = jest.fn()
+    console.error = jest.fn()
     sheet.insert('.asdfasdf4###112121211{')
-    expect(console.warn).toHaveBeenCalledTimes(1)
-    expect((console.warn: any).mock.calls[0][0]).toBe(
+    expect(console.error).toHaveBeenCalledTimes(1)
+    expect((console.error: any).mock.calls[0][0]).toBe(
       'There was a problem inserting the following rule: ".asdfasdf4###112121211{"'
     )
     // $FlowFixMe
-    console.warn = oldConsoleWarn
+    console.error = oldConsoleError
     sheet.flush()
   })
 

--- a/packages/sheet/src/index.js
+++ b/packages/sheet/src/index.js
@@ -131,7 +131,7 @@ export class StyleSheet {
         )
       } catch (e) {
         if (process.env.NODE_ENV !== 'production') {
-          console.warn(
+          console.error(
             `There was a problem inserting the following rule: "${rule}"`,
             e
           )


### PR DESCRIPTION
I don't think this deserves a changeset, just a small unification as we use `console.error` for most of the warnings/errors reported.