### PR TITLE
fix: memoize broken on props present in prototype chain

### DIFF
--- a/.changeset/unlucky-swans-care.md
+++ b/.changeset/unlucky-swans-care.md
@@ -1,0 +1,5 @@
+---
+"@emotion/memoize": patch
+---
+
+Fixed an issue with prototype properties not being correctly handled.

--- a/packages/memoize/src/index.js
+++ b/packages/memoize/src/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 export default function memoize<V>(fn: string => V): string => V {
-  const cache = {}
+  const cache = Object.create(null)
 
   return (arg: string) => {
     if (cache[arg] === undefined) cache[arg] = fn(arg)


### PR DESCRIPTION
**Why**:

Test case (invalid results):
```js
> require('@emotion/memoize').default(x => x)('toString')
[Function: toString]
> require('@emotion/memoize').default(x => x)('constructor')
[Function: Object]
```

Memoize (and is-prop-valid) was broken on a number of arguments.

```js
> require('@emotion/is-prop-valid').default('constructor')
[Function: Object]
> require('@emotion/is-prop-valid').default('toString')
[Function: toString]
> require('@emotion/is-prop-valid').default('__proto__')
{}
```
Note that those are all truthy.

**How**:

Create the underlying storage object with a null prototype.
Could also have used a `Map`.

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests — No tests in that dir.
- [ ] Code complete N/A
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->
