### PR TITLE
Update TypeScript definition of EmotionCache (#1990)

### DIFF
--- a/.changeset/honest-terms-mate.md
+++ b/.changeset/honest-terms-mate.md
@@ -2,4 +2,4 @@
 '@emotion/utils': patch
 ---
 
-Updated TypeScript definition of EmotionCache; replace stylis fn with insert
+Fixed TypeScript definition of the `EmotionCache` by replacing the non-existent `stylis` method with `insert` that is available at runtime.

--- a/.changeset/honest-terms-mate.md
+++ b/.changeset/honest-terms-mate.md
@@ -1,0 +1,5 @@
+---
+'@emotion/utils': patch
+---
+
+Updated TypeScript definition of EmotionCache; replace stylis fn with insert

--- a/packages/utils/types/index.d.ts
+++ b/packages/utils/types/index.d.ts
@@ -15,7 +15,6 @@ export interface StyleSheet {
 }
 
 export interface EmotionCache {
-  stylis(key: string, value: string): Array<string>
   inserted: {
     [key: string]: string | true
   }
@@ -24,6 +23,12 @@ export interface EmotionCache {
   key: string
   compat?: true
   nonce?: string
+  insert(
+    selector: string,
+    serialized: SerializedStyles,
+    sheet: StyleSheet,
+    shouldCache: boolean
+  ): string | void
 }
 
 export interface SerializedStyles {


### PR DESCRIPTION
Replaced `stylis` function with `insert` function, following
the Flow definition.

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Updating TypeScript definition of EmotionCache

**Why**:

See issue #1990 

**How**:

Matching existing Flow definition.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Code complete N/A
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
