### PR TITLE
Fix `css` prop missing from props types in TypeScript

### DIFF
--- a/.changeset/perfect-spoons-whisper.md
+++ b/.changeset/perfect-spoons-whisper.md
@@ -2,4 +2,4 @@
 '@emotion/react': patch
 ---
 
-Add `css` prop to all types of props with className: string
+Fixed an issue with `css` prop type not being added to all components that accept a string `className` correctly.

--- a/.changeset/perfect-spoons-whisper.md
+++ b/.changeset/perfect-spoons-whisper.md
@@ -1,0 +1,5 @@
+---
+'@emotion/react': patch
+---
+
+Add `css` prop to all types of props with className: string

--- a/packages/react/types/jsx-namespace.d.ts
+++ b/packages/react/types/jsx-namespace.d.ts
@@ -2,8 +2,8 @@ import 'react'
 import { Interpolation } from '@emotion/serialize'
 import { Theme } from './index'
 
-type WithConditionalCSSProp<P> = 'className' extends keyof P
-  ? (P extends { className?: string } ? P & { css?: Interpolation<Theme> } : P)
+declare type WithConditionalCSSProp<P> = { className: string } extends P
+  ? P & { css?: Interpolation<Theme> }
   : P
 
 // unpack all here to avoid infinite self-referencing when defining our own JSX namespace

--- a/packages/react/types/jsx-namespace.d.ts
+++ b/packages/react/types/jsx-namespace.d.ts
@@ -2,8 +2,12 @@ import 'react'
 import { Interpolation } from '@emotion/serialize'
 import { Theme } from './index'
 
-type WithConditionalCSSProp<P> = { className: string } extends P
-  ? P & { css?: Interpolation<Theme> }
+// prettier-ignore
+type WithConditionalCSSProp<P> =
+  'className' extends keyof P
+    ? string extends P['className' & keyof P]
+      ? P & { css?: Interpolation<Theme> }
+      : P
   : P
 
 // unpack all here to avoid infinite self-referencing when defining our own JSX namespace

--- a/packages/react/types/jsx-namespace.d.ts
+++ b/packages/react/types/jsx-namespace.d.ts
@@ -2,12 +2,10 @@ import 'react'
 import { Interpolation } from '@emotion/serialize'
 import { Theme } from './index'
 
-// prettier-ignore
-type WithConditionalCSSProp<P> =
-  'className' extends keyof P
-    ? string extends P['className' & keyof P]
-      ? P & { css?: Interpolation<Theme> }
-      : P
+type WithConditionalCSSProp<P> = 'className' extends keyof P
+  ? string extends P['className' & keyof P]
+    ? P & { css?: Interpolation<Theme> }
+    : P
   : P
 
 // unpack all here to avoid infinite self-referencing when defining our own JSX namespace

--- a/packages/react/types/jsx-namespace.d.ts
+++ b/packages/react/types/jsx-namespace.d.ts
@@ -2,7 +2,7 @@ import 'react'
 import { Interpolation } from '@emotion/serialize'
 import { Theme } from './index'
 
-declare type WithConditionalCSSProp<P> = { className: string } extends P
+type WithConditionalCSSProp<P> = { className: string } extends P
   ? P & { css?: Interpolation<Theme> }
   : P
 

--- a/packages/react/types/tests.tsx
+++ b/packages/react/types/tests.tsx
@@ -8,6 +8,7 @@ import {
   keyframes,
   withEmotionCache
 } from '@emotion/react'
