### PR TITLE
Fix the links fixer

### DIFF
--- a/site/plugins/gatsby-remark-fix-links/index.js
+++ b/site/plugins/gatsby-remark-fix-links/index.js
@@ -8,7 +8,7 @@ module.exports = ({ markdownAST }) => {
         .replace(/\.mdx?(#.*)?$/, (match, hash) => {
           return hash || ''
         })
-        .replace(/^\/packages\//, '/docs/')
+        .replace(/^\/packages\//, '/docs/@emotion/')
     }
   })
 }


### PR DESCRIPTION
Supersedes https://github.com/emotion-js/emotion/pull/1432 . The fix is only working for the `next` branch as now **all** packages are within `@emotion/` scope so the rewrite that has to be done is very straightforward.