### PR TITLE
(styled-base) Changed default props.theme type to any

### DIFF
--- a/.changeset/eight-feet-hide.md
+++ b/.changeset/eight-feet-hide.md
@@ -1,0 +1,5 @@
+---
+'@emotion/styled-base': patch
+---
+
+Default props.theme to any to match the docs

--- a/packages/styled-base/package.json
+++ b/packages/styled-base/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "repository": "https://github.com/emotion-js/emotion/tree/master/packages/styled-base",
   "scripts": {
-    "test:typescript": "dtslint types"
+    "test:typescript": "dtslint --expectOnly types"
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@emotion/core": "^10.0.28",
     "@types/react": "^16.8.20",
-    "dtslint": "^0.3.0",
+    "dtslint": "^3.3.0",
     "react": "^16.5.2"
   },
   "peerDependencies": {

--- a/packages/styled-base/types/index.d.ts
+++ b/packages/styled-base/types/index.d.ts
@@ -59,21 +59,19 @@ interface CreateStyledComponentBaseThemeless<InnerProps, ExtraProps> {
     StyleProps extends Omit<
       Overwrapped<InnerProps, StyleProps>,
       ReactClassPropKeys
-    > = Omit<InnerProps & ExtraProps, ReactClassPropKeys>,
-    Theme extends object = object
+    > = Omit<InnerProps & ExtraProps, ReactClassPropKeys>
   >(
-    ...styles: Array<Interpolation<WithTheme<StyleProps, Theme>>>
-  ): StyledComponent<InnerProps, StyleProps, Theme>
+    ...styles: Array<Interpolation<WithTheme<StyleProps, any>>>
+  ): StyledComponent<InnerProps, StyleProps, any>
   <
     StyleProps extends Omit<
       Overwrapped<InnerProps, StyleProps>,
       ReactClassPropKeys
-    > = Omit<InnerProps & ExtraProps, ReactClassPropKeys>,
-    Theme extends object = object
+    > = Omit<InnerProps & ExtraProps, ReactClassPropKeys>
   >(
     template: TemplateStringsArray,
-    ...styles: Array<Interpolation<WithTheme<StyleProps, Theme>>>
-  ): StyledComponent<InnerProps, StyleProps, Theme>
+    ...styles: Array<Interpolation<WithTheme<StyleProps, any>>>
+  ): StyledComponent<InnerProps, StyleProps, any>
 }
 
 interface CreateStyledComponentBaseThemed<

--- a/packages/styled-base/types/tests.tsx
+++ b/packages/styled-base/types/tests.tsx
@@ -93,7 +93,7 @@ interface PrimaryProps {
  * it could be more efficient.
  */
 const Button2 = styled<'button', PrimaryProps>('button')`
-  fontsize: ${5}px;
+  font-size: ${5}px;
   color: ${props => props.primary};
 `
 const Button3 = styled<'button', PrimaryProps>('button')(props => ({
@@ -119,10 +119,10 @@ const Button3 = styled<'button', PrimaryProps>('button')(props => ({
 const Button4 = styled<typeof ReactClassComponent0, PrimaryProps>(
   ReactClassComponent0
 )`
-  backgroundColor: ${props => props.theme.backColor}
+  background-color: ${props => props.theme.backColor};
 
-  fontSize: ${5}px;
-  color: ${props => props.primary}
+  font-size: ${5}px;
+  color: ${props => props.primary};
 `
 const Button5 = styled<typeof ReactSFC0, PrimaryProps>(ReactSFC0)(props => ({
   color: props.primary
@@ -146,7 +146,7 @@ const Button5 = styled<typeof ReactSFC0, PrimaryProps>(ReactSFC0)(props => ({
 
 const Container0 = styled(ReactClassComponent0)`
   display: flex;
-  flexdirection: ${props => props.column && 'column'};
+  flex-direction: ${props => props.column && 'column'};
 `
 ;<Container0 column={false} />
 // $ExpectError


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
### What:

- **Changed default `props.theme` type to _any_**
- Updated dtslint and added `--expectOnly` flag
- Corrected stylis errors from ts-styled-plugin

<!-- Why are these changes necessary? -->
### Why:

The [docs][theme-docs] were wrong.

<!-- How were these changes implemented? -->
### How:


#### Updated dtslint and added `--expectOnly` flag

Not sure if anybody cares about the string coercion warnings which were already here.

![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2F2ndbrain%2FEhjkwGi3xH?alt=media&token=82ba37cb-c875-4c17-8c1e-4d30b4b26b9e)

Then, only following error remains:
```
background-color: ${props => props.theme.backColor};
```
```
ERROR: 122:44  expect  TypeScript@next compile error: 
Property 'backColor' does not exist on type 'object'.
```

#### Changed default `props.theme` type to _any_ 

It stems from *CreateStyledComponentBaseThemeless* defaulting Theme to `*object*.

https://github.com/emotion-js/emotion/blob/ef7794f50a1ef9790ea6ebe530b6fd8e0b7b0942/packages/styled-base/types/index.d.ts#L57-L77

*CreateStyledComponentBaseThemeless* is used when the theme isn't given to *CreateStyled*.

https://github.com/emotion-js/emotion/blob/ef7794f50a1ef9790ea6ebe530b6fd8e0b7b0942/packages/styled-base/types/index.d.ts#L103-L115

The [docs][theme-docs] claim that props.theme is _any_ and the type definition also suggests so.
```
interface CreateStyled<Theme extends object = any>
```

[theme-docs]: https://emotion.sh/docs/typescript#define-a-theme

However, I encountered *object*, both in **styled-base** and **styled** packages.

![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2F2ndbrain%2FqL7NmOMVVI?alt=media&token=76964e5e-1f32-4fa8-bd2c-777fb474c199)
![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2F2ndbrain%2FM5AvYu6Fwe?alt=media&token=e73c7668-83ed-413b-85dd-8a5f03bce6cd)

ThemeContext is [defined][theme-context] as _React.Context\<Object\>_ in **@emotion/core** flow source, but in TypeScript _any_ or _Record<string, any>_ would be more suitable. 

I'm changing it to _any_ to match the docs.

[theme-context]: https://github.com/emotion-js/emotion/blob/10514a8635dcaa55b85c7bff90e2a9e14d1ba61f/packages/core/src/context.js#L17

#### Corrected stylis errors from ts-styled-plugin

Fixed problems:
  - camelCase properties instead of kebab-case
  - missing semis


<!-- Have you done all of these things?  -->
### Checklist ###:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests (I fixed an error in existing test)
- [x] Code complete 
- [x] Changeset