+import { WithConditionalCSSProp } from './jsx-namespace'
 
 declare module '@emotion/react' {
   // tslint:disable-next-line: strict-export-declare-modifiers
@@ -159,14 +160,20 @@ const anim1 = keyframes`
 
   // TS@next reports an error on a different line, so this has to be in a single line so `test:typescript` can validate this on all TS versions correctly
   // $ExpectError
-  ;<CompWithoutClassNameSupport prop1="test" css={{ backgroundColor: 'hotpink' }} />
+  ;<CompWithoutClassNameSupport
+    prop1="test"
+    css={{ backgroundColor: 'hotpink' }}
+  />
 
   const MemoedCompWithoutClassNameSupport = React.memo(
     CompWithoutClassNameSupport
   )
   // TS@next reports an error on a different line, so this has to be in a single line so `test:typescript` can validate this on all TS versions correctly
   // $ExpectError
-  ;<MemoedCompWithoutClassNameSupport prop1="test" css={{ backgroundColor: 'hotpink' }} />
+  ;<MemoedCompWithoutClassNameSupport
+    prop1="test"
+    css={{ backgroundColor: 'hotpink' }}
+  />
 }
 
 {
@@ -181,6 +188,31 @@ const anim1 = keyframes`
   // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/40993
   // this is really problematic behaviour by @types/react IMO
   // but it's what @types/react does so let's not break it.
-  const CompWithImplicitChildren: React.FC = () => null;
-  ;<CompWithImplicitChildren>content<div/></CompWithImplicitChildren>
+  const CompWithImplicitChildren: React.FC = () => null
+  ;<CompWithImplicitChildren>
+    content
+    <div />
+  </CompWithImplicitChildren>
+}
+
+// Tests for WithConditionalCSSProp
+{
+  type _HasCssPropAsIntended3 = WithConditionalCSSProp<{
+    className?: string
+  }>['css']
+  type _HasCssPropAsIntended4 = WithConditionalCSSProp<{
+    className: string
+  }>['css']
+  type _HasCssPropAsIntended5 = WithConditionalCSSProp<{
+    className?: unknown
+  }>['css']
+  type _HasCssPropAsIntended6 = WithConditionalCSSProp<{
+    className?: string | string[]
+  }>['css']
+
+  const _noCssPropAsIntended1: 'css' extends keyof WithConditionalCSSProp<{
+    className?: undefined
+  }>
+    ? true
+    : false = false
 }

