### PR TITLE
Update type import

### DIFF
--- a/docs/typescript.mdx
+++ b/docs/typescript.mdx
@@ -62,7 +62,7 @@ When using our jsx pragma the support for `css` prop is being added only for com
 However, it's not possible to leverage `css` prop support being added conditionally based on a type of rendered component when one is not using our jsx pragma. For those cases when people use our pragma implicitly (for example when using our `@emotion/babel-preset-css-prop`) we have a special file that can be imported once to add support for the `css` prop globally, for all components. Use it like this:
 
 ```ts
-import {} from '@emotion/react/types/css-prop'
+import type {} from '@emotion/react/types/css-prop'
 ```
 
 ## @emotion/styled


### PR DESCRIPTION
 What changes are being made? (What feature/bug is being fixed here?) 

When using the css prop in my Next.js project as suggested in the docs, TypeScript gave me an error message (see screenshot).

Why are these changes necessary? 

The suggested solution did not work. It gave me this error message:
![error_message](https://user-images.githubusercontent.com/66747385/100272520-94359100-2f5b-11eb-91df-6a869ffdd74b.jpg)


How were these changes implemented?

By adding the word "type" (as described in https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export). 

Have you done all of these things?  

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation "N/A"
- [ ] Tests "N/A"
- [ ] Code complete "N/A"
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
