### PR TITLE
Remove extra characters

### DIFF
--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -35,7 +35,7 @@ A nonce that will be set on each style tag that emotion inserts for [Content Sec
 
 ### `stylisPlugins`
 
-``Array<Function>`
+`Array<Function>`
 
 A Stylis plugins that will be run by Stylis during preprocessing. [Read the Stylis docs to find out more](https://github.com/thysultan/stylis.js#middleware). This can be used for many purposes such as RTL.
 
@@ -45,7 +45,7 @@ A Stylis plugins that will be run by Stylis during preprocessing. [Read the Styl
 
 ### `key`
 
-`string`,
+`string`
 
 The prefix before class names. It will also be set as the value of the `data-emotion` attribute on the style tags that emotion inserts and it's used in the attribute name that marks style elements in `renderStylesToString` and `renderStylesToNodeStream`. This is **required if using multiple emotion caches in the same app**.
 


### PR DESCRIPTION
**What**:
I removed extra characters from README.md of @emotion/cache.

**Why**:
This is because the markdown was broken.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A
- [ ] Changeset N/A

<!-- feel free to add additional comments -->
