### PR TITLE
[TypeScript] Fix that some functions unnecessarily require their  arguments to inc…

### DIFF
--- a/.changeset/serious-melons-sip.md
+++ b/.changeset/serious-melons-sip.md
@@ -1,0 +1,6 @@
+---
+'@emotion/native': patch
+'@emotion/styled': patch
+---
+
+Fixed TypeScript false positive with `styled` components

--- a/.changeset/serious-melons-sip.md
+++ b/.changeset/serious-melons-sip.md
@@ -1,6 +1,0 @@
----
-'@emotion/native': patch
-'@emotion/styled': patch
----
-
-Fixed TypeScript false positive with `styled` components

--- a/.changeset/strong-laws-draw.md
+++ b/.changeset/strong-laws-draw.md
@@ -1,0 +1,10 @@
+---
+'@emotion/cache': patch
+'@emotion/css': patch
+'@emotion/native': patch
+'@emotion/react': patch
+'@emotion/serialize': patch
+'@emotion/utils': patch
+---
+
+Fixed TypeScript issue where functions that accepted `Array`s as arguments did not accept `ReadonlyArray`s.

--- a/packages/cache/types/index.d.ts
+++ b/packages/cache/types/index.d.ts
@@ -7,9 +7,9 @@ export { EmotionCache }
 export interface StylisElement {
   type: string
   value: string
-  props: Array<string>
+  props: ReadonlyArray<string>
   root: StylisElement | null
-  children: Array<StylisElement>
+  children: ReadonlyArray<StylisElement>
   line: number
   column: number
   length: number
@@ -18,20 +18,20 @@ export interface StylisElement {
 export type StylisPluginCallback = (
   element: StylisElement,
   index: number,
-  children: Array<StylisElement>,
+  children: ReadonlyArray<StylisElement>,
   callback: StylisPluginCallback
 ) => string | undefined
 
 export type StylisPlugin = (
   element: StylisElement,
   index: number,
-  children: Array<StylisElement>,
+  children: ReadonlyArray<StylisElement>,
   callback: StylisPluginCallback
 ) => string | undefined
 
 export interface Options {
   nonce?: string
-  stylisPlugins?: Array<StylisPlugin>
+  stylisPlugins?: ReadonlyArray<StylisPlugin>
   key: string
   container?: HTMLElement
   speedy?: boolean

--- a/packages/css/types/create-instance.d.ts
+++ b/packages/css/types/create-instance.d.ts
@@ -14,7 +14,7 @@ export {
 
 export { EmotionCache, Options }
 
-export interface ArrayClassNamesArg extends Array<ClassNamesArg> {}
+export interface ArrayClassNamesArg extends ReadonlyArray<ClassNamesArg> {}
 export type ClassNamesArg =
   | undefined
   | null
@@ -32,7 +32,7 @@ export interface Emotion {
   css(...args: Array<CSSInterpolation>): string
   cx(...classNames: Array<ClassNamesArg>): string
   flush(): void
-  hydrate(ids: Array<string>): void
+  hydrate(ids: ReadonlyArray<string>): void
   injectGlobal(
     template: TemplateStringsArray,
     ...args: Array<CSSInterpolation>
@@ -47,7 +47,7 @@ export interface Emotion {
   cache: EmotionCache
   merge(className: string): string
   getRegisteredStyles(
-    registeredStyles: Array<string>,
+    registeredStyles: ReadonlyArray<string>,
     className: string
   ): string
 }

--- a/packages/native/types/base.d.ts
+++ b/packages/native/types/base.d.ts
@@ -30,7 +30,7 @@ export type ObjectInterpolation<
 
 export interface ArrayCSSInterpolation<
   StyleType extends ReactNativeStyle = ReactNativeStyle
-> extends Array<CSSInterpolation<StyleType>> {}
+> extends ReadonlyArray<CSSInterpolation<StyleType>> {}
 
 export type CSSInterpolation<
   StyleType extends ReactNativeStyle = ReactNativeStyle
@@ -39,7 +39,7 @@ export type CSSInterpolation<
 export interface ArrayInterpolation<
   MergedProps,
   StyleType extends ReactNativeStyle = ReactNativeStyle
-> extends Array<Interpolation<MergedProps, StyleType>> {}
+> extends ReadonlyArray<Interpolation<MergedProps, StyleType>> {}
 
 export interface FunctionInterpolation<
   MergedProps,
@@ -101,8 +101,12 @@ export interface CreateStyledComponent<
 > {
   /**
    * @typeparam AdditionalProps  Additional props to add to your styled component
+   * @typeparam InferredAdditionalProps  Should not be explicitly specified
    */
-  <AdditionalProps extends {} = {}>(
+  <
+    AdditionalProps extends {} = {},
+    InferredAdditionalProps extends AdditionalProps = AdditionalProps
+  >(
     ...styles: ArrayInterpolation<
       ComponentProps &
         SpecificComponentProps &
@@ -110,19 +114,23 @@ export interface CreateStyledComponent<
       StyleType
     >
   ): StyledComponent<
-    ComponentProps & AdditionalProps,
+    ComponentProps & InferredAdditionalProps,
     SpecificComponentProps,
     JSXProps
   >
   /**
    * @typeparam AdditionalProps  Additional props to add to your styled component
+   * @typeparam InferredAdditionalProps  Should not be explicitly specified
    */
-  <AdditionalProps extends {} = {}>(
+  <
+    AdditionalProps extends {} = {},
+    InferredAdditionalProps extends AdditionalProps = AdditionalProps
+  >(
     template: TemplateStringsArray,
     ...styles: ArrayInterpolation<
       ComponentProps &
         SpecificComponentProps &
-        AdditionalProps & { theme: Theme },
+        InferredAdditionalProps & { theme: Theme },
       StyleType
     >
   ): StyledComponent<

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -68,7 +68,7 @@ export function keyframes(
 ): Keyframes
 export function keyframes(...args: Array<CSSInterpolation>): Keyframes
 
-export interface ArrayClassNamesArg extends Array<ClassNamesArg> {}
+export interface ArrayClassNamesArg extends ReadonlyArray<ClassNamesArg> {}
 export type ClassNamesArg =
   | undefined
   | null

--- a/packages/react/types/tests-css.tsx
+++ b/packages/react/types/tests-css.tsx
@@ -32,8 +32,8 @@ css`
 // $ExpectError
 css(() => 'height: 300px;')
 
-// $ExpectError
 css`
   position: relative;
-  flexgrow: ${() => 20};
+  flexgrow: ${// $ExpectError
+  () => 20};
 `

--- a/packages/react/types/tests-css.tsx
+++ b/packages/react/types/tests-css.tsx
@@ -32,8 +32,11 @@ css`
 // $ExpectError
 css(() => 'height: 300px;')
 
+// prettier-ignore
 css`
   position: relative;
-  flexgrow: ${// $ExpectError
-  () => 20};
+  flexgrow: ${
+    // $ExpectError
+    () => 20
+  };
 `

--- a/packages/serialize/types/index.d.ts
+++ b/packages/serialize/types/index.d.ts
@@ -10,12 +10,13 @@ export type CSSProperties = CSS.PropertiesFallback<number | string>
 export type CSSPropertiesWithMultiValues = {
   [K in keyof CSSProperties]:
     | CSSProperties[K]
-    | Array<Extract<CSSProperties[K], string>>
+    | ReadonlyArray<Extract<CSSProperties[K], string>>
 }
 
 export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject }
 
-export interface ArrayCSSInterpolation extends Array<CSSInterpolation> {}
+export interface ArrayCSSInterpolation
+  extends ReadonlyArray<CSSInterpolation> {}
 
 export type InterpolationPrimitive =
   | null
@@ -51,7 +52,7 @@ export type Keyframes = {
 } & string
 
 export interface ArrayInterpolation<Props>
-  extends Array<Interpolation<Props>> {}
+  extends ReadonlyArray<Interpolation<Props>> {}
 
 export interface FunctionInterpolation<Props> {
   (props: Props): Interpolation<Props>
@@ -63,7 +64,7 @@ export type Interpolation<Props> =
   | FunctionInterpolation<Props>
 
 export function serializeStyles<Props>(
-  args: Array<TemplateStringsArray | Interpolation<Props>>,
+  args: ReadonlyArray<TemplateStringsArray | Interpolation<Props>>,
   registered: RegisteredCache,
   props?: Props
 ): SerializedStyles

--- a/packages/styled/types/base.d.ts
+++ b/packages/styled/types/base.d.ts
@@ -66,13 +66,17 @@ export interface CreateStyledComponent<
 > {
   /**
    * @typeparam AdditionalProps  Additional props to add to your styled component
+   * @typeparam InferredAdditionalProps  Should not be explicitly specified
    */
-  <AdditionalProps extends {} = {}>(
+  <
+    AdditionalProps extends {} = {},
+    InferredAdditionalProps extends AdditionalProps = AdditionalProps
+  >(
     ...styles: Array<
       Interpolation<
         ComponentProps &
           SpecificComponentProps &
-          AdditionalProps & { theme: Theme }
+          InferredAdditionalProps & { theme: Theme }
       >
     >
   ): StyledComponent<
@@ -90,14 +94,18 @@ export interface CreateStyledComponent<
 
   /**
    * @typeparam AdditionalProps  Additional props to add to your styled component
+   * @typeparam InferredAdditionalProps  Should not be explicitly specified
    */
-  <AdditionalProps extends {}>(
+  <
+    AdditionalProps extends {} = {},
+    InferredAdditionalProps extends AdditionalProps = AdditionalProps
+  >(
     template: TemplateStringsArray,
     ...styles: Array<
       Interpolation<
         ComponentProps &
           SpecificComponentProps &
-          AdditionalProps & { theme: Theme }
+          InferredAdditionalProps & { theme: Theme }
       >
     >
   ): StyledComponent<

--- a/packages/utils/types/index.d.ts
+++ b/packages/utils/types/index.d.ts
@@ -41,7 +41,7 @@ export interface SerializedStyles {
 export const isBrowser: boolean
 export function getRegisteredStyles(
   registered: RegisteredCache,
-  registeredStyles: Array<string>,
+  registeredStyles: ReadonlyArray<string>,
   classNames: string
 ): string
 export function insertStyles(


### PR DESCRIPTION
…lude mutable arrays

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Type definitions

<!-- Why are these changes necessary? -->
**Why**: A TypeScript error is emitted when trying to pass in readonly arrays to some functions. Ex.

```tsx
const classnames = [classname1, classname2] as const;
cx(styles);
```

<!-- How were these changes implemented? -->
**How**: Updated type definitions to use `ReadonlyArray` instead of `Array`. 

Since this only relaxes types that only used in function arguments, it's not a backwards-incompatible change.

I also fixed a couple pre-existing errors coming from `yarn test:typescript`.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
