### PR TITLE
Add docs about new JSX factories

### DIFF
--- a/docs/css-prop.mdx
+++ b/docs/css-prop.mdx
@@ -55,6 +55,8 @@ This option works best for testing out the `css` prop feature or in projects whe
 
 Similar to a comment containing linter configuration, this configures the [jsx babel plugin](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx) to use the `jsx` function instead of `React.createElement`.
 
+If you are using a zero-config tool with automatic detection of which runtime (classic vs. automatic) should be used and you are already using a React version that has [the new JSX runtimes](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) (hence `runtime: 'automatic'` being configured automatically for your) such as Create React App 4 then `/** @jsx jsx */` pragma might not work and you should use `/** @jsxImportSource @emotion/core */` instead. Keep in mind that this also requires a compatible version of `@emotion/core` which is `^10.1.0`.
+
 > [JSX Pragma Babel Documentation](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#pragma)
 
 #### Import the `jsx` function from `@emotion/core`

--- a/docs/css-prop.mdx
+++ b/docs/css-prop.mdx
@@ -13,7 +13,7 @@ There are 2 ways to get started with the `css` prop.
 
 Both methods result in the same compiled code.
 After adding the preset or setting the pragma as a comment, compiled jsx code will use emotion's `jsx` function instead of `React.createElement`.
-  
+
 | | Input | Output |
 | ------ | -------------------------- | --------------------------------------------------- |
 | Before | `<img src="avatar.png" />` | `React.createElement('img', { src: 'avatar.png' })` |
@@ -29,6 +29,16 @@ Use the [JSX Pragma](#jsx-pragma) method instead.
 ```json
 {
   "presets": ["@emotion/babel-preset-css-prop"]
+}
+```
+
+If you are using the compatible React version (`>=16.14.0`) and a compatible version of `@emotion/core` (`>=10.1.0`) then you can opt into using [the new JSX runtimes](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) by using such configuration:
+
+**.babelrc**
+
+```json
+{
+  "presets": [["@emotion/babel-preset-css-prop", { "runtime": "automatic" }]]
 }
 ```
 

--- a/docs/css-prop.mdx
+++ b/docs/css-prop.mdx
@@ -55,7 +55,7 @@ This option works best for testing out the `css` prop feature or in projects whe
 
 Similar to a comment containing linter configuration, this configures the [jsx babel plugin](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx) to use the `jsx` function instead of `React.createElement`.
 
-If you are using a zero-config tool with automatic detection of which runtime (classic vs. automatic) should be used and you are already using a React version that has [the new JSX runtimes](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) (hence `runtime: 'automatic'` being configured automatically for your) such as Create React App 4 then `/** @jsx jsx */` pragma might not work and you should use `/** @jsxImportSource @emotion/core */` instead. Keep in mind that this also requires a compatible version of `@emotion/core` which is `^10.1.0`.
+If you are using a zero-config tool with automatic detection of which runtime (classic vs. automatic) should be used and you are already using a React version that has [the new JSX runtimes](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) (hence `runtime: 'automatic'` being configured automatically for you) such as Create React App 4 then `/** @jsx jsx */` pragma might not work and you should use `/** @jsxImportSource @emotion/core */` instead. Keep in mind that this also requires a compatible version of `@emotion/core` which is `^10.1.0`.
 
 > [JSX Pragma Babel Documentation](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#pragma)
 

--- a/packages/babel-preset-css-prop/README.md
+++ b/packages/babel-preset-css-prop/README.md
@@ -66,14 +66,14 @@ require('@babel/core').transform(code, {
 
 ## Features
 
-This preset enables the `css` prop for an entire project via a single entry to the babel configuration. After adding the preset, compiled jsx code will use emotion's `jsx` function instead of `React.createElement`.
+This preset enables the `css` prop for an entire project via a single entry to the babel configuration. After adding the preset, compiled JSX code will use Emotion's JSX factories instead of the ones provided by React.
 
 |        | Input                      | Output                                              |
 | ------ | -------------------------- | --------------------------------------------------- |
 | Before | `<img src="avatar.png" />` | `React.createElement('img', { src: 'avatar.png' })` |
 | After  | `<img src="avatar.png" />` | `jsx('img', { src: 'avatar.png' })`                 |
 
-`import { jsx } from '@emotion/core'` is automatically added to the top of files where required.
+Import to `@emotion/core`'s appropriate JSX factory is automatically added to the top of files where required.
 
 ## Example
 
@@ -127,7 +127,7 @@ const Link = props =>
   )
 ```
 
-_In addition to the custom pragma, this example includes `babel-plugin-emotion` transforms that are enabled by default._
+_In addition to the custom JSX factory, this example includes `babel-plugin-emotion` transforms that are enabled by default._
 
 ## Options
 
@@ -138,6 +138,8 @@ Options for both `babel-plugin-emotion` and `@babel/plugin-transform-react-jsx` 
 > - [`babel-plugin-emotion`](https://emotion.sh/docs/babel)
 >
 > - [`@babel/plugin-transform-react-jsx`](https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx)
+
+You can opt into [the new JSX runtimes](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) by configuring this preset with `{ runtime: 'automatic' }`. Keep in mind that you have to use compatible React version (`>=16.14.0`) to use this options.
 
 ### Examples
 

--- a/packages/babel-preset-css-prop/README.md
+++ b/packages/babel-preset-css-prop/README.md
@@ -139,7 +139,7 @@ Options for both `babel-plugin-emotion` and `@babel/plugin-transform-react-jsx` 
 >
 > - [`@babel/plugin-transform-react-jsx`](https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx)
 
-You can opt into [the new JSX runtimes](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) by configuring this preset with `{ runtime: 'automatic' }`. Keep in mind that you have to use compatible React version (`>=16.14.0`) to use this options.
+You can opt into [the new JSX runtimes](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) by configuring this preset with `{ runtime: 'automatic' }`. Keep in mind that you have to use compatible React version (`>=16.14.0`) to use this option and a compatible version of `@emotion/core` (`>=10.1.0`).
 
 ### Examples
 


### PR DESCRIPTION
This is super hard to document because there are many subtle details that one should account for, especially around how Babel doesn't (currently) allow `@jsxImportSource` to be used when the runtime is configured to be classic and how using `@jsx` throws when the runtime is configured to be automatic. At the same time, it's easy to overload users with those subtle details and it doesn't seem right. 

I propose rolling with smth like this and observe reported issues to assess which parts require more details to be put in the docs. At the same time, I'm still discussing the possibility to lift some of those restrictions in Babel so using this might become more straight-forward in the future