### PR TITLE
Remove hydrate method as there is auto-hydration anyway

### DIFF
--- a/docs/ssr.mdx
+++ b/docs/ssr.mdx
@@ -118,24 +118,14 @@ const stream = renderToNodeStream(<App />).pipe(renderStylesToNodeStream())
 
 ### extractCritical
 
-This returns an object with the properties `html`, `ids` and `css`. It removes unused rules that were created with emotion(it still includes rules that were inserted with `injectGlobal`).
+This returns an object with the properties `html` and `css`. It removes unused rules that were created with emotion(it still includes rules that were inserted with `injectGlobal`).
 
 ```jsx
 import { renderToString } from 'react-dom/server'
 import { extractCritical } from '@emotion/server'
 import App from './App'
 
-const { html, ids, css } = extractCritical(renderToString(<App />))
-```
-
-#### hydrate
-
-`hydrate` should be called on the client with the `ids` that `extractCritical` returns. If you don't call it then emotion will reinsert all the rules. `hydrate` is **only** required for `extractCritical`, **not** for `renderStylesToString` or `renderStylesToNodeStream`, hydration occurs automatically with `renderStylesToString` and `renderStylesToNodeStream`.
-
-```jsx
-import { hydrate } from '@emotion/css'
-
-hydrate(ids)
+const { html, css } = extractCritical(renderToString(<App />))
 ```
 
 ## Next.js

