### PR TITLE
Improve regex for getting labels on Node.js

### DIFF
--- a/.changeset/six-geckos-battle.md
+++ b/.changeset/six-geckos-battle.md
@@ -1,0 +1,5 @@
+---
+"@emotion/core": patch
+---
+
+Fixed label extraction from the stack traces in node for components wrapped in `React.forwardRef`. This has affected only development builds.

--- a/packages/core/src/jsx.js
+++ b/packages/core/src/jsx.js
@@ -154,7 +154,7 @@ export const jsx: typeof React.createElement = function(
     if (error.stack) {
       // chrome
       let match = error.stack.match(
-        /at (?:Object\.|Module\.|)jsx.*\n\s+at ([A-Z][A-Za-z$]+) /
+        /at (?:Object\.|Module\.|)jsx.*\n\s+at (?:Object\.|)([A-Z][A-Za-z$]+) /
       )
       if (!match) {
         // safari and firefox


### PR DESCRIPTION
**What**:
I'm trying to fix some rehydration missmatch warnings using Chakra-UI (https://github.com/chakra-ui/chakra-ui/issues/1446 , subsequent comments are discussing some other issue).
I found that the root of the issue was that on the node side the stack trace looked like this:
```
Error
    at jsx (...../node_modules/@emotion/core/dist/core.cjs.dev.js:246:17)
    at jsx (...../node_modules/@chakra-ui/system/dist/cjs/jsx.js:57:20)
    at Object.Collapse [as render] (...../node_modules/@chakra-ui/collapse/dist/cjs/collapse.js:119:26)
    ...
```
and the regex for getting the label was missing the name.

I'm not sure why the stack trace looks like this on the server side but this case can be easily handled by tweaking the regex a bit. Please let me know if I'm missing something or if it's there a workaround to this.

<!-- Why are these changes necessary? -->
**Why**:

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

