### PR TITLE
RFC: Expose interface for custom CSSObject declaration

### DIFF
--- a/.changeset/early-jokes-applaud.md
+++ b/.changeset/early-jokes-applaud.md
@@ -1,0 +1,5 @@
+---
+'@emotion/serialize': minor
+---
+
+Add interface for custom CSSObject declaration

--- a/docs/typescript.mdx
+++ b/docs/typescript.mdx
@@ -310,6 +310,28 @@ declare module '@emotion/react' {
 }
 ```
 
+### Define a CSS Interface
+
+By default, the interface of style objects is based on
+[CSSType](https://github.com/frenic/csstype). This library provides type safety where possible without
+restricting valid CSS values.
+
+If you want to constrain which styles are globally allowed in your project, you can provide your own
+`CustomCSSObject` interface:
+
+_emotion.d.ts_
+
+```typescript
+import "@emotion/serialize";
+
+declare module "@emotion/serialize" {
+  export interface CustomCSSObject {
+    color: "red" | "green" | "blue";
+  }
+}
+```
+
+
 ### TypeScript < 2.9
 
 For Typescript <2.9, the generic type version only works with object styles due to https://github.com/Microsoft/TypeScript/issues/11947.

--- a/packages/serialize/types/index.d.ts
+++ b/packages/serialize/types/index.d.ts
@@ -34,10 +34,16 @@ export interface CSSOthersObject {
   [propertiesName: string]: CSSInterpolation
 }
 
-export interface CSSObject
+export interface DefaultCSSObject
   extends CSSPropertiesWithMultiValues,
     CSSPseudos,
     CSSOthersObject {}
+
+export interface CustomCSSObject {}
+
+export type CSSObject = {} extends CustomCSSObject
+  ? DefaultCSSObject
+  : CustomCSSObject
 
 export interface ComponentSelector {
   __emotion_styles: any

--- a/packages/serialize/types/tslint.json
+++ b/packages/serialize/types/tslint.json
@@ -4,6 +4,7 @@
     "array-type": [true, "generic"],
     "semicolon": false,
     "no-null-undefined-union": false,
-    "callable-types": false
+    "callable-types": false,
+    "no-empty-interface": false
   }
 }


### PR DESCRIPTION
**What**:

Modifications to `@emotion/serialize/types` so that the user may specify a custom `CSSObject` declaration in preference to the default.

**Why**:
- To allow users to constrain what styles may be applied at any leaf in their React tree
- To allow users to opt-out of arbitrary CSS selectors etc

**How**:
The existing `CSSObject` is renamed to `DefaultCSSObject`. A new, empty interface named `CustomCSSObject` is added. Finally, a new type named `CSSObject` is exported that takes the value of `CustomCSSObject` is it's provided, otherwise `DefaultCSSObject`. Users can augment `CustomCSSObject` in their project to override the value of `CSSObject` globally. This shouldn't have any impact on users who don't provide their own declaration.

**Checklist**:
- [x] Documentation
- [ ] Tests
- [x] Code complete
- [x] Changeset

I'm not sure if/how this can be tested without splitting `dtslint` into two stages, since declaring a `CustomCSSObject` anywhere changes the value globally. Feedback appreciated!