### PR TITLE
Use `StyleSheet.create` in React Native

### DIFF
--- a/.changeset/strong-cooks-drum.md
+++ b/.changeset/strong-cooks-drum.md
@@ -1,0 +1,7 @@
+---
+'@emotion/native': major
+'@emotion/primitives': major
+'@emotion/primitives-core': major
+---
+
+`StyleSheet.create` is used now under the hood. This means that when used in combination with React Native Web atomic class names are applied on components instead of inline styles.

--- a/packages/native/test/__snapshots__/native-styled.test.js.snap
+++ b/packages/native/test/__snapshots__/native-styled.test.js.snap
@@ -5,9 +5,7 @@ exports[`Emotion native styled primitive should work with \`withComponent\` 1`] 
   decor="hotpink"
   style={
     Array [
-      Object {
-        "color": "hotpink",
-      },
+      77,
       undefined,
     ]
   }
@@ -21,9 +19,7 @@ exports[`Emotion native styled should pass props in withComponent 1`] = `
   color="green"
   style={
     Array [
-      Object {
-        "backgroundColor": "green",
-      },
+      81,
       undefined,
     ]
   }
@@ -35,9 +31,7 @@ exports[`Emotion native styled should pass props in withComponent 2`] = `
   color="hotpink"
   style={
     Array [
-      Object {
-        "backgroundColor": "hotpink",
-      },
+      82,
       undefined,
     ]
   }
