### PR TITLE
adds translate to the list of valid props

### DIFF
--- a/.changeset/zany-cougars-shop.md
+++ b/.changeset/zany-cougars-shop.md
@@ -1,0 +1,5 @@
+---
+"@emotion/is-prop-valid": minor
+---
+
+`translate` got added to the list of the valid props.

--- a/packages/is-prop-valid/src/props.js
+++ b/packages/is-prop-valid/src/props.js
@@ -153,6 +153,7 @@ const props = {
   tabIndex: true,
   target: true,
   title: true,
+  translate: true,
   // Setting .type throws on non-<input> tags
   type: true,
   useMap: true,


### PR DESCRIPTION
**What**:

Adds `translate` to the list of valid props.

**Why**:

Because it's a valid HTML attribute:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L1759

... and we'd like to be able to use it.

**How**:

Just added it to the list. Pretty straight-forward.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests
- [x] Code complete
- [ ] Changeset N/A
