### PR TITLE
Add support for the `as` prop in React Native related packages

### DIFF
--- a/.changeset/two-cooks-kiss.md
+++ b/.changeset/two-cooks-kiss.md
@@ -1,0 +1,7 @@
+---
+'@emotion/native': minor
+'@emotion/primitives': minor
+'@emotion/primitives-core': minor
+---
+
+Added support for the `as` prop.

--- a/packages/native/types/base.d.ts
+++ b/packages/native/types/base.d.ts
@@ -153,6 +153,7 @@ export interface CreateStyled {
   ): CreateStyledComponent<
     Pick<React.ComponentProps<C>, ForwardedProps> & {
       theme?: Theme
+      as?: React.ElementType
     },
     {},
     { ref?: React.Ref<InstanceType<C>> },
@@ -165,6 +166,7 @@ export interface CreateStyled {
   ): CreateStyledComponent<
     React.ComponentProps<C> & {
       theme?: Theme
+      as?: React.ElementType
     },
     {},
     { ref?: React.Ref<InstanceType<C>> },
@@ -182,6 +184,7 @@ export interface CreateStyled {
   ): CreateStyledComponent<
     Pick<React.ComponentProps<C>, ForwardedProps> & {
       theme?: Theme
+      as?: React.ElementType
     },
     {},
     {},
@@ -192,7 +195,7 @@ export interface CreateStyled {
     component: C,
     options?: StyledOptions<React.ComponentProps<C>>
   ): CreateStyledComponent<
-    React.ComponentProps<C> & { theme?: Theme },
+    React.ComponentProps<C> & { theme?: Theme; as?: React.ElementType },
     {},
     {},
     ReactNativeStyleType<React.ComponentProps<C>>

--- a/packages/native/types/index.d.ts
+++ b/packages/native/types/index.d.ts
@@ -44,7 +44,7 @@ export function css<StyleType extends ReactNativeStyle = ReactNativeStyle>(
 type HostClassComponent<
   C extends React.ComponentClass<any>
 > = CreateStyledComponent<
-  React.ComponentProps<C> & { theme?: Theme },
+  React.ComponentProps<C> & { theme?: Theme; as?: React.ElementType },
   {},
   { ref?: React.Ref<InstanceType<C>> },
   ReactNativeStyleType<React.ComponentProps<C>>
@@ -52,7 +52,7 @@ type HostClassComponent<
 type HostFunctionComponent<
   C extends React.FunctionComponent<any>
 > = CreateStyledComponent<
-  React.ComponentProps<C> & { theme?: Theme },
+  React.ComponentProps<C> & { theme?: Theme; as?: React.ElementType },
   {},
   {},
   ReactNativeStyleType<React.ComponentProps<C>>

--- a/packages/primitives-core/src/styled.js
+++ b/packages/primitives-core/src/styled.js
@@ -29,7 +29,10 @@ export function createStyled(
     let shouldForwardProp =
       options && options.shouldForwardProp
         ? options.shouldForwardProp
-        : getShouldForwardProp(component)
+        : undefined
+    let defaultShouldForwardProp =
+      shouldForwardProp || getShouldForwardProp(component)
+    let shouldUseAs = !defaultShouldForwardProp('as')
 
     return function createStyledComponent(...rawStyles: *) {
       let styles
@@ -43,6 +46,8 @@ export function createStyled(
       // do we really want to use the same infra as the web since it only really uses theming?
       // $FlowFixMe
       let Styled = React.forwardRef((props, ref) => {
+        const finalTag = (shouldUseAs && props.as) || component
+
         let mergedProps = props
         if (props.theme == null) {
           mergedProps = {}
@@ -52,10 +57,17 @@ export function createStyled(
           mergedProps.theme = React.useContext(ThemeContext)
         }
 
+        let finalShouldForwardProp =
+          shouldUseAs && shouldForwardProp === undefined
+            ? getShouldForwardProp(finalTag)
+            : defaultShouldForwardProp
+
         let newProps = {}
 
         for (let key in props) {
-          if (shouldForwardProp(key)) {
+          if (shouldUseAs && key === 'as') continue
+
+          if (finalShouldForwardProp(key)) {
             newProps[key] = props[key]
           }
         }
@@ -64,7 +76,7 @@ export function createStyled(
         newProps.ref = ref
 
         // $FlowFixMe
-        return React.createElement(component, newProps)
+        return React.createElement(finalTag, newProps)
       })
       // $FlowFixMe
       Styled.withComponent = (newComponent: React.ElementType) =>

--- a/packages/primitives-core/src/styled.js
+++ b/packages/primitives-core/src/styled.js
@@ -4,7 +4,7 @@ import { interleave } from './utils'
 import { ThemeContext } from '@emotion/react'
 import { createCss } from './css'
 
-let testOmitPropsOnComponent = prop => prop !== 'theme'
+let testOmitPropsOnComponent = prop => prop !== 'theme' && prop !== 'as'
 
 type CreateStyledOptions = {
   getShouldForwardProp: (cmp: React.ElementType) => (prop: string) => boolean


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Add support for the `as` prop for React Native related packages. Fixes #2055

<!-- Why are these changes necessary? -->
**Why**:

Because the `as` prop is currently missing and it can be very helpful.

<!-- How were these changes implemented? -->
**How**:

Like it is done in the React package.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->