@@ -55,12 +49,7 @@ exports[`Emotion native styled should render <Image /> 1`] = `
   }
   style={
     Array [
-      Object {
-        "borderBottomLeftRadius": 2,
-        "borderBottomRightRadius": 2,
-        "borderTopLeftRadius": 2,
-        "borderTopRightRadius": 2,
-      },
+      83,
       undefined,
     ]
   }
@@ -71,9 +60,7 @@ exports[`Emotion native styled should render primitive with style prop 1`] = `
 <Text
   style={
     Array [
-      Object {
-        "color": "hotpink",
-      },
+      77,
       Object {
         "padding": 10,
       },
@@ -89,10 +76,7 @@ exports[`Emotion native styled should render styles correctly from all nested st
   backgroundColor="blue"
   style={
     Array [
-      Object {
-        "backgroundColor": "blue",
-        "color": "hotpink",
-      },
+      86,
       undefined,
     ]
   }
@@ -106,13 +90,7 @@ exports[`Emotion native styled should render the primitive on changing the props
   decor="hotpink"
   style={
     Array [
-      Object {
-        "color": "hotpink",
-        "paddingBottom": 20,
-        "paddingLeft": 20,
-        "paddingRight": 20,
-        "paddingTop": 20,
-      },
+      76,
       undefined,
     ]
   }
@@ -126,11 +104,7 @@ exports[`Emotion native styled should render the primitive when styles applied u
   back="red"
   style={
     Array [
-      Object {
-        "backgroundColor": "red",
-        "color": "red",
-        "fontSize": 20,
-      },
+      74,
       Object {
         "fontSize": 40,
       },
@@ -145,9 +119,7 @@ exports[`Emotion native styled should style any other component 1`] = `
 <Text
   style={
     Array [
-      Object {
-        "color": "hotpink",
-      },
+      77,
       undefined,
     ]
   }
@@ -160,10 +132,8 @@ exports[`Emotion native styled should work with StyleSheet.create API 1`] = `
 <Text
   style={
     Array [
-      Object {
-        "fontSize": 10,
-      },
-      74,
+      79,
+      78,
     ]
   }
 >
@@ -175,9 +145,7 @@ exports[`Emotion native styled should work with theming from @emotion/react 1`] 
 <Text
   style={
     Array [
-      Object {
-        "color": "magenta",
-      },
+      75,
       undefined,
     ]
   }

--- a/packages/native/test/native-css.test.js
+++ b/packages/native/test/native-css.test.js
@@ -1,4 +1,5 @@
 import { css } from '@emotion/native'
+import { StyleSheet } from 'react-native'
 
 jest.mock('react-native')
 
@@ -6,16 +7,24 @@ let returnArguments = (...args) => args
 
 describe('Emotion native css', () => {
   test('basic', () => {
-    expect(css`
-      color: hotpink;
-      ${{ backgroundColor: 'green' }};
-    `).toEqual({ color: 'hotpink', backgroundColor: 'green' })
-    expect(css({ color: 'green' })).toEqual({ color: 'green' })
-    expect(css([{ color: 'green' }, `background-color:yellow;`])).toEqual({
+    expect(
+      StyleSheet.flatten(css`
+        color: hotpink;
+        ${{ backgroundColor: 'green' }};
+      `)
+    ).toEqual({ color: 'hotpink', backgroundColor: 'green' })
+    expect(StyleSheet.flatten(css({ color: 'green' }))).toEqual({
+      color: 'green'
+    })
+    expect(
+      StyleSheet.flatten(css([{ color: 'green' }, `background-color:yellow;`]))
+    ).toEqual({
       color: 'green',
       backgroundColor: 'yellow'
     })
-    expect(css([{ color: 'green' }])).toEqual({ color: 'green' })
+    expect(StyleSheet.flatten(css([{ color: 'green' }]))).toEqual({
+      color: 'green'
+    })
   })
 
   test('order with string and object', () => {
@@ -23,83 +32,99 @@ describe('Emotion native css', () => {
     // because we care about the order of the keys
     expect(
       Object.keys(
-        css({ color: 'green' }, `background-color:yellow;`, { flex: 2 })
+        StyleSheet.flatten(
+          css({ color: 'green' }, `background-color:yellow;`, { flex: 2 })
+        )
       )
     ).toEqual(['color', 'backgroundColor', 'flex'])
     expect(
       Object.keys(
-        css([
-          [{ color: 'green' }, `background-color:yellow;`],
-          {
-            flex: 2
-          }
-        ])
-      )
-    ).toEqual(['color', 'backgroundColor', 'flex'])
-    expect(
-      Object.keys(
-        css([
-          { color: 'green' },
-          [
-            `background-color:yellow;`,
+        StyleSheet.flatten(
+          css([
+            [{ color: 'green' }, `background-color:yellow;`],
             {
               flex: 2
             }
-          ]
-        ])
+          ])
+        )
       )
     ).toEqual(['color', 'backgroundColor', 'flex'])
     expect(
       Object.keys(
-        css([
-          { color: 'green' },
-          [
-            { flex: 8 },
-            `background-color:yellow;`,
-            [`flex-grow: 1;`, { flexDirection: 'row' }]
-          ]
-        ])
+        StyleSheet.flatten(
+          css([
+            { color: 'green' },
+            [
+              `background-color:yellow;`,
+              {
+                flex: 2
+              }
+            ]
+          ])
+        )
+      )
+    ).toEqual(['color', 'backgroundColor', 'flex'])
+    expect(
+      Object.keys(
+        StyleSheet.flatten(
+          css([
+            { color: 'green' },
+            [
+              { flex: 8 },
+              `background-color:yellow;`,
+              [`flex-grow: 1;`, { flexDirection: 'row' }]
+            ]
+          ])
+        )
       )
     ).toEqual(['color', 'flex', 'backgroundColor', 'flexGrow', 'flexDirection'])
   })
 
   it('allows function interpolations when this.mergedProps is defined', () => {
     expect(
-      css.call({ thing: true }, props => ({
-        color: props.thing && 'hotpink'
-      }))
+      StyleSheet.flatten(
+        css.call({ thing: true }, props => ({
+          color: props.thing && 'hotpink'
+        }))
+      )
     ).toEqual({ color: 'hotpink' })
   })
 
   it('works with nested functions', () => {
     expect(
-      css.call({ thing: true }, props => () => ({
-        color: props.thing && 'hotpink'
-      }))
+      StyleSheet.flatten(
+        css.call({ thing: true }, props => () => ({
+          color: props.thing && 'hotpink'
+        }))
+      )
     ).toEqual({ color: 'hotpink' })
   })
 
   it('works with functions in tagged template literals', () => {
     expect(
-      css.call(
-        {},
-        ...returnArguments`
+      StyleSheet.flatten(
+        css.call(
+          {},
+          ...returnArguments`
         color: ${() => 'hotpink'};
       `
+        )
       )
     ).toEqual({ color: 'hotpink' })
   })
 
   test('last arg falsy and string before that', () => {
-    expect(css('color:hotpink;', false)).toEqual({ color: 'hotpink' })
+    expect(StyleSheet.flatten(css('color:hotpink;', false))).toEqual({
+      color: 'hotpink'
+    })
   })
 
   test('falsy value in the middle', () => {
     expect(
-      css`
+      StyleSheet.flatten(css`
         color: ${false};
         background-color: hotpink;
-      `
+      `)
     ).toEqual({ backgroundColor: 'hotpink' })
   })
 
