### PR TITLE
Add commonjs option to babel-plugin-jsx-pragmatic

### DIFF
--- a/.changeset/fifty-rabbits-switch.md
+++ b/.changeset/fifty-rabbits-switch.md
@@ -1,0 +1,5 @@
+---
+'@emotion/babel-plugin-jsx-pragmatic': minor
+---
+
+Add commonjs option to babel-plugin-jsx-pragmatic

--- a/packages/babel-plugin-jsx-pragmatic/README.md
+++ b/packages/babel-plugin-jsx-pragmatic/README.md
@@ -163,6 +163,20 @@ String. The export that you want to import as `import` from `module`. Default va
 // import {something as x} from "whatever"
 ```
 
+### `commonjs`
+
+Boolean. If provided and set to `true`, then CommonJS-style `require` statements will be produced instead of `import` statements. This should not be necessary in the typical case.
+
+```js
+{
+  module: "whatever",
+  import: "x",
+  export: "something",
+  commonjs: true
+}
+// var x = require("whatever").something
+```
+
 # Known Issues
 
 - Doesn't do anything special in the case that the file being transformed

--- a/packages/babel-plugin-jsx-pragmatic/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-plugin-jsx-pragmatic/__tests__/__snapshots__/index.js.snap
@@ -24,6 +24,32 @@ import { jsx as ___EmotionJSX } from \\"@emotion/core\\";
 ReactDOM.render(<App />, document.getElementById('root'));"
 `;
 
+exports[`@emotion/babel-plugin-jsx-pragmatic existing-imports 2`] = `
+"// inserted import has to go AFTER polyfills
+import 'react-app-polyfill/ie11'
+import 'react-app-polyfill/stable'
+
+import React from 'react'
+import ReactDOM from 'react-dom'
+import App from './App'
+
+ReactDOM.render(<App />, document.getElementById('root'))
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// inserted import has to go AFTER polyfills
+import 'react-app-polyfill/ie11';
+import 'react-app-polyfill/stable';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+var ___EmotionJSX = require(\\"@emotion/core\\").jsx;
+
+ReactDOM.render(<App />, document.getElementById('root'));"
+`;
+
 exports[`@emotion/babel-plugin-jsx-pragmatic fragment-only 1`] = `
 "import * as React from 'react'
 
@@ -38,6 +64,21 @@ import { jsx as ___EmotionJSX } from \\"@emotion/core\\";
 const F = () => <></>;"
 `;
 
+exports[`@emotion/babel-plugin-jsx-pragmatic fragment-only 2`] = `
+"import * as React from 'react'
+
+const F = () => <></>
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import * as React from 'react';
+
+var ___EmotionJSX = require(\\"@emotion/core\\").jsx;
+
+const F = () => <></>;"
+`;
+
 exports[`@emotion/babel-plugin-jsx-pragmatic minimal 1`] = `
 "import * as React from 'react'
 
@@ -48,6 +89,21 @@ const P = () => <p />
 
 import * as React from 'react';
 import { jsx as ___EmotionJSX } from \\"@emotion/core\\";
+
+const P = () => <p />;"
+`;
+
+exports[`@emotion/babel-plugin-jsx-pragmatic minimal 2`] = `
+"import * as React from 'react'
+
+const P = () => <p />
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import * as React from 'react';
+
+var ___EmotionJSX = require(\\"@emotion/core\\").jsx;
 
 const P = () => <p />;"
 `;

--- a/packages/babel-plugin-jsx-pragmatic/__tests__/index.js
+++ b/packages/babel-plugin-jsx-pragmatic/__tests__/index.js
@@ -15,6 +15,20 @@ babelTester('@emotion/babel-plugin-jsx-pragmatic', __dirname, {
   ]
 })
 
+babelTester('@emotion/babel-plugin-jsx-pragmatic', __dirname, {
+  plugins: [
+    [
+      jsxPragmatic,
+      {
+        export: 'jsx',
+        module: '@emotion/core',
+        import: '___EmotionJSX',
+        commonjs: true
+      }
+    ]
+  ]
+})
+
 test('babel-plugin-jsx-pragmatic should throw error when invalid options', () => {
   expect(() => {
     transformSync('<></>', {

--- a/packages/babel-plugin-jsx-pragmatic/src/index.js
+++ b/packages/babel-plugin-jsx-pragmatic/src/index.js
@@ -12,15 +12,27 @@ export default function jsxPragmatic(babel) {
   const t = babel.types
 
   function addPragmaImport(path, state) {
-    const importDeclar = t.importDeclaration(
-      [
-        t.importSpecifier(
-          t.identifier(state.opts.import),
-          t.identifier(state.opts.export || 'default')
+    const importDeclar = !state.opts.commonjs
+      ? t.importDeclaration(
+          [
+            t.importSpecifier(
+              t.identifier(state.opts.import),
+              t.identifier(state.opts.export || 'default')
+            )
+          ],
+          t.stringLiteral(state.opts.module)
         )
-      ],
-      t.stringLiteral(state.opts.module)
-    )
+      : t.variableDeclaration('var', [
+          t.variableDeclarator(
+            t.identifier(state.opts.import),
+            t.memberExpression(
+              t.callExpression(t.identifier('require'), [
+                t.stringLiteral(state.opts.module)
+              ]),
+              t.identifier(state.opts.export || 'default')
+            )
+          )
+        ])
 
     const targetPath = findLast(path.get('body'), p => p.isImportDeclaration())
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
The commonjs option, when `true`, will allow output to be a CommonJS-style require statement rather than an ECMAScript import statement.

<!-- Why are these changes necessary? -->
**Why**:
The intent behind this is to route around problems of babel configuration within Jest, primarily.

<!-- How were these changes implemented? -->
**How**:
Within babel-plugin-jsx-pragmatic, a check is done for `opts.commonjs` which, if truthy, will insert a `VariableDeclaration` instead of an `ImportDeclaration`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ x Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
Alternatively, if anyone knows how to ensure that Babel consistently processes import statements after babel-plugin-jsx-pragmatic when running within Jest, this effort might be unnecessary.