### PR TITLE
Remove all sourcemaps

### DIFF
--- a/.changeset/lazy-elephants-stare.md
+++ b/.changeset/lazy-elephants-stare.md
@@ -1,0 +1,6 @@
+---
+'@emotion/core': patch
+'@emotion/serialize': patch
+---
+
+Fix to what location generated source maps are pointing in case of composed styles.

--- a/packages/serialize/src/index.js
+++ b/packages/serialize/src/index.js
@@ -332,7 +332,7 @@ let labelPattern = /label:\s*([^\s;\n{]+)\s*;/g
 
 let sourceMapPattern
 if (process.env.NODE_ENV !== 'production') {
-  sourceMapPattern = /\/\*#\ssourceMappingURL=data:application\/json;\S+\s+\*\//
+  sourceMapPattern = /\/\*#\ssourceMappingURL=data:application\/json;\S+\s+\*\//g
 }
 
 // this is the cursor for keyframes


### PR DESCRIPTION
**What**: This change removes _all_ sourcemaps from rendered CSS during serialization, (as opposed to just the first one). This seems to happen when composing serialized styles together. 

<!-- Why are these changes necessary? -->
**Why**:  Here's the (very contrived) test case:

```jsx
test('Emotion sourcemaps composition', () => {
  const bgColor = fill => css({ backgroundColor: fill });

  const Box = styled.div(
    props => ({
      '@media (max-width: 500px)': bgColor(props.fill[0]),
      '@media (min-width: 501px)': bgColor(props.fill[1]),
    }),
    props => ({ width: props.size[0], height: props.size[1] }),
  );

  const { container } = render(<Box fill={['blue', 'green']} size={[20, 30]} />);

  expect(container.firstChild).toMatchSnapshot();
});
```

Without sourcemaps:
```css
.emotion-0 {
  width: 20px;
  height: 30px;
}

@media (max-width:500px) {
  .emotion-0 {
    background-color: blue;
  }
}

@media (min-width:501px) {
  .emotion-0 {
    background-color: green;
  }
}
```

With sourcemaps:

```css
@media (max-width:500px) {
  .emotion-0 {
    background-color: blue;
  }

@media (min-width:501px) {
    .emotion-0 {
      background-color: green;
      width: 20px;
      height: 30px;
    }
}
}
```

<!-- How were these changes implemented? -->
**How**: This is a backport of a fix available in `next` by simply cherry-picking 5c55fd1. 

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests
- [x] Code complete 
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

I'm not sure how to add this test case to the test suite. I'd be happy to add it if someone could suggest a strategy.

