### PR TITLE
[DOCS] Fixed link to options of @emotion/cache package on CacheProvider page

### DIFF
--- a/docs/cache-provider.mdx
+++ b/docs/cache-provider.mdx
@@ -2,7 +2,7 @@
 title: 'CacheProvider'
 ---
 
-It can be useful to customize emotion's options - i.e. to add custom Stylis plugins, customize prefix of inserted class names, render style tags into specific element and more. You can look up full list of options [here](/packages/@emotion/cache#options).
+It can be useful to customize emotion's options - i.e. to add custom Stylis plugins, customize prefix of inserted class names, render style tags into specific element and more. You can look up full list of options [here](/packages/cache#options).
 
 ```jsx
 // @live


### PR DESCRIPTION
**What**:

I made a quick fix of link to page of @emotion/cache package on CacheProvider page in docs.

**Why**:
Currently link inside text on CacheProvider redirects to https://emotion.sh/docs/@emotion/@emotion/cache#options which display "Not found". 

> [...] You can look up full list of options [here](https://emotion.sh/docs/@emotion/@emotion/cache#options).

**How**:
Changed link from: `/packages/@emotion/cache#options` to `/packages/cache#options`

**Checklist**:
- [x] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A
- [ ] Changeset N/A

**Question**:
The code preview is broken and displays `Module "stylis" not found` on the CacheProvider page. I wanted to fix it to, but after I added stylis to scope in `Playground.js` file I got another error because `customPlugin` is not defined. I would remove `stylisPlugins` and leave only the `key` inside `createCache` options or I would remove live preview in this example. 
What do You think?