### PR TITLE
Add guidance for overriding style precedence

### DIFF
--- a/docs/css-prop.mdx
+++ b/docs/css-prop.mdx
@@ -245,6 +245,9 @@ The styles are concatenated together and inserted via `insertRule`.
 
 Relying on the css spec's ["Order of Appearance"](https://www.w3.org/TR/css-cascade-3/#cascade-order) rule, property values defined later (green) override those before it (red).
 
+If you find that emotion's default style precedence does not work for your use-case, you can override it with the [Class Names API]/docs/class-names). 
+
+
 ## Gotchas
 
 - If you include the plugin `babel-plugin-transform-react-inline-elements` in your `.babelrc` your styles will not be applied. The plugin is not compatible with the `css` prop.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Adds some guidance around how to override emotion's default style precedence. 
The solution I propose (I'm not 100% sure if this is the best way) is to use the `ClassNames` API. 

<!-- Why are these changes necessary? -->
**Why**: Found myself in a situation where the default style precedence was not suitable for my use-case, so i thought these docs might help the next person :) 

<!-- How were these changes implemented? -->
**How**: Added directly to the MD file via github

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
