### PR TITLE
update install page links

### DIFF
--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -2,7 +2,7 @@
 title: 'Install'
 ---
 
-There are lots of ways to use Emotion, if you're using React, the easiest way to get started is to use the [`@emotion/react` package](/packages/@emotion/react). If you're not using React, you should use [the `emotion` package](#vanilla).
+There are lots of ways to use Emotion, if you're using React, the easiest way to get started is to use the [`@emotion/react` package](/packages/react). If you're not using React, you should use [the `emotion` package](#vanilla).
 
 ```bash
 yarn add @emotion/react
@@ -73,7 +73,7 @@ const Button = styled.button`
 render(<Button>This is a hotpink button.</Button>)
 ```
 
-## With [`@emotion/babel-plugin`](/packages/@emotion/babel-plugin)
+## With [`@emotion/babel-plugin`](/packages/babel-plugin)
 
 > Note:
 >


### PR DESCRIPTION
**What**: update link on install docs page

Current, broken URL: https://emotion.sh/docs/@emotion/@emotion/babel-plugin
Updated, correct URL: https://emotion.sh/docs/@emotion/babel-plugin

similar for @emotion/react

**Why**: documentation links should link to the correct documentation page

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Code complete N/A
- [ ] Changeset N/A
