### PR TITLE
Fixed an issue with multiple Emotion caches moving SSRed styles to head at their initialization times

### DIFF
--- a/.changeset/gentle-owls-chew.md
+++ b/.changeset/gentle-owls-chew.md
@@ -1,0 +1,5 @@
+---
+'@emotion/sheet': patch
+---
+
+Generated style elements got `data-s="1"` attribute so `@emotion/cache` can recognize them as being already owned by another Emotion copy to avoid messing up existing style elements when initializing a new copy.

--- a/.changeset/proud-bats-cheer.md
+++ b/.changeset/proud-bats-cheer.md
@@ -1,0 +1,5 @@
+---
+'@emotion/cache': patch
+---
+
+Fixed an issue with Emotion messing up style elements already processed by previously initialized Emotion copy.

--- a/packages/cache/__tests__/__snapshots__/hydration.js.snap
+++ b/packages/cache/__tests__/__snapshots__/hydration.js.snap
@@ -5,6 +5,7 @@ exports[`it works 1`] = `
   <head>
     <style
       data-emotion="css 1lrxbo5"
+      data-s=""
     >
       .css-1lrxbo5{color:hotpink;}
     </style>
@@ -18,6 +19,7 @@ exports[`rehydrated styles to head can be flushed 1`] = `
   <head>
     <style
       data-emotion="emo 1lrxbo5"
+      data-s=""
     >
       .emo-1lrxbo5{color:hotpink;}
     </style>

--- a/packages/cache/src/index.js
+++ b/packages/cache/src/index.js
@@ -41,7 +41,6 @@ let getServerStylisCache = isBrowser
     )
 
 const defaultStylisPlugins = [prefixer]
-let movedStyles = false
 
 let createCache = (options: Options): EmotionCache => {
   let key = options.key
@@ -53,14 +52,15 @@ let createCache = (options: Options): EmotionCache => {
     )
   }
 
