### PR TITLE
docs(cache): prepend should be described as a bool

### DIFF
--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -59,4 +59,4 @@ A DOM node that emotion will insert all of its style tags into. This is useful f
 
 `boolean`
 
-A string representing whether to prepend rather than append style tags into the specified container DOM node.
+A boolean representing whether to prepend rather than append style tags into the specified container DOM node.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

docs only: `prepend` is typed a boolean but described as a string.
<!-- Why are these changes necessary? -->

**Why**:

`prepend` is typed a boolean.
<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A
- [ ] Changeset N/A <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
