### PR TITLE
Fix v11 jsx factory type not allowing children when implictly in component type

### DIFF
--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -116,9 +116,8 @@ export namespace jsx {
     interface ElementChildrenAttribute
       extends ReactJSXElementChildrenAttribute {}
 
-    type LibraryManagedAttributes<C, P> = C extends React.ComponentType<infer T>
-      ? WithConditionalCSSProp<T>
-      : WithConditionalCSSProp<ReactJSXLibraryManagedAttributes<C, P>>
+    type LibraryManagedAttributes<C, P> = WithConditionalCSSProp<P> &
+      ReactJSXLibraryManagedAttributes<C, P>
 
     interface IntrinsicAttributes extends ReactJSXIntrinsicAttributes {}
     interface IntrinsicClassAttributes<T>

--- a/packages/react/types/tests.tsx
+++ b/packages/react/types/tests.tsx
@@ -177,4 +177,11 @@ const anim1 = keyframes`
   ;<CompWithoutProps css={{ backgroundColor: 'hotpink' }} />
 }
 
-;<React.Fragment>content</React.Fragment>
+{
+  // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/40993
+  // this is really problematic behaviour by @types/react IMO
+  // but it's what @types/react does so let's not break it.
+  const CompWithImplicitChildren: React.FC = () => null;
+  ;<CompWithImplicitChildren>content<div/></CompWithImplicitChildren>
+
+}

--- a/packages/react/types/tests.tsx
+++ b/packages/react/types/tests.tsx
@@ -183,5 +183,4 @@ const anim1 = keyframes`
   // but it's what @types/react does so let's not break it.
   const CompWithImplicitChildren: React.FC = () => null;
   ;<CompWithImplicitChildren>content<div/></CompWithImplicitChildren>
-
 }

--- a/packages/react/types/tests.tsx
+++ b/packages/react/types/tests.tsx
@@ -176,3 +176,5 @@ const anim1 = keyframes`
   // $ExpectError
   ;<CompWithoutProps css={{ backgroundColor: 'hotpink' }} />
 }
+
+;<React.Fragment>content</React.Fragment>


### PR DESCRIPTION
I tried out the definitions and found this problem(it caught some bugs in the repo I tested it on because of the conditional adding of the css prop + the css prop not being global 🎉)

Another thing related to this: We should probably omit the `css` prop from where styled-components and emotion v10 add it so this is compatible with styled-components and emotion v10(wouldn't work with both emotion v10 and s-c but having one of them + emotion v11 working together would be nice), I haven't looked into it but just wanted to raise it. (For the repo I was testing the types on, I deleted @emotion/core's global declarations to get around it)

I'm not 100% sure about the fix but I _think_ it's correct?