### PR TITLE
DOCS: Typescript typeof theme for less typing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Prerequisites
 
-- [Node.js](http://nodejs.org/) >= v7 must be installed.
+- [Node.js](http://nodejs.org/) >= v7 <= 12 must be installed.
 - [Yarn](https://yarnpkg.com/en/docs/install)
 
 ## Installation

--- a/docs/typescript.mdx
+++ b/docs/typescript.mdx
@@ -238,16 +238,18 @@ _styled.tsx_
 ```tsx
 import styled, { CreateStyled } from '@emotion/styled'
 
-type Theme = {
+const theme = {
   color: {
-    primary: string
-    positive: string
-    negative: string
+    primary: 'blue'
+    positive: 'green'
+    negative: 'red'
   }
   // ...
 }
 
-export default styled as CreateStyled<Theme>
+export type ThemeType = typeof theme
+
+export default styled as CreateStyled<ThemeType>
 ```
 
 _Button.tsx_
@@ -263,3 +265,5 @@ const Button = styled('button')`
 
 export default Button
 ```
+
+Note that the `export type ThemeType ...` statement above allows you to import the ThemeType for use with the `useTheme()` hook.


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: I made a small change to the typescript documentation page and the contribution guildelines.

<!-- Why are these changes necessary? -->
**Why**: The current typescript docs suggest to create a type of the Theme object. I changed this to let Typescript generate the type for us, with `typeof theme`. The update to CONTRIBUTION.md was made because the installation of the project failes with a node version above 12. More specifically the compilation of the sharp dependency (https://github.com/lovell/sharp/issues/1909).

<!-- How were these changes implemented? -->
**How**: Just some text changes to the docs.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->


<!-- feel free to add additional comments -->
