### PR TITLE
Change the key of a global key (indicating the @emotion/react has been already loaded) to include the major version

### DIFF
--- a/.changeset/long-geckos-raise.md
+++ b/.changeset/long-geckos-raise.md
@@ -1,0 +1,5 @@
+---
+'@emotion/react': patch
+---
+
+Changed the key of the global flag that helps us identify that `@emotion/react` has been loaded more than once to include the current major version of `@emotion/react`.

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -1,4 +1,5 @@
 // @flow
+import pkg from '../package.json'
 export { withEmotionCache, CacheProvider } from './context'
 export { jsx } from './jsx'
 export { Global } from './global'
@@ -14,7 +15,7 @@ if (process.env.NODE_ENV !== 'production') {
 
   if (isBrowser && !isJest) {
     const globalContext = isBrowser ? window : global
-    const globalKey = '__EMOTION_REACT__'
+    const globalKey = `__EMOTION_REACT_${pkg.version.split('.')[0]}__`
     if (globalContext[globalKey]) {
       console.warn(
         'You are loading @emotion/react when it is already loaded. Running ' +


### PR DESCRIPTION
In the future, it should be possible to upgrade your own code to Emotion 12 but still use, for example, Storybook based on Emotion 11 without this warning popping up. Actually there might be other problems with such setup and it might not work for some reason (but hopefully it would) - don't want to focus on unknown problems, because I can't imagine how this would potentially break on my own, so this is the least we can do right now until other issues arise in the future.