### PR TITLE
update styled link

### DIFF
--- a/docs/styled.mdx
+++ b/docs/styled.mdx
@@ -2,7 +2,7 @@
 title: 'Styled Components'
 ---
 
-`styled` is a way to create React components that have styles attached to them. It's available from [@emotion/styled](/packages/@emotion/styled). `styled` was heavily inspired by [styled-components](https://www.styled-components.com/) and [glamorous](https://glamorous.rocks/)
+`styled` is a way to create React components that have styles attached to them. It's available from [@emotion/styled](/packages/styled). `styled` was heavily inspired by [styled-components](https://www.styled-components.com/) and [glamorous](https://glamorous.rocks/)
 
 ### Styling elements and components
 


### PR DESCRIPTION
**What**: update link on styled doc page

Current, broken URL: https://emotion.sh/docs/@emotion/@emotion/styled
Updated, correct URL: https://emotion.sh/docs/@emotion/styled

**Why**: documentation links should link to the correct documentation page

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Code complete N/A
- [ ] Changeset N/A

I could also use this PR to update the first two links on [this page](https://github.com/emotion-js/emotion/blob/master/docs/install.mdx), as well, as they have the same issue.