@@ -108,10 +133,10 @@ describe('Emotion native css', () => {
       color: hotpink;
     `
     expect(
-      css`
+      StyleSheet.flatten(css`
         background-color: green;
         ${firstStyle};
-      `
+      `)
     ).toEqual({ backgroundColor: 'green', color: 'hotpink' })
   })
 
@@ -128,7 +153,7 @@ describe('Emotion native css', () => {
       // color: red;
     `
 
-    expect(styles).toEqual({ color: 'hotpink' })
-    expect(anotherStyles).toEqual({ fontSize: 10 })
+    expect(StyleSheet.flatten(styles)).toEqual({ color: 'hotpink' })
+    expect(StyleSheet.flatten(anotherStyles)).toEqual({ fontSize: 10 })
   })
 })

--- a/packages/native/test/native-css.test.js
+++ b/packages/native/test/native-css.test.js
@@ -31,6 +31,7 @@ describe('Emotion native css', () => {
     // this test checks the keys instead of the objects
     // because we care about the order of the keys
     expect(
+      // $FlowFixMe
       Object.keys(
         StyleSheet.flatten(
           css({ color: 'green' }, `background-color:yellow;`, { flex: 2 })
@@ -38,6 +39,7 @@ describe('Emotion native css', () => {
       )
     ).toEqual(['color', 'backgroundColor', 'flex'])
     expect(
+      // $FlowFixMe
       Object.keys(
         StyleSheet.flatten(
           css([
@@ -50,6 +52,7 @@ describe('Emotion native css', () => {
       )
     ).toEqual(['color', 'backgroundColor', 'flex'])
     expect(
+      // $FlowFixMe
       Object.keys(
         StyleSheet.flatten(
           css([
@@ -65,6 +68,7 @@ describe('Emotion native css', () => {
       )
     ).toEqual(['color', 'backgroundColor', 'flex'])
     expect(
+      // $FlowFixMe
       Object.keys(
         StyleSheet.flatten(
           css([

--- a/packages/primitives-core/src/css.js
+++ b/packages/primitives-core/src/css.js
@@ -7,6 +7,7 @@ import { interleave } from './utils'
 // this is done so we don't create a new
 // handleInterpolation function on every css call
 let styles
+let generated = {}
 let buffer = ''
 let lastType
 
@@ -102,7 +103,12 @@ export function createCss(StyleSheet: Object) {
       buffer = prevBuffer
     }
 
-    return StyleSheet.flatten(styles)
+    const hash = JSON.stringify(styles)
+    if (!generated[hash]) {
+      const styleSheet = StyleSheet.create({ generated: styles })
+      generated[hash] = styleSheet.generated
+    }
+    return generated[hash]
   }
 }
 

--- a/packages/primitives-core/src/css.js
+++ b/packages/primitives-core/src/css.js
@@ -105,7 +105,9 @@ export function createCss(StyleSheet: Object) {
 
     const hash = JSON.stringify(styles)
     if (!generated[hash]) {
-      const styleSheet = StyleSheet.create({ generated: styles })
+      const styleSheet = StyleSheet.create({
+        generated: StyleSheet.flatten(styles)
+      })
       generated[hash] = styleSheet.generated
     }
     return generated[hash]

--- a/packages/primitives/test/__snapshots__/emotion-primitives.test.js.snap
+++ b/packages/primitives/test/__snapshots__/emotion-primitives.test.js.snap
@@ -2,14 +2,9 @@
 
 exports[`Emotion primitives custom shouldForwardProp works 1`] = `
 <div
-  className="css-text-901oao"
+  className="css-text-901oao r-color-185hjl9"
   dir="auto"
   onClick={[Function]}
-  style={
-    Object {
-      "color": "rgba(255,105,180,1.00)",
-    }
-  }
 >
   Emotion
 </div>
@@ -17,14 +12,9 @@ exports[`Emotion primitives custom shouldForwardProp works 1`] = `
 
 exports[`Emotion primitives primitive should work with \`withComponent\` 1`] = `
 <div
-  className="css-text-901oao"
+  className="css-text-901oao r-color-185hjl9"
   dir="auto"
   onClick={[Function]}
-  style={
-    Object {
-      "color": "rgba(255,105,180,1.00)",
-    }
-  }
 >
   Mike
 </div>
@@ -32,25 +22,15 @@ exports[`Emotion primitives primitive should work with \`withComponent\` 1`] = `
 
 exports[`Emotion primitives should pass props in withComponent 1`] = `
 <div
-  className="css-view-1dbjc4n"
-  style={
-    Object {
-      "backgroundColor": "rgba(0,128,0,1.00)",
-    }
-  }
+  className="css-view-1dbjc4n r-backgroundColor-1542mo4"
 />
 `;
 
 exports[`Emotion primitives should pass props in withComponent 2`] = `
 <div
-  className="css-text-901oao"
+  className="css-text-901oao r-backgroundColor-173gl9r"
   dir="auto"
   onClick={[Function]}
-  style={
-    Object {
-      "backgroundColor": "rgba(255,105,180,1.00)",
-    }
-  }
 />
 `;
 
@@ -82,12 +62,11 @@ exports[`Emotion primitives should render <Image /> 1`] = `
 
 exports[`Emotion primitives should render primitive with style prop 1`] = `
 <div
-  className="css-text-901oao"
+  className="css-text-901oao r-color-185hjl9"
   dir="auto"
   onClick={[Function]}
   style={
     Object {
-      "color": "rgba(255,105,180,1.00)",
       "paddingBottom": "10px",
       "paddingLeft": "10px",
       "paddingRight": "10px",
@@ -101,18 +80,9 @@ exports[`Emotion primitives should render primitive with style prop 1`] = `
 
 exports[`Emotion primitives should render the primitive on changing the props 1`] = `
 <div
-  className="css-text-901oao"
+  className="css-text-901oao r-color-185hjl9 r-paddingBottom-k8qxaj r-paddingLeft-b5h31w r-paddingRight-1ah4tor r-paddingTop-1knelpx"
   dir="auto"
   onClick={[Function]}
-  style={
-    Object {
-      "color": "rgba(255,105,180,1.00)",
-      "paddingBottom": "20px",
-      "paddingLeft": "20px",
-      "paddingRight": "20px",
-      "paddingTop": "20px",
-    }
-  }
 >
   Emotion Primitives
 </div>
@@ -120,13 +90,11 @@ exports[`Emotion primitives should render the primitive on changing the props 1`
 
 exports[`Emotion primitives should render the primitive when styles applied using object style notation 1`] = `
 <div
-  className="css-text-901oao"
+  className="css-text-901oao r-backgroundColor-1g6456j r-color-howw7u"
   dir="auto"
   onClick={[Function]}
   style={
     Object {
-      "backgroundColor": "rgba(255,0,0,1.00)",
-      "color": "rgba(255,0,0,1.00)",
       "fontSize": "40px",
     }
   }
@@ -137,14 +105,9 @@ exports[`Emotion primitives should render the primitive when styles applied usin
 
 exports[`Emotion primitives should style any other component 1`] = `
 <div
-  className="css-text-901oao"
+  className="css-text-901oao r-color-185hjl9"
   dir="auto"
   onClick={[Function]}
-  style={
-    Object {
-      "color": "rgba(255,105,180,1.00)",
-    }
-  }
 >
   Hello World
 </div>
@@ -153,9 +116,9 @@ exports[`Emotion primitives should style any other component 1`] = `
 exports[`Emotion primitives should unmount with theming 1`] = `
 <div>
   <div
-    class="css-text-901oao"
+    class="css-text-901oao r-display-6koalj"
     dir="auto"
-    style="background-color: rgb(255, 255, 0); display: flex;"
+    style="background-color: rgb(255, 255, 0);"
   >
     Hello World
   </div>
@@ -164,14 +127,9 @@ exports[`Emotion primitives should unmount with theming 1`] = `
 
 exports[`Emotion primitives should work with StyleSheet.create API 1`] = `
 <div
-  className="css-text-901oao r-color-howw7u"
+  className="css-text-901oao r-color-howw7u r-fontSize-10x49cs"
   dir="auto"
   onClick={[Function]}
-  style={
-    Object {
-      "fontSize": "10px",
-    }
-  }
 >
   Emotion Primitives
 </div>
@@ -179,14 +137,9 @@ exports[`Emotion primitives should work with StyleSheet.create API 1`] = `
 
 exports[`Emotion primitives should work with theming from @emotion/react 1`] = `
 <div
-  className="css-text-901oao"
+  className="css-text-901oao r-color-1hxtt4r"
   dir="auto"
   onClick={[Function]}
-  style={
-    Object {
-      "color": "rgba(255,0,255,1.00)",
-    }
-  }
 >
   Hello World
 </div>

--- a/packages/primitives/test/css.test.js
+++ b/packages/primitives/test/css.test.js
@@ -1,19 +1,28 @@
 // @flow
 import { css } from '@emotion/primitives'
+import { StyleSheet } from 'react-native'
 
 let returnArguments = (...args) => args
 
 test('basic', () => {
-  expect(css`
-    color: hotpink;
-    ${{ backgroundColor: 'green' }};
-  `).toEqual({ color: 'hotpink', backgroundColor: 'green' })
-  expect(css({ color: 'green' })).toEqual({ color: 'green' })
-  expect(css([{ color: 'green' }, `background-color:yellow;`])).toEqual({
+  expect(
+    StyleSheet.flatten(css`
+      color: hotpink;
+      ${{ backgroundColor: 'green' }};
+    `)
+  ).toEqual({ color: 'hotpink', backgroundColor: 'green' })
+  expect(StyleSheet.flatten(css({ color: 'green' }))).toEqual({
+    color: 'green'
+  })
+  expect(
+    StyleSheet.flatten(css([{ color: 'green' }, `background-color:yellow;`]))
+  ).toEqual({
     color: 'green',
     backgroundColor: 'yellow'
   })
-  expect(css([{ color: 'green' }])).toEqual({ color: 'green' })
+  expect(StyleSheet.flatten(css([{ color: 'green' }]))).toEqual({
+    color: 'green'
+  })
 })
 
 test('order with string and object', () => {
@@ -21,83 +30,99 @@ test('order with string and object', () => {
   // because we care about the order of the keys
   expect(
     Object.keys(
-      css({ color: 'green' }, `background-color:yellow;`, { flex: 2 })
+      StyleSheet.flatten(
+        css({ color: 'green' }, `background-color:yellow;`, { flex: 2 })
+      )
     )
   ).toEqual(['color', 'backgroundColor', 'flex'])
   expect(
     Object.keys(
-      css([
-        [{ color: 'green' }, `background-color:yellow;`],
-        {
-          flex: 2
-        }
-      ])
-    )
-  ).toEqual(['color', 'backgroundColor', 'flex'])
-  expect(
-    Object.keys(
-      css([
-        { color: 'green' },
-        [
-          `background-color:yellow;`,
+      StyleSheet.flatten(
+        css([
+          [{ color: 'green' }, `background-color:yellow;`],
           {
             flex: 2
           }
-        ]
-      ])
+        ])
+      )
     )
   ).toEqual(['color', 'backgroundColor', 'flex'])
   expect(
     Object.keys(
-      css([
-        { color: 'green' },
-        [
-          { flex: 8 },
-          `background-color:yellow;`,
-          [`flex-grow: 1;`, { flexDirection: 'row' }]
-        ]
-      ])
+      StyleSheet.flatten(
+        css([
+          { color: 'green' },
+          [
+            `background-color:yellow;`,
+            {
+              flex: 2
+            }
+          ]
+        ])
+      )
+    )
+  ).toEqual(['color', 'backgroundColor', 'flex'])
+  expect(
+    Object.keys(
+      StyleSheet.flatten(
+        css([
+          { color: 'green' },
+          [
+            { flex: 8 },
+            `background-color:yellow;`,
+            [`flex-grow: 1;`, { flexDirection: 'row' }]
+          ]
+        ])
+      )
     )
   ).toEqual(['color', 'flex', 'backgroundColor', 'flexGrow', 'flexDirection'])
 })
 
 it('allows function interpolations when this is defined', () => {
   expect(
-    css.call({ thing: true }, props => ({
-      color: props.thing && 'hotpink'
-    }))
+    StyleSheet.flatten(
+      css.call({ thing: true }, props => ({
+        color: props.thing && 'hotpink'
+      }))
+    )
   ).toEqual({ color: 'hotpink' })
 })
 
 it('works with nested functions', () => {
   expect(
-    css.call({ thing: true }, props => () => ({
-      color: props.thing && 'hotpink'
-    }))
+    StyleSheet.flatten(
+      css.call({ thing: true }, props => () => ({
+        color: props.thing && 'hotpink'
+      }))
+    )
   ).toEqual({ color: 'hotpink' })
 })
 
 it('works with functions in tagged template literals', () => {
   expect(
-    css.call(
-      {},
-      ...returnArguments`
+    StyleSheet.flatten(
+      css.call(
+        {},
+        ...returnArguments`
         color: ${() => 'hotpink'};
       `
+      )
     )
   ).toEqual({ color: 'hotpink' })
 })
 
 test('last arg falsy and string before that', () => {
-  expect(css('color:hotpink;', false)).toEqual({ color: 'hotpink' })
+  expect(StyleSheet.flatten(css('color:hotpink;', false))).toEqual({
+    color: 'hotpink'
+  })
 })
 
 test('falsy value in the middle', () => {
   expect(
-    css`
+    StyleSheet.flatten(css`
       color: ${false};
       background-color: hotpink;
-    `
+    `)
   ).toEqual({ backgroundColor: 'hotpink' })
 })
 
@@ -106,9 +131,9 @@ test('composition', () => {
     color: hotpink;
   `
   expect(
-    css`
+    StyleSheet.flatten(css`
       background-color: green;
       ${firstStyle};
-    `
+    `)
   ).toEqual({ backgroundColor: 'green', color: 'hotpink' })
 })

--- a/packages/primitives/test/css.test.js
+++ b/packages/primitives/test/css.test.js
@@ -29,6 +29,7 @@ test('order with string and object', () => {
   // this test checks the keys instead of the objects
   // because we care about the order of the keys
   expect(
+    // $FlowFixMe
     Object.keys(
       StyleSheet.flatten(
         css({ color: 'green' }, `background-color:yellow;`, { flex: 2 })
@@ -36,6 +37,7 @@ test('order with string and object', () => {
     )
   ).toEqual(['color', 'backgroundColor', 'flex'])
   expect(
+    // $FlowFixMe
     Object.keys(
       StyleSheet.flatten(
         css([
@@ -48,6 +50,7 @@ test('order with string and object', () => {
     )
   ).toEqual(['color', 'backgroundColor', 'flex'])
   expect(
+    // $FlowFixMe
     Object.keys(
       StyleSheet.flatten(
         css([
@@ -63,6 +66,7 @@ test('order with string and object', () => {
     )
   ).toEqual(['color', 'backgroundColor', 'flex'])
   expect(
+    // $FlowFixMe
     Object.keys(
       StyleSheet.flatten(
         css([

--- a/packages/primitives/test/no-babel/__snapshots__/basic.test.js.snap
+++ b/packages/primitives/test/no-babel/__snapshots__/basic.test.js.snap
@@ -2,13 +2,11 @@
 
 exports[`should render the primitive when styles applied using object style notation 1`] = `
 <div
-  className="css-text-901oao"
+  className="css-text-901oao r-backgroundColor-1g6456j r-color-howw7u"
   dir="auto"
   onClick={[Function]}
   style={
     Object {
-      "backgroundColor": "rgba(255,0,0,1.00)",
-      "color": "rgba(255,0,0,1.00)",
       "fontSize": "40px",
     }
   }

--- a/packages/primitives/test/no-babel/basic.test.js
+++ b/packages/primitives/test/no-babel/basic.test.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import styled, { css } from '@emotion/primitives'
 import renderer from 'react-test-renderer'
+import { StyleSheet } from 'react-native'
 
 jest.mock('react-primitives')
 
@@ -10,24 +11,32 @@ jest.mock('react-primitives')
 // without the babel plugin
 
 test('basic', () => {
-  expect(css`
-    color: hotpink;
-    ${{ backgroundColor: 'green' }};
-  `).toEqual({ color: 'hotpink', backgroundColor: 'green' })
-  expect(css({ color: 'green' })).toEqual({ color: 'green' })
-  expect(css([{ color: 'green' }, `background-color:yellow;`])).toEqual({
+  expect(
+    StyleSheet.flatten(css`
+      color: hotpink;
+      ${{ backgroundColor: 'green' }};
+    `)
+  ).toEqual({ color: 'hotpink', backgroundColor: 'green' })
+  expect(StyleSheet.flatten(css({ color: 'green' }))).toEqual({
+    color: 'green'
+  })
+  expect(
+    StyleSheet.flatten(css([{ color: 'green' }, `background-color:yellow;`]))
+  ).toEqual({
     color: 'green',
     backgroundColor: 'yellow'
   })
-  expect(css([{ color: 'green' }])).toEqual({ color: 'green' })
+  expect(StyleSheet.flatten(css([{ color: 'green' }]))).toEqual({
+    color: 'green'
+  })
 })
 
 test('falsy value in the middle', () => {
   expect(
-    css`
+    StyleSheet.flatten(css`
       color: ${false};
       background-color: hotpink;
-    `
+    `)
   ).toEqual({ backgroundColor: 'hotpink' })
 })
 
@@ -54,5 +63,5 @@ test('empty string', () => {
   let style = css`    
       
   `
-  expect(style).toEqual({})
+  expect(StyleSheet.flatten(style)).toEqual({})
 })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Change to `StyleSheet.create` for React Native

<!-- Why are these changes necessary? -->
**Why**:

`StyleSheet.create` creates an instance for the given styles and we prevent re-creation of that instance when the same styles come in. Besides that `StyleSheet.flatten` which was used before, creates inline styles with React Native Web, while `StyleSheet.create` create atomic CSS classes.

<!-- How were these changes implemented? -->
**How**:

Change `StyleSheet.flatten` to `StyleSheet.create` with an extra check to prevent re-creation.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
