### PR TITLE
Only use `'@babel/plugin-transform-react-jsx-development'` based on the `development` option when `runtime` is set to `"automatic"`

### DIFF
--- a/.changeset/wicked-baboons-vanish.md
+++ b/.changeset/wicked-baboons-vanish.md
@@ -1,0 +1,5 @@
+---
+'@emotion/babel-preset-css-prop': patch
+---
+
+Only use `'@babel/plugin-transform-react-jsx-development'` based on the `development` option when `runtime` is set to `"automatic"`. The classic runtime is not compatible with this plugin.

--- a/packages/babel-preset-css-prop/src/index.js
+++ b/packages/babel-preset-css-prop/src/index.js
@@ -34,15 +34,15 @@ export default (
         pragmatic,
         { export: 'jsx', module: '@emotion/core', import: pragmaName }
       ],
-      [
-        development ? jsxDev : jsx,
-        {
-          ...(options.runtime === 'automatic'
-            ? { importSource: '@emotion/core' }
-            : { pragma: pragmaName, pragmaFrag: 'React.Fragment' }),
-          ...options
-        }
-      ],
+      options.runtime === 'automatic'
+        ? [
+            development ? jsxDev : jsx,
+            { importSource: '@emotion/core', ...options }
+          ]
+        : [
+            jsx,
+            { pragma: pragmaName, pragmaFrag: 'React.Fragment', ...options }
+          ],
       [
         emotion,
         {


### PR DESCRIPTION
fixes #2082