### PR TITLE
Change some changeset bump types and do a few changeset cleanups

### DIFF
--- a/.changeset/cool-candles-lie.md
+++ b/.changeset/cool-candles-lie.md
@@ -1,5 +1,5 @@
 ---
-'@emotion/is-prop-valid': minor
+'@emotion/is-prop-valid': major
 ---
 
 Allow `isPropValid` to take any `PropertyKey` as an argument (instead of just `string`).

--- a/.changeset/long-apes-admire.md
+++ b/.changeset/long-apes-admire.md
@@ -1,8 +1,5 @@
 ---
-'@emotion/css': major
-'emotion-theming': major
-'@emotion/serialize': major
-'@emotion/styled-base': major
+'@emotion/react': major
 '@emotion/styled': major
 ---
 

--- a/.changeset/new-melons-draw.md
+++ b/.changeset/new-melons-draw.md
@@ -1,5 +1,0 @@
----
-'@emotion/serialize': patch
----
-
-Removed leftover `@emotion/react` import from type definition file.

--- a/.changeset/tender-steaks-melt.md
+++ b/.changeset/tender-steaks-melt.md
@@ -1,5 +1,0 @@
----
-'@emotion/serialize': patch
----
-
-Update `csstype` dependency.

--- a/.changeset/tricky-bears-hope.md
+++ b/.changeset/tricky-bears-hope.md
@@ -1,5 +1,5 @@
 ---
-'@emotion/serialize': minor
+'@emotion/serialize': major
 ---
 
-Reworked Interpolation-related types. Correct types should now be provided to all flavours of emotion.
+Reworked Interpolation-related types. Correct types should now be provided to all flavours of Emotion.


### PR DESCRIPTION
closes https://github.com/emotion-js/emotion/issues/1471

I've promoted `@emotion/is-prop-valid` & `@emotion/serialize` to v1. While this isn't technically necessary and doesn't really help #1471 anyhow as any, previously, minor bump will just have to be a major bump now so nothing changes in regards to possibly duplicated modules. However, I kinda have started to consider 0.x versions harmful - they require a slightly different mindset and when managing a monorepo I just don't want to focus on that. 

Changesets also do not differentiate them - so while major bumping you get a nice helpful message about what should be put into a changeset, but when minor bumping 0.x (which is a similar situation) you don't get any such message.

It also makes it less apparent that you might end up with weird situations when managing 2 release lines (master & next) such as the one reported here: https://github.com/emotion-js/emotion/issues/1974 . Making those packages v1+ doesn't, of course, solve this problem entirely - but I feel one is way more vigilant about cases like this when working with >=1.0 packages and thus it makes it harder to run into such problems.

I haven't touched some packages that are still at `0.x` stage as there is only a low chance for them to ever be upgraded - like `@emotion/memoize`. And even if we decide to upgrade them, for whatever reason, then it won't really matter if we upgrade them with a minor or with a major bump, both mean a breaking change for them, so I have concluded that it's not worth creating weird changelog entries right now just for a sake of upgrading them.

Also - I've cleaned up a few changeset files just a little bit. Just some random things I've spotted when reviewing existing changesets. More cleanups will be required before releasing v11.