### PR TITLE
Fixed an issue with type for as prop not being available for prebound components

### DIFF
--- a/.changeset/lemon-bobcats-turn.md
+++ b/.changeset/lemon-bobcats-turn.md
@@ -1,0 +1,5 @@
+---
+'@emotion/styled': patch
+---
+
+Fixed an issue with typing for the `as` prop not being provided to components created using component factories available on the `styled` factory (e.g. `styled.div`).

--- a/packages/styled/types/index.d.ts
+++ b/packages/styled/types/index.d.ts
@@ -17,7 +17,10 @@ export {
 
 export type StyledTags = {
   [Tag in keyof JSX.IntrinsicElements]: CreateStyledComponent<
-    { theme?: Theme },
+    {
+      theme?: Theme
+      as?: React.ElementType
+    },
     JSX.IntrinsicElements[Tag]
   >
 }

--- a/packages/styled/types/tests.tsx
+++ b/packages/styled/types/tests.tsx
@@ -165,3 +165,14 @@ const Input5 = styled.input`
   const Z = styled(Y)()
   ;<Z>No excessive instantiation</Z>
 }
+
+{
+  const StyledWithAs = styled.div`
+    display: flex;
+  `
+  const Section = styled.section`
+    color: hotpink;
+  `
+  ;<StyledWithAs as="section" />
+  ;<StyledWithAs as={Section} />
+}

--- a/packages/styled/types/tests.tsx
+++ b/packages/styled/types/tests.tsx
@@ -3,20 +3,26 @@ import styled from '@emotion/styled'
 
 // This file uses the same Theme declaration from tests-base.tsx
 
-// $ExpectType CreateStyledComponent<{ theme?: Theme | undefined; }, DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>>
-styled.a
-// $ExpectType CreateStyledComponent<{ theme?: Theme | undefined; }, DetailedHTMLProps<HTMLAttributes<HTMLBodyElement>, HTMLBodyElement>>
-styled.body
-// $ExpectType CreateStyledComponent<{ theme?: Theme | undefined; }, DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>>
-styled.div
-// $ExpectType CreateStyledComponent<{ theme?: Theme | undefined; }, SVGProps<SVGSVGElement>>
-styled.svg
+{
+  const Anchor = styled.a``
+  ;<Anchor href="test" />
+  const Body = styled.body``
+  ;<Body />
+  const Div = styled.div``
+  ;<Div onClick={() => {}} />
+  const Svg = styled.svg``
+  ;<Svg color="hotpink" />
+}
 
 {
   styled.div<{ bar: string }>`
     color: ${props => {
-      // $ExpectType { theme?: Theme | undefined; } & ClassAttributes<HTMLDivElement> & HTMLAttributes<HTMLDivElement> & { bar: string; } & { theme: Theme; }
-      props
+      // $ExpectType Theme
+      props.theme
+      // $ExpectType string
+      props.bar
+      // $ExpectType string | undefined
+      props.dir
 
       return {}
     }};


### PR DESCRIPTION
fixes #1992

This is the same type as provided here: https://github.com/emotion-js/emotion/blob/8db5c326b7d55304797346f160a05bc23cf4169f/packages/styled/types/base.d.ts#L112