### PR TITLE
Replace is-prop regex to O(1) hash table compare

### DIFF
--- a/.changeset/ninety-toes-nail.md
+++ b/.changeset/ninety-toes-nail.md
@@ -1,0 +1,5 @@
+---
+'@emotion/is-prop-valid': patch
+---
+
+Replaces is-prop-valid HUGE RegExp to a small RegExp and a hash table increasing the performance

--- a/packages/is-prop-valid/src/index.js
+++ b/packages/is-prop-valid/src/index.js
@@ -1,17 +1,21 @@
 // @flow
 import memoize from '@emotion/memoize'
 
-declare var codegen: { require: string => RegExp }
+declare var codegen: { require: string => string }
 
-const reactPropsRegex = codegen.require('./props')
+const reactProps = JSON.parse(codegen.require('./props'))
+const reactPropsRegex = /^(([Dd][Aa][Tt][Aa]|[Aa][Rr][Ii][Aa]|x)-.*)$/
 
-// https://esbench.com/bench/5bfee68a4cd7e6009ef61d23
-const isPropValid = /* #__PURE__ */ memoize(
-  prop =>
-    reactPropsRegex.test(prop) ||
-    (prop.charCodeAt(0) === 111 /* o */ &&
+const isPropValid = /* #__PURE__ */ memoize(prop => {
+  const chars =
+    prop.charCodeAt(0) === 111 /* o */ &&
     prop.charCodeAt(1) === 110 /* n */ &&
-      prop.charCodeAt(2) < 91) /* Z+1 */
-)
+    prop.charCodeAt(2) < 91 /* Z+1 */
+
+  const inProps = reactProps[prop] === true
+  const inRegex = reactPropsRegex.test(prop)
+
+  return chars || inProps || inRegex
+})
 
 export default isPropValid

--- a/packages/is-prop-valid/src/props.js
+++ b/packages/is-prop-valid/src/props.js
@@ -476,6 +476,4 @@ const props = {
   autofocus: true
 }
 // eslint-disable-next-line import/no-commonjs
-module.exports = `/^((${Object.keys(props).join(
-  '|'
-)})|(([Dd][Aa][Tt][Aa]|[Aa][Rr][Ii][Aa]|x)-.*))$/`
+module.exports = JSON.stringify(JSON.stringify(props))


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
This PR improves is-prop-valid performance by replacing a huge (4Kb) RegExp with a small RegExp and a O(1) hash table.

<!-- Why are these changes necessary? -->

**Why**:
I am developing an e-commerce website using Gatsby.js and theme-ui. Theme-ui uses emotion-js. Analyzing my website in Google's Lighthouse, I figured out a huge TBT (total blocking time). Using Google Chrome's flamechart performance analyzer, I've figured out that a huge time was spent running is-prop-valid.

Using some webpack aliases, I've managed to use my own implementation of `@emtion/is-prop-valid`. This change completely removed the blocking time in Chrome's performance flamechart. [This PR](https://github.com/vtex/faststore/pull/370) explains a little bit better the changes I've done in theme-ui.

I'm now backporting my custom is-prop-valid implementation to emotion-js so everybody can benefit from this performance improvement 

<!-- How were these changes implemented? -->

**How**:
`@emotion/is-prop-valid` is a small, two files package. One package contains the is-prop-valid function implementation and the other contains all the data for generating a RegExp that computes if a prop is valid or not. 

This final RegExp is something like `/^(children|dangerouslySetInnerHTML|key)$/`. This RegExp could be replaced by the following hash table
```
{
   children: true,
   dangerouslySetInnerHTML: true,
   key: true
}
```

By doing this replacement, we can achieve greater performance. 

Also, serializing this hash table in the final JS is important. This PR uses the old JSON.parse/JSON.serialize technique for speeding up compile/parse times. To understand a little bit more about this technique, take a look at [this video](https://www.youtube.com/watch?v=ff4fgQxPaO0)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests N/A
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->

I'd like to thank you for reading my small contribution. If you have any suggestions/comments, please feel free to let me know

Thanks !