--- a/packages/babel-plugin/README.md
+++ b/packages/babel-plugin/README.md
@@ -327,13 +327,7 @@ An example config:
 Instead of using `@emotion/babel-plugin`, you can use emotion with [`babel-plugin-macros`](https://github.com/kentcdodds/babel-plugin-macros). Add `babel-plugin-macros` to your babel config (which is included in Create React App 2.0) and use the imports/packages shown below.
 
 ```jsx
-import {
-  css,
-  keyframes,
-  injectGlobal,
-  flush,
-  hydrate
-} from '@emotion/css/macro'
+import { css, keyframes, injectGlobal, flush } from '@emotion/css/macro'
 import { jsx, css, Global, keyframes } from '@emotion/react/macro'
 import styled from '@emotion/styled/macro'
 ```

--- a/packages/cache/src/index.js
+++ b/packages/cache/src/index.js
@@ -85,7 +85,7 @@ let createCache = (options: Options): EmotionCache => {
   let inserted = {}
   // $FlowFixMe
   let container: HTMLElement
-  const nodesToRehydrate = []
+  const nodesToHydrate = []
   if (isBrowser) {
     container = options.container || document.head
 
@@ -102,7 +102,7 @@ let createCache = (options: Options): EmotionCache => {
         for (let i = 1; i < attrib.length; i++) {
           inserted[attrib[i]] = true
         }
-        nodesToRehydrate.push(node)
+        nodesToHydrate.push(node)
       }
     )
   }
@@ -274,7 +274,7 @@ let createCache = (options: Options): EmotionCache => {
     insert
   }
 
-  cache.sheet.rehydrate(nodesToRehydrate)
+  cache.sheet.hydrate(nodesToHydrate)
 
   return cache
 }

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -282,7 +282,6 @@ import createEmotion from '@emotion/css/create-instance'
 
 export const {
   flush,
-  hydrate,
   cx,
   merge,
   getRegisteredStyles,
@@ -325,7 +324,6 @@ import createEmotion from '@emotion/css/create-instance'
 
 export const {
   flush,
-  hydrate,
   cx,
   merge,
   getRegisteredStyles,

--- a/packages/css/src/create-instance.js
+++ b/packages/css/src/create-instance.js
@@ -54,7 +54,6 @@ export type Emotion = {
   css: CreateStyles<string>,
   cx: (...classNames: Array<ClassNameArg>) => string,
   flush: () => void,
-  hydrate: (ids: Array<string>) => void,
   injectGlobal: CreateStyles<void>,
   keyframes: CreateStyles<string>,
   sheet: StyleSheet,
@@ -104,11 +103,6 @@ let createEmotion = (options: *): Emotion => {
     cx,
     injectGlobal,
     keyframes,
-    hydrate(ids: Array<string>) {
-      ids.forEach(key => {
-        cache.inserted[key] = true
-      })
-    },
     flush() {
       cache.registered = {}
       cache.inserted = {}

--- a/packages/css/src/index.js
+++ b/packages/css/src/index.js
@@ -3,7 +3,6 @@ import createEmotion from './create-instance'
 
 export const {
   flush,
-  hydrate,
   cx,
   merge,
   getRegisteredStyles,

--- a/packages/css/test/instance/emotion-instance.js
+++ b/packages/css/test/instance/emotion-instance.js
@@ -32,7 +32,6 @@ const emotion = createEmotion({
 
 export const {
   flush,
-  hydrate,
   cx,
   merge,
   getRegisteredStyles,

--- a/packages/css/types/create-instance.d.ts
+++ b/packages/css/types/create-instance.d.ts
@@ -28,7 +28,6 @@ export interface Emotion {
   css(...args: Array<CSSInterpolation>): string
   cx(...classNames: Array<ClassNamesArg>): string
   flush(): void
-  hydrate(ids: Array<string>): void
   injectGlobal(
     template: TemplateStringsArray,
     ...args: Array<CSSInterpolation>

--- a/packages/css/types/index.d.ts
+++ b/packages/css/types/index.d.ts
@@ -15,7 +15,6 @@ export {
 } from './create-instance'
 
 export const flush: Emotion['flush']
-export const hydrate: Emotion['hydrate']
 export const cx: Emotion['cx']
 export const merge: Emotion['merge']
 export const getRegisteredStyles: Emotion['getRegisteredStyles']

--- a/packages/css/types/tests-create-instance.ts
+++ b/packages/css/types/tests-create-instance.ts
@@ -16,7 +16,6 @@ createEmotion({}, undefined as any)
 
 const {
   flush,
-  hydrate,
   cx,
   merge,
   getRegisteredStyles,
@@ -31,16 +30,6 @@ flush()
 
 // $ExpectError
 flush(undefined as any)
-
-hydrate([])
-hydrate(['123'])
-
-// $ExpectError
-hydrate()
-// $ExpectError
-hydrate([0])
-// $ExpectError
-hydrate([], undefined as any)
 
 cx()
 cx(true)

--- a/packages/css/types/tests.ts
+++ b/packages/css/types/tests.ts
@@ -1,6 +1,5 @@
 import {
   flush,
-  hydrate,
   cx,
   merge,
   getRegisteredStyles,
@@ -12,8 +11,6 @@ import {
 } from '@emotion/css'
 
 flush()
-
-hydrate(['css-123', 'css-456'])
 
 const cssObject = {
   height: 100,

--- a/packages/react/src/global.js
+++ b/packages/react/src/global.js
@@ -106,7 +106,7 @@ export let Global: React.AbstractComponent<
         sheet.before = cache.sheet.tags[0]
       }
       if (node !== null) {
-        sheet.rehydrate([node])
+        sheet.hydrate([node])
       }
       sheetRef.current = sheet
       return () => {

--- a/packages/server/src/create-instance/extract-critical.js
+++ b/packages/server/src/create-instance/extract-critical.js
@@ -6,7 +6,7 @@ const createExtractCritical = (cache: EmotionCache) => (html: string) => {
   // reconstruct css/rules/cache to pass
   let RGX = new RegExp(`${cache.key}-([a-zA-Z0-9-_]+)`, 'gm')
 
-  let o = { html, ids: [], css: '' }
+  let o = { html, css: '' }
   let match
   let ids = {}
   while ((match = RGX.exec(html)) !== null) {
@@ -17,14 +17,13 @@ const createExtractCritical = (cache: EmotionCache) => (html: string) => {
     }
   }
 
-  o.ids = Object.keys(cache.inserted).filter(id => {
+  Object.keys(cache.inserted).forEach(id => {
     if (
       (ids[id] !== undefined ||
         cache.registered[`${cache.key}-${id}`] === undefined) &&
       cache.inserted[id] !== true
     ) {
       o.css += cache.inserted[id]
-      return true
     }
   })
 

--- a/packages/server/test/index.test.js
+++ b/packages/server/test/index.test.js
@@ -63,6 +63,7 @@ describe('hydration', () => {
     emotionServer = require('@emotion/server')
 
     expect(emotion.cache.inserted).toEqual({})
+    // TODO: check how this test should be refactored
     emotion.hydrate(ids)
     const { Page1: NewPage1 } = getComponents(emotion, reactEmotion)
     renderToString(<NewPage1 />)

--- a/packages/sheet/README.md
+++ b/packages/sheet/README.md
@@ -61,7 +61,7 @@ This method inserts a single rule into the document. It **must** be a single rul
 
 This method will remove all style tags that were inserted into the document.
 
-#### rehydrate
+#### hydrate
 
 This method moves given style elements into sheet's container and put them into internal tags collection. It's can be used for SSRed styles.
 

--- a/packages/sheet/__tests__/index.js
+++ b/packages/sheet/__tests__/index.js
@@ -127,7 +127,7 @@ describe('StyleSheet', () => {
     head.removeChild(otherStyle)
   })
 
-  it('should be able to rehydrate styles', () => {
+  it('should be able to hydrate styles', () => {
     const fooStyle = document.createElement('style')
     fooStyle.textContent = '.foo { color: hotpink; }'
     const barStyle = document.createElement('style')
@@ -139,13 +139,13 @@ describe('StyleSheet', () => {
     const sheet = new StyleSheet(defaultOptions)
     expect(document.documentElement).toMatchSnapshot()
 
-    sheet.rehydrate([fooStyle, barStyle])
+    sheet.hydrate([fooStyle, barStyle])
     expect(document.documentElement).toMatchSnapshot()
 
     sheet.flush()
   })
 
-  it('should flush rehydrated styles', () => {
+  it('should flush hydrated styles', () => {
     const fooStyle = document.createElement('style')
     fooStyle.textContent = '.foo { color: hotpink; }'
     const barStyle = document.createElement('style')
@@ -156,7 +156,7 @@ describe('StyleSheet', () => {
 
     const sheet = new StyleSheet(defaultOptions)
 
-    sheet.rehydrate([fooStyle, barStyle])
+    sheet.hydrate([fooStyle, barStyle])
 
     sheet.insert(rule)
     sheet.insert(rule2)
@@ -166,7 +166,7 @@ describe('StyleSheet', () => {
     expect(document.documentElement).toMatchSnapshot()
   })
 
-  it('should correctly position rehydrated styles when used with `prepend` option', () => {
+  it('should correctly position hydrated styles when used with `prepend` option', () => {
     const head = safeQuerySelector('head')
     const otherStyle = document.createElement('style')
     otherStyle.setAttribute('id', 'other')
@@ -185,7 +185,7 @@ describe('StyleSheet', () => {
       prepend: true
     })
 
-    sheet.rehydrate([fooStyle, barStyle])
+    sheet.hydrate([fooStyle, barStyle])
     expect(document.documentElement).toMatchSnapshot()
 
     sheet.flush()

--- a/packages/sheet/src/index.js
+++ b/packages/sheet/src/index.js
@@ -95,7 +95,7 @@ export class StyleSheet {
     this.tags.push(tag)
   }
 
-  rehydrate(nodes: HTMLStyleElement[]) {
+  hydrate(nodes: HTMLStyleElement[]) {
     nodes.forEach(this._insertTag)
   }
 

--- a/packages/sheet/types/index.d.ts
+++ b/packages/sheet/types/index.d.ts
@@ -20,5 +20,5 @@ export class StyleSheet {
   constructor(options?: Options)
   insert(rule: string): void
   flush(): void
-  rehydrate(nodes: Array<HTMLStyleElement>): void
+  hydrate(nodes: Array<HTMLStyleElement>): void
 }


### PR DESCRIPTION
Seems like `hydrate` is not required as auto-hydration is happening at all times. 

Additionally, I've renamed `rehydrate` methods to `hydrate` as both we were using `hydrate` and ReactDOM is using the same verb.

This is just a quick PR - opening a discussion about this, if this is something we want to do then I'm going to add changeset and fix tests.