### PR TITLE
Added a new case to the stack.match() regex query 

### DIFF
--- a/.changeset/blue-pianos-smell.md
+++ b/.changeset/blue-pianos-smell.md
@@ -1,0 +1,5 @@
+---
+"@emotion/core": patch
+---
+
+Fixed label extraction from the stack traces in Chrome in certain scenarios. This has affected only development builds.

--- a/packages/core/src/jsx.js
+++ b/packages/core/src/jsx.js
@@ -154,7 +154,7 @@ export const jsx: typeof React.createElement = function(
     if (error.stack) {
       // chrome
       let match = error.stack.match(
-        /at (?:Object\.|)jsx.*\n\s+at ([A-Z][A-Za-z$]+) /
+        /at (?:Object\.|Module\.|)jsx.*\n\s+at ([A-Z][A-Za-z$]+) /
       )
       if (!match) {
         // safari and firefox


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Updated the regexp query that fails in certain cases.

<!-- Why are these changes necessary? -->
**Why**: Please see [this issue](https://github.com/emotion-js/emotion/issues/1947). The current regexp query fails to match in certain cases. 

<!-- How were these changes implemented? -->
**How**: We changed ```(?:Object\.|)``` to ```(?:Object\.|Module\.|)``` to support regexp matching when the function name is `Module.jsx` while maintaining backwards compatibility. 

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [ ] Code complete N/A

<!-- feel free to add additional comments -->
Thank you to @Andarist for helping me arrive on these changes!