### PR TITLE
Fixed issue with typescript and mutable refs

### DIFF
--- a/.changeset/purple-goats-exercise.md
+++ b/.changeset/purple-goats-exercise.md
@@ -1,0 +1,6 @@
+---
+'@emotion/native': patch
+'@emotion/styled': patch
+---
+
+Fixed issue with typescript and mutable refs

--- a/packages/native/types/base.d.ts
+++ b/packages/native/types/base.d.ts
@@ -82,7 +82,7 @@ export interface StyledComponent<
   ): StyledComponent<
     ComponentProps & React.ComponentProps<C>,
     {},
-    { ref?: React.Ref<InstanceType<C>> }
+    { ref?: React.Ref<InstanceType<C> | undefined> }
   >
   withComponent<C extends React.ComponentType<React.ComponentProps<C>>>(
     component: C
@@ -156,7 +156,7 @@ export interface CreateStyled {
       as?: React.ElementType
     },
     {},
-    { ref?: React.Ref<InstanceType<C>> },
+    { ref?: React.Ref<InstanceType<C> | undefined> },
     ReactNativeStyleType<React.ComponentProps<C>>
   >
 
@@ -169,7 +169,7 @@ export interface CreateStyled {
       as?: React.ElementType
     },
     {},
-    { ref?: React.Ref<InstanceType<C>> },
+    { ref?: React.Ref<InstanceType<C> | undefined> },
     ReactNativeStyleType<React.ComponentProps<C>>
   >
 

--- a/packages/styled/types/base.d.ts
+++ b/packages/styled/types/base.d.ts
@@ -45,7 +45,7 @@ export interface StyledComponent<
   ): StyledComponent<
     ComponentProps & PropsOf<C>,
     {},
-    { ref?: React.Ref<InstanceType<C>> }
+    { ref?: React.Ref<InstanceType<C> | undefined> }
   >
   withComponent<C extends React.ComponentType<React.ComponentProps<C>>>(
     component: C
@@ -132,7 +132,7 @@ export interface CreateStyled {
     },
     {},
     {
-      ref?: React.Ref<InstanceType<C>>
+      ref?: React.Ref<InstanceType<C> | undefined>
     }
   >
 
@@ -146,7 +146,7 @@ export interface CreateStyled {
     },
     {},
     {
-      ref?: React.Ref<InstanceType<C>>
+      ref?: React.Ref<InstanceType<C> | undefined>
     }
   >
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Typescript definitions for refs.

<!-- Why are these changes necessary? -->

**Why**:

When using mutable refs, typescript will throw an error

<!-- How were these changes implemented? -->

**How**:

Changed the typescript definitions.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] ~Documentation~ N/A
- [ ] ~Tests~ N/A
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->

**Example**

This code was not valid in typescript prior to the changes:

```jsx
import { FunctionComponent, useRef } from 'react'
import { View } from 'react-native'
import styled from 'emotion/native'

const MyComponent: FunctionComponent = () => {
  const ref = useRef<View>()
  
  return <MyStyledComponent ref={ref} />
}

const MyStyledComponent = styled(View)`
  background-color: red;
`
```