-  if (isBrowser && !movedStyles && key === 'css') {
-    movedStyles = true
-
-    const ssrStyles = document.querySelectorAll(`style[data-emotion]`)
+  if (isBrowser && key === 'css') {
+    const ssrStyles = document.querySelectorAll(
+      `style[data-emotion]:not([data-s])`
+    )
     // get SSRed styles out of the way of React's hydration
     // document.head is a safe place to move them to
     Array.prototype.forEach.call(ssrStyles, (node: HTMLStyleElement) => {
       ;((document.head: any): HTMLHeadElement).appendChild(node)
+      node.setAttribute('data-s', '')
     })
   }
 

--- a/packages/css/test/__snapshots__/sheet.dom.test.js.snap
+++ b/packages/css/test/__snapshots__/sheet.dom.test.js.snap
@@ -6,6 +6,7 @@ exports[`sheet tags 1`] = `
 Array [
   <style
     data-emotion="css"
+    data-s=""
   >
     
   </style>,

--- a/packages/react/__tests__/__snapshots__/at-import.js.snap
+++ b/packages/react/__tests__/__snapshots__/at-import.js.snap
@@ -4,11 +4,13 @@ exports[`basic 1`] = `
 <head>
   <style
     data-emotion="css-global"
+    data-s=""
   >
     
   </style>
   <style
     data-emotion="css"
+    data-s=""
   >
     
   </style>
@@ -31,6 +33,7 @@ exports[`basic 4`] = `
 <head>
   <style
     data-emotion="css"
+    data-s=""
   >
     
   </style>

--- a/packages/react/__tests__/__snapshots__/global-with-theme.js.snap
+++ b/packages/react/__tests__/__snapshots__/global-with-theme.js.snap
@@ -5,12 +5,14 @@ exports[`array 1`] = `
   <head>
     <style
       data-emotion="css-global"
+      data-s=""
     >
       
       html{background-color:green;}
     </style>
     <style
       data-emotion="css-global"
+      data-s=""
     >
       
       html{font-size:16px;}
@@ -40,6 +42,7 @@ exports[`basic 1`] = `
   <head>
     <style
       data-emotion="css-global"
+      data-s=""
     >
       
       html{background-color:green;}

--- a/packages/react/__tests__/__snapshots__/global.js.snap
+++ b/packages/react/__tests__/__snapshots__/global.js.snap
@@ -4,42 +4,49 @@ exports[`basic 1`] = `
 <head>
   <style
     data-emotion="css"
+    data-s=""
   >
     
     .css-animation-ocj8pk{}
   </style>
   <style
     data-emotion="css"
+    data-s=""
   >
     
     @-webkit-keyframes animation-ocj8pk{from,to{color:green;}50%{color:hotpink;}}
   </style>
   <style
     data-emotion="css"
+    data-s=""
   >
     
     @keyframes animation-ocj8pk{from,to{color:green;}50%{color:hotpink;}}
   </style>
   <style
     data-emotion="css-global"
+    data-s=""
   >
     
     @import url('something.com/file.css');
   </style>
   <style
     data-emotion="css-global"
+    data-s=""
   >
     
     html{background-color:hotpink;}
   </style>
   <style
     data-emotion="css-global"
+    data-s=""
   >
     
     h1{-webkit-animation:animation-ocj8pk 1s;animation:animation-ocj8pk 1s;}
   </style>
   <style
     data-emotion="css-global"
+    data-s=""
   >
     
     @font-face{font-family:some-name;}
@@ -59,18 +66,21 @@ exports[`basic 3`] = `
 <head>
   <style
     data-emotion="css"
+    data-s=""
   >
     
     .css-animation-ocj8pk{}
   </style>
   <style
     data-emotion="css"
+    data-s=""
   >
     
     @-webkit-keyframes animation-ocj8pk{from,to{color:green;}50%{color:hotpink;}}
   </style>
   <style
     data-emotion="css"
+    data-s=""
   >
     
     @keyframes animation-ocj8pk{from,to{color:green;}50%{color:hotpink;}}
@@ -90,12 +100,14 @@ exports[`updating more than 1 global rule 1`] = `
 <head>
   <style
     data-emotion="global-multiple-rules-global"
+    data-s=""
   >
     
     body{background:white;}
   </style>
   <style
     data-emotion="global-multiple-rules-global"
+    data-s=""
   >
     
     div{color:black;}
@@ -107,12 +119,14 @@ exports[`updating more than 1 global rule 2`] = `
 <head>
   <style
     data-emotion="global-multiple-rules-global"
+    data-s=""
   >
     
     body{background:gray;}
   </style>
   <style
     data-emotion="global-multiple-rules-global"
+    data-s=""
   >
     
     div{color:white;}

--- a/packages/react/__tests__/__snapshots__/globals-are-the-worst.js.snap
+++ b/packages/react/__tests__/__snapshots__/globals-are-the-worst.js.snap
@@ -5,12 +5,14 @@ exports[`specificity with globals 1`] = `
   <head>
     <style
       data-emotion="css-global"
+      data-s=""
     >
       
       .some-class{color:green;}
     </style>
     <style
       data-emotion="css"
+      data-s=""
     >
       
       .css-1ndtvd6{color:hotpink;}
@@ -40,12 +42,14 @@ exports[`specificity with globals 2`] = `
   <head>
     <style
       data-emotion="css-global"
+      data-s=""
     >
       
       .some-class{color:yellow;}
     </style>
     <style
       data-emotion="css"
+      data-s=""
     >
       
       .css-1ndtvd6{color:hotpink;}

--- a/packages/react/__tests__/compat/__snapshots__/browser.js.snap
+++ b/packages/react/__tests__/compat/__snapshots__/browser.js.snap
@@ -5,6 +5,7 @@ exports[`composition works from old emotion css calls 1`] = `
   <head>
     <style
       data-emotion="css"
+      data-s=""
     >
       
       .css-ulmpz9{color:green;}

--- a/packages/react/__tests__/rehydration.js
+++ b/packages/react/__tests__/rehydration.js
@@ -63,3 +63,106 @@ test("cache created in render doesn't cause a hydration mismatch", () => {
   expect((console.error: any).mock.calls).toMatchInlineSnapshot(`Array []`)
   expect((console.warn: any).mock.calls).toMatchInlineSnapshot(`Array []`)
 })
+
+test('initializing another Emotion instance should not move already moved styles elements', () => {
+  safeQuerySelector('head').innerHTML = '<div id="style-container"></div>'
+  safeQuerySelector('body').innerHTML = [
+    '<div id="root">',
+    '<style data-emotion="stl 1pdkrhd">.stl-1pdkrhd-App {color: hotpink;}</style>',
+    '<div class="stl-1pdkrhd-App">Hello world!</div>',
+    '</div>'
+  ].join('')
+
+  resetAllModules()
+
+  const cache = createCache({
+    key: 'stl',
+    container: safeQuerySelector('#style-container')
+  })
+
+  function App() {
+    return (
+      <CacheProvider value={cache}>
+        <div
+          css={css`
+            color: hotpink;
+          `}
+        >
+          {'Hello world!'}
+        </div>
+      </CacheProvider>
+    )
+  }
+
+  ReactDOM.hydrate(<App />, safeQuerySelector('#root'))
+
+  resetAllModules()
+
+  expect(safeQuerySelector('head')).toMatchInlineSnapshot(`
+    <head>
+      <div
+        id="style-container"
+      >
+        <style
+          data-emotion="stl 1pdkrhd"
+          data-s=""
+        >
+          .stl-1pdkrhd-App {color: hotpink;}
+        </style>
+        <style
+          data-emotion="stl"
+          data-s=""
+        >
+          
+          .stl-1pdkrhd-App{color:hotpink;}
+        </style>
+      </div>
+    </head>
+  `)
+})
+
+test('initializing another Emotion instance should not move already moved styles elements', () => {
+  safeQuerySelector('head').innerHTML = '<div id="style-container"></div>'
+  safeQuerySelector('body').innerHTML = '<div id="root"></div>'
+
+  resetAllModules()
+
+  const cache = createCache({
+    key: 'stl',
+    container: safeQuerySelector('#style-container')
+  })
+
+  function App() {
+    return (
+      <CacheProvider value={cache}>
+        <div
+          css={css`
+            color: hotpink;
+          `}
+        >
+          {'Hello world!'}
+        </div>
+      </CacheProvider>
+    )
+  }
+
+  ReactDOM.render(<App />, safeQuerySelector('#root'))
+
+  resetAllModules()
+
+  expect(safeQuerySelector('head')).toMatchInlineSnapshot(`
+    <head>
+      <div
+        id="style-container"
+      >
+        <style
+          data-emotion="stl"
+          data-s=""
+        >
+          
+          .stl-1pdkrhd-App{color:hotpink;}
+        </style>
+      </div>
+    </head>
+  `)
+})

--- a/packages/sheet/__tests__/__snapshots__/index.js.snap
+++ b/packages/sheet/__tests__/__snapshots__/index.js.snap
@@ -5,12 +5,14 @@ exports[`StyleSheet should accept prepend option 1`] = `
   <head>
     <style
       data-emotion=""
+      data-s=""
     >
       
       html { color: hotpink; }
     </style>
     <style
       data-emotion=""
+      data-s=""
     >
       
       * { box-sizing: border-box; }
@@ -79,12 +81,14 @@ exports[`StyleSheet should flush hydrated styles 1`] = `
     </style>
     <style
       data-emotion=""
+      data-s=""
     >
       
       html { color: hotpink; }
     </style>
     <style
       data-emotion=""
+      data-s=""
     >
       
       * { box-sizing: border-box; }
@@ -106,6 +110,7 @@ exports[`StyleSheet should insert a rule into the DOM when not in speedy 1`] = `
   <head>
     <style
       data-emotion=""
+      data-s=""
     >
       
       html { color: hotpink; }
@@ -120,6 +125,7 @@ exports[`StyleSheet should insert a rule with insertRule when in speedy 1`] = `
   <head>
     <style
       data-emotion=""
+      data-s=""
     >
       
     </style>
@@ -158,6 +164,7 @@ exports[`StyleSheet should remove its style elements from the document when flus
   <head>
     <style
       data-emotion=""
+      data-s=""
     >
       
       html { color: hotpink; }
@@ -179,6 +186,7 @@ exports[`StyleSheet should set the data-emotion attribute to the key option 1`] 
   <head>
     <style
       data-emotion="some-key"
+      data-s=""
     >
       
       html { color: hotpink; }
@@ -195,6 +203,7 @@ exports[`StyleSheet should use the container option instead of document.head to 
     <div>
       <style
         data-emotion=""
+        data-s=""
       >
         
         html { color: hotpink; }

--- a/packages/sheet/src/index.js
+++ b/packages/sheet/src/index.js
@@ -57,6 +57,7 @@ function createStyleElement(options: {
     tag.setAttribute('nonce', options.nonce)
   }
   tag.appendChild(document.createTextNode(''))
+  tag.setAttribute('data-s', '')
   return tag
 }
 

--- a/packages/styled/test/__snapshots__/source-map.test.js.snap
+++ b/packages/styled/test/__snapshots__/source-map.test.js.snap
@@ -5,6 +5,7 @@ exports[`inserts source map 1`] = `
   <head>
     <style
       data-emotion="css"
+      data-s=""
     >
       
       .css-1igngve-Comp{color:hotpink;}/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInNvdXJjZS1tYXAudGVzdC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFNdUIiLCJmaWxlIjoic291cmNlLW1hcC50ZXN0LmpzIiwic291cmNlc0NvbnRlbnQiOlsiLy8gQGZsb3dcbmltcG9ydCBSZWFjdCBmcm9tICdyZWFjdCdcbmltcG9ydCBzdHlsZWQgZnJvbSAnQGVtb3Rpb24vc3R5bGVkJ1xuaW1wb3J0IHJlbmRlcmVyIGZyb20gJ3JlYWN0LXRlc3QtcmVuZGVyZXInXG5cbnRlc3QoJ2luc2VydHMgc291cmNlIG1hcCcsICgpID0+IHtcbiAgbGV0IENvbXAgPSBzdHlsZWQuZGl2YFxuICAgIGNvbG9yOiBob3RwaW5rO1xuICBgXG4gIHJlbmRlcmVyLmNyZWF0ZSg8Q29tcCAvPilcbiAgZXhwZWN0KGRvY3VtZW50LmRvY3VtZW50RWxlbWVudCkudG9NYXRjaFNuYXBzaG90KClcbn0pXG4iXX0= */


### PR DESCRIPTION
fixes https://github.com/emotion-js/emotion/issues/1945

If this gets accepted then I'll add changeset and some basic tests. Personally, I'm not super fond of this - I would much rather like to remove this initialization side-effect altogether, but 🤷‍♂️ 

This ensures that no styles are moved twice by adding a marker data attribute to:
- moved styles
- all styles inserted at runtime