### PR TITLE
Fix emotion label not being applied to components with numbers in name

### DIFF
--- a/.changeset/nasty-starfishes-retire.md
+++ b/.changeset/nasty-starfishes-retire.md
@@ -1,0 +1,5 @@
+---
+'@emotion/react': patch
+---
+
+Fix emotion label not being applied to components with numbers in name

--- a/.changeset/nasty-starfishes-retire.md
+++ b/.changeset/nasty-starfishes-retire.md
@@ -2,4 +2,4 @@
 '@emotion/react': patch
 ---
 
-Improved label extraction from the stack traces. We should be able to extract labels from components with numbers in their names now.
+Improved label extraction from the stack traces to handle components with numbers in their names.

--- a/.changeset/nasty-starfishes-retire.md
+++ b/.changeset/nasty-starfishes-retire.md
@@ -2,4 +2,4 @@
 '@emotion/react': patch
 ---
 
-Fix emotion label not being applied to components with numbers in name
+Improved label extraction from the stack traces. We should be able to extract labels from components with numbers in their names now.

--- a/packages/react/src/emotion-element.js
+++ b/packages/react/src/emotion-element.js
@@ -44,7 +44,7 @@ export const createEmotionProps = (type: React.ElementType, props: Object) => {
     if (error.stack) {
       // chrome
       let match = error.stack.match(
-        /at (?:Object\.|Module\.|)(?:jsx|createEmotionProps).*\n\s+at (?:Object\.|)([A-Z][A-Za-z$]+) /
+        /at (?:Object\.|Module\.|)(?:jsx|createEmotionProps).*\n\s+at (?:Object\.|)([A-Z][A-Za-z0-9$]+) /
       )
       if (!match) {
         // safari and firefox

--- a/packages/react/src/emotion-element.js
+++ b/packages/react/src/emotion-element.js
@@ -48,7 +48,7 @@ export const createEmotionProps = (type: React.ElementType, props: Object) => {
       )
       if (!match) {
         // safari and firefox
-        match = error.stack.match(/.*\n([A-Z][A-Za-z$]+)@/)
+        match = error.stack.match(/.*\n([A-Z][A-Za-z0-9$]+)@/)
       }
       if (match) {
         newProps[labelPropName] = sanitizeIdentifier(match[1])


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes emotion label in development not being applied to components with numbers in component name.

```js
/** @jsx jsx */
import { jsx } from '@emotion/react'

// className: css-2a3l4r-MyComponent
const MyComponent = () => <div css={{}}  />

// className: css-fhsrqh
const MyComponentNo1 = () => <div css={{}}  />
```

<!-- Why are these changes necessary? -->

**Why**:

Components with numbers in their name deserve the same love and recognition within the Elements tab in Chrome devtools!

<!-- How were these changes implemented? -->

**How**:

Adding numbers to the regex which is used to identify the emotion label.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