--- a/packages/react/types/tests.tsx
+++ b/packages/react/types/tests.tsx
@@ -160,20 +160,14 @@ const anim1 = keyframes`
 
   // TS@next reports an error on a different line, so this has to be in a single line so `test:typescript` can validate this on all TS versions correctly
   // $ExpectError
-  ;<CompWithoutClassNameSupport
-    prop1="test"
-    css={{ backgroundColor: 'hotpink' }}
-  />
+  ;<CompWithoutClassNameSupport prop1="test" css={{ color: 'hotpink' }} />
 
   const MemoedCompWithoutClassNameSupport = React.memo(
     CompWithoutClassNameSupport
   )
   // TS@next reports an error on a different line, so this has to be in a single line so `test:typescript` can validate this on all TS versions correctly
   // $ExpectError
-  ;<MemoedCompWithoutClassNameSupport
-    prop1="test"
-    css={{ backgroundColor: 'hotpink' }}
-  />
+  ;<MemoedCompWithoutClassNameSupport prop1="test" css={{ color: 'hotpink' }} />
 }
 
 {

--- a/packages/react/types/tests.tsx
+++ b/packages/react/types/tests.tsx
@@ -191,24 +191,31 @@ const anim1 = keyframes`
 
 // Tests for WithConditionalCSSProp
 {
+  // $ExpectType Interpolation<Theme>
   type _HasCssPropAsIntended3 = EmotionJSX.LibraryManagedAttributes<
     {},
     {
       className?: string
     }
   >['css']
+
+  // $ExpectType Interpolation<Theme>
   type _HasCssPropAsIntended4 = EmotionJSX.LibraryManagedAttributes<
     {},
     {
       className: string
     }
   >['css']
+
+  // $ExpectType Interpolation<Theme>
   type _HasCssPropAsIntended5 = EmotionJSX.LibraryManagedAttributes<
     {},
     {
       className?: unknown
     }
   >['css']
+
+  // $ExpectType Interpolation<Theme>
   type _HasCssPropAsIntended6 = EmotionJSX.LibraryManagedAttributes<
     {},
     {
@@ -216,12 +223,11 @@ const anim1 = keyframes`
     }
   >['css']
 
-  const _noCssPropAsIntended1: 'css' extends keyof EmotionJSX.LibraryManagedAttributes<
+  // $ExpectType false
+  type _NoCssPropAsIntended1 = 'css' extends keyof EmotionJSX.LibraryManagedAttributes<
     {},
-    {
-      className?: undefined
-    }
+    { className?: undefined }
   >
     ? true
-    : false = false
+    : false
 }

--- a/packages/react/types/tests.tsx
+++ b/packages/react/types/tests.tsx
@@ -8,7 +8,7 @@ import {
   keyframes,
   withEmotionCache
 } from '@emotion/react'
-import { WithConditionalCSSProp } from './jsx-namespace'
+import { JSX as EmotionJSX } from '@emotion/react/jsx-runtime'
 
 declare module '@emotion/react' {
   // tslint:disable-next-line: strict-export-declare-modifiers
@@ -197,22 +197,37 @@ const anim1 = keyframes`
 
 // Tests for WithConditionalCSSProp
 {
-  type _HasCssPropAsIntended3 = WithConditionalCSSProp<{
-    className?: string
-  }>['css']
-  type _HasCssPropAsIntended4 = WithConditionalCSSProp<{
-    className: string
-  }>['css']
-  type _HasCssPropAsIntended5 = WithConditionalCSSProp<{
-    className?: unknown
-  }>['css']
-  type _HasCssPropAsIntended6 = WithConditionalCSSProp<{
-    className?: string | string[]
-  }>['css']
+  type _HasCssPropAsIntended3 = EmotionJSX.LibraryManagedAttributes<
+    {},
+    {
+      className?: string
+    }
+  >['css']
+  type _HasCssPropAsIntended4 = EmotionJSX.LibraryManagedAttributes<
+    {},
+    {
+      className: string
+    }
+  >['css']
+  type _HasCssPropAsIntended5 = EmotionJSX.LibraryManagedAttributes<
+    {},
+    {
+      className?: unknown
+    }
+  >['css']
+  type _HasCssPropAsIntended6 = EmotionJSX.LibraryManagedAttributes<
+    {},
+    {
+      className?: string | string[]
+    }
+  >['css']
 
-  const _noCssPropAsIntended1: 'css' extends keyof WithConditionalCSSProp<{
-    className?: undefined
-  }>
+  const _noCssPropAsIntended1: 'css' extends keyof EmotionJSX.LibraryManagedAttributes<
+    {},
+    {
+      className?: undefined
+    }
+  >
     ? true
     : false = false
 }

--- a/packages/react/types/tests.tsx
+++ b/packages/react/types/tests.tsx
@@ -218,7 +218,7 @@ const anim1 = keyframes`
   type _HasCssPropAsIntended6 = EmotionJSX.LibraryManagedAttributes<
     {},
     {
-      className?: string | string[]
+      className?: string | Array<string>
     }
   >['css']
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Sup folks. I fixed one small problem with WithConditionalCSSProp.

I was actually fixing a similar thing in another library https://github.com/system-ui/theme-ui/issues/1307.
I accidentaly auto-imported WithConditionalCSSProp instead of WithConditionalSxProps while writing tests, and I noticed you have exactly the same problem :D

**Why**:

**`css` prop is not added to all props types which accept `className` of type `string`, and it's also added to props which accept `className?: undefined`.**

[**Take a look at this TS Playground.**](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgSQHYwKZUgGwIYzASoA0cAKgBYYgZwC+cAZlBCHAOQACNEhxAeigY8AYxgcA3AChpMAJ5g6AdWAxKAYWIATNUVR4cGgMrGACqzAAeMwD44AXk6j8AZ1cA5PLQ5wMAD0xUbVc4AGsMeQgmODNpODgAfjgACjM-QIxg0KQXPHcvWkSALjhXGChgVABzBiTYuAAyRDhRdxKUdCxcAn0rKhoMe0ZSswBKeLhR2TlFOgB9AAl8jXcLCDAAIQBXGGNKCG2cbQ8+RzhVdS1gvWJDE3NLK1y3T28MDu3gjCYqjG0GLZZAolHB5qdVq51ltdvtDsdlgA3DAARnOl00OluBiMpmhz1ar0KH1KXzCqAgAHdUIDZqDwRBIdCdnsDkdtEiMAAmdFqTE3fg4h74l75N5FUrlSo1OAAHzKFSq1QA2gBdWl0hbLVxMywAQVcaCC2n+aKcGOuukF9zxT1FBXeksVMvoQJBWpWa31hq6320PPNfMt2Jtjw2BLyDolCultVdM2kAgEcAAtGnZCa8sI4O6LkGsdbcWGwB4AKLKGz2ByTBL28UYJ2xyR1ALG0JxBKdzvJdLNXLtUpG7oQfCC-rUWjDGtdqaxYFzMEQr0bA1Dv1mvNXAv6UPQssVuvEz7fX6of4a3NLT1Q71rk3aADMvK3Ap3Rb35YjRPeHSlStpl7arqK4+sa-wACzPvyVpvsKlj7l+YrEo2-7xoB17Qquvr3gArFBwaFnBGwIYeP6kqg5JUjSaELleOrLmAWFgdoABs+Hbnc77wZ+pHRn+MryvxKrqq6QA)

**How**:

We can read `extends` as _is assignable to_ or _is subset of_.
We need to add `css` prop to all props objects that can accept `className` prop of type `string`, so
- if `{ className: string }` is assignable to P
- or if we think of sets, if a set of all objects that have className property of type string is a subset of set P.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Code complete
- [x] Changeset

<!-- feel free to add additional comments
