### PR TITLE
Fix TypeScript support for custom components with non-standard declarations

### DIFF
--- a/.changeset/silent-otters-build.md
+++ b/.changeset/silent-otters-build.md
@@ -1,0 +1,5 @@
+---
+'@emotion/react': patch
+---
+
+Fixes React components with custom/generic render functions

--- a/.changeset/silent-otters-build.md
+++ b/.changeset/silent-otters-build.md
@@ -2,4 +2,4 @@
 '@emotion/react': patch
 ---
 
-Fixes React components with custom/generic render functions
+Fixed some typing issues with React components with custom generic render functions.

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -1,5 +1,5 @@
 // Definitions by: Junyoung Clare Jang <https://github.com/Ailrun>
-// TypeScript Version: 3.2
+// TypeScript Version: 3.4
 
 import { EmotionCache } from '@emotion/cache'
 import {

--- a/packages/react/types/jsx-namespace.d.ts
+++ b/packages/react/types/jsx-namespace.d.ts
@@ -4,9 +4,9 @@ import { Theme } from './index'
 
 type WithConditionalCSSProp<P> = 'className' extends keyof P
   ? string extends P['className' & keyof P]
-    ? P & { css?: Interpolation<Theme> }
-    : P
-  : P
+    ? { css?: Interpolation<Theme> }
+    : {}
+  : {}
 
 // unpack all here to avoid infinite self-referencing when defining our own JSX namespace
 type ReactJSXElement = JSX.Element

--- a/packages/react/types/tests.tsx
+++ b/packages/react/types/tests.tsx
@@ -231,3 +231,19 @@ const anim1 = keyframes`
     ? true
     : false
 }
+
+// RMWC-like component test
+declare const OtherComponent: {
+  <Tag extends React.ElementType<any> = 'input'>(
+    props:
+      | React.AllHTMLAttributes<HTMLInputElement>
+      | React.ComponentPropsWithRef<Tag>,
+    ref: any
+  ): JSX.Element
+  displayName?: string
+}
+;<OtherComponent
+  onChange={ev => {
+    console.log(ev.currentTarget.value)
+  }}
+/>

--- a/packages/react/types/tests.tsx
+++ b/packages/react/types/tests.tsx
@@ -234,7 +234,7 @@ const anim1 = keyframes`
 
 // RMWC-like component test
 declare const OtherComponent: {
-  <Tag extends React.ElementType<any> = 'input'>(
+  <Tag extends React.ElementType>(
     props:
       | React.AllHTMLAttributes<HTMLInputElement>
       | React.ComponentPropsWithRef<Tag>,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
This PR makes a tiny modification to #2140 in order to fix support for components that do not use `React.ComponentType` but rather a custom declaration with a generic render function.

<!-- Why are these changes necessary? -->

**Why**:
A certain package [RMWC](https://rmwc.io) has been causing issues when using `"jsxImportSource": "@emotion/react"`. For instance, the types of the parameters passed to event handlers such as `onClick` were `any`. I investigated the problem and discovered that the components were not declared with `React.ComponentType`; instead, they had a generic render function to add support for a `tag` property that changes the underlying DOM element used (e.g. `tag="div"` can be used to make a button use a div element internally). These changes resolve the issues and fix the typings on event handlers.

<!-- How were these changes implemented? -->

**How**:
In all honesty: absolutely no idea. However, it seems to me that `LibraryManagedAttributes` is meant to only specify the attributes that will be handled outside of React, whereas Emotion was previously including P in the intersection no matter what. This may have caused attributes to have been duplicated and merged with a union. For functions, unions make typing the parameters impossible in TypeScript, which would be the cause of the implicit `any` issues. Of course, this is all speculation.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
Again, I'm really not sure *how* this works, but I do know that it does work.
CodeSandbox: https://codesandbox.io/s/gallant-snowflake-xt8dy