### PR TITLE
Make memoize, is-prop-valid ES modules

### DIFF
--- a/packages/is-prop-valid/package.json
+++ b/packages/is-prop-valid/package.json
@@ -1,10 +1,13 @@
 {
+  "type": "module",
   "name": "@emotion/is-prop-valid",
   "version": "0.8.8",
   "description": "A function to check whether a prop is valid for HTML and SVG elements",
   "main": "dist/is-prop-valid.cjs.js",
+  "exports": "./dist/is-prop-valid.esm.js",
   "module": "dist/is-prop-valid.esm.js",
   "types": "types/index.d.ts",
+  "sideEffects": false,
   "license": "MIT",
   "repository": "https://github.com/emotion-js/emotion/tree/master/packages/is-prop-valid",
   "scripts": {

--- a/packages/is-prop-valid/package.json
+++ b/packages/is-prop-valid/package.json
@@ -1,11 +1,15 @@
 {
-  "type": "module",
   "name": "@emotion/is-prop-valid",
   "version": "0.8.8",
   "description": "A function to check whether a prop is valid for HTML and SVG elements",
   "main": "dist/is-prop-valid.cjs.js",
-  "exports": "./dist/is-prop-valid.esm.js",
-  "module": "dist/is-prop-valid.esm.js",
+  "exports": {
+    ".": {
+      "import": "./dist/is-prop-valid.esm.mjs",
+      "default": "./dist/is-prop-valid.cjs.js"
+    }
+  },
+  "module": "dist/is-prop-valid.esm.mjs",
   "types": "types/index.d.ts",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -1,10 +1,13 @@
 {
+  "type": "module",
   "name": "@emotion/memoize",
   "version": "0.7.4",
   "description": "emotion's memoize utility",
   "main": "dist/memoize.cjs.js",
+  "exports": "./dist/memoize.esm.js",
   "module": "dist/memoize.esm.js",
   "types": "types/index.d.ts",
+  "sideEffects": false,
   "license": "MIT",
   "repository": "https://github.com/emotion-js/emotion/tree/master/packages/memoize",
   "scripts": {

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -1,11 +1,15 @@
 {
-  "type": "module",
   "name": "@emotion/memoize",
   "version": "0.7.4",
   "description": "emotion's memoize utility",
   "main": "dist/memoize.cjs.js",
-  "exports": "./dist/memoize.esm.js",
-  "module": "dist/memoize.esm.js",
+  "exports": {
+    ".": {
+      "import": "./dist/memoize.esm.mjs",
+      "default": "./dist/memoize.cjs.js"
+    }
+  },
+  "module": "dist/memoize.esm.mjs",
   "types": "types/index.d.ts",
   "sideEffects": false,
   "license": "MIT",


### PR DESCRIPTION
Also mark those packages as side-effect free.

**What**: Node.js 13+ supports ES modules out of the box. This PR makes the code in the two packages `@emotion/memoize` and `@emotion/is-prop-valid` available as ES modules.

**Why**: To allow modern Node.js versions to consume the ES modules directly instead of going through CJS. Using "exports" also prevents users from importing internal files (on purpose or by accident, `import "@emotion/memoize/dist/memoize.esm.js"` will throw an error).

**How**: Only changes in the two respective package.json files are needed. There should not be any regressions for older Node.js versions since they ignore the two new fields "type" and "exports".

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

I'm not certain whether this should be a major bump or not. It should not cause any regressions, so I'm tempted to give it a patch bump.