### PR TITLE
call useContext at the top level

### DIFF
--- a/packages/primitives-core/src/styled.js
+++ b/packages/primitives-core/src/styled.js
@@ -44,12 +44,13 @@ export function createStyled(
       // $FlowFixMe
       let Styled = React.forwardRef((props, ref) => {
         let mergedProps = props
+        const theme = React.useContext(ThemeContext)
         if (props.theme == null) {
           mergedProps = {}
           for (let key in props) {
             mergedProps[key] = props[key]
           }
-          mergedProps.theme = React.useContext(ThemeContext)
+          mergedProps.theme = theme
         }
 
         let newProps = {}

--- a/packages/styled/src/base.js
+++ b/packages/styled/src/base.js
@@ -77,12 +77,13 @@ let createStyled: CreateStyled = (tag: any, options?: StyledOptions) => {
         let className = ''
         let classInterpolations = []
         let mergedProps = props
+        const theme = React.useContext(ThemeContext)
         if (props.theme == null) {
           mergedProps = {}
           for (let key in props) {
             mergedProps[key] = props[key]
           }
-          mergedProps.theme = React.useContext(ThemeContext)
+          mergedProps.theme = theme
         }
 
         if (typeof props.className === 'string') {


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Refactor `React.useContext` hook calls to be called at the top level of the component (outside of an if statement).

<!-- Why are these changes necessary? -->
**Why**:
Follow react's [hooks rules](https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level) to avoid potential bugs. As far as I understand in this scenario it's very unlikely to actually cause any problems, but thought it might be a good practice. 

<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete
- [ ] Changeset (haven't run it, not sure if necessary to create a release)<!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
