### PR TITLE
add "option", "fallback" amp html property to whitelist

### DIFF
--- a/.changeset/wet-apes-report.md
+++ b/.changeset/wet-apes-report.md
@@ -1,0 +1,5 @@
+---
+"@emotion/is-prop-valid": minor
+---
+
+Added `option` & `fallback` AMP props to the list of valid props.

--- a/packages/is-prop-valid/src/props.js
+++ b/packages/is-prop-valid/src/props.js
@@ -186,6 +186,9 @@ const props = {
   autoSave: true,
   // color is for Safari mask-icon link
   color: true,
+  // used in amp html for indicating the fallback behavior
+  // https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/placeholders/
+  fallback: true,
   // https://html.spec.whatwg.org/multipage/interaction.html#inert
   inert: true,
   // itemProp, itemScope, itemType are for
@@ -199,7 +202,11 @@ const props = {
   itemID: true,
   itemRef: true,
   // used in amp html for eventing purposes
+  // https://amp.dev/documentation/guides-and-tutorials/learn/common_attributes/
   on: true,
+  // used in amp html for indicating that the option is selectable
+  // https://amp.dev/documentation/components/amp-selector/
+  option: true,
   // results show looking glass icon and recent searches on input
   // search fields in WebKit/Blink
   results: true,


### PR DESCRIPTION
**What**:

fixed https://github.com/emotion-js/emotion/issues/2224

Add attributes for AMP html to is-prop-valid.

**Why**:

Because, styled-component drops these attributes.

**How**:

Add them in props.js.

**Checklist**:

- [ ] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->

## Additional Context

should consider these transient props in v12.

refer: 
> y'all should consider considering transient props in v12 so you can drop this whitelist though

https://github.com/emotion-js/emotion/issues/2224#issuecomment-767648912
