### PR TITLE
Remove `as` prop for composed components (fixes #2238)

### DIFF
--- a/.changeset/tall-chairs-watch.md
+++ b/.changeset/tall-chairs-watch.md
@@ -1,0 +1,5 @@
+---
+'@emotion/styled': patch
+---
+
+TS declaration fix: remove `as` prop for composed components

--- a/.changeset/tall-chairs-watch.md
+++ b/.changeset/tall-chairs-watch.md
@@ -2,4 +2,4 @@
 '@emotion/styled': patch
 ---
 
-TS declaration fix: remove `as` prop for composed components
+`as` prop has been removed from TypeScript declarations for composite components. This prop has not actually been handled by default by `styled` for those components - to make `styled` handle it you need to provide a custom `shouldForwardProp` that doesn't forward the `as` prop.

--- a/packages/styled/types/base.d.ts
+++ b/packages/styled/types/base.d.ts
@@ -128,7 +128,6 @@ export interface CreateStyled {
   ): CreateStyledComponent<
     Pick<PropsOf<C>, ForwardedProps> & {
       theme?: Theme
-      as?: React.ElementType
     },
     {},
     {
@@ -142,7 +141,6 @@ export interface CreateStyled {
   ): CreateStyledComponent<
     PropsOf<C> & {
       theme?: Theme
-      as?: React.ElementType
     },
     {},
     {
@@ -161,7 +159,6 @@ export interface CreateStyled {
   ): CreateStyledComponent<
     Pick<PropsOf<C>, ForwardedProps> & {
       theme?: Theme
-      as?: React.ElementType
     }
   >
 
@@ -171,7 +168,6 @@ export interface CreateStyled {
   ): CreateStyledComponent<
     PropsOf<C> & {
       theme?: Theme
-      as?: React.ElementType
     }
   >
 

--- a/packages/styled/types/tests.tsx
+++ b/packages/styled/types/tests.tsx
@@ -184,6 +184,14 @@ const Input5 = styled.input`
   // $ExpectError
   ;<StyledWithAs as="random string" />
 
+  const ComposedWithAs = styled(StyledWithAs)`
+    flex-direction: column;
+  `
+  ;<ComposedWithAs as="section" />
+  ;<ComposedWithAs as={Section} />
+  // $ExpectError
+  ;<ComposedWithAs as="random string" />
+
   const ComponentWithAs: React.FC<{ as: string; className?: string }> = ({
     as,
     className
@@ -196,11 +204,16 @@ const Input5 = styled.input`
   // $ExpectError
   ;<StyledComp as={Section} />
 
-  const ComposedWithAs = styled(StyledWithAs)`
-    flex-direction: column;
+  const ComponentWithoutAs: React.FC<{ className?: string }> = props => (
+    <div {...props} />
+  )
+  const StyledCompWithoutAs = styled(ComponentWithoutAs)`
+    background: hotpink;
   `
-  ;<ComposedWithAs as="section" />
-  ;<ComposedWithAs as={Section} />
   // $ExpectError
-  ;<ComposedWithAs as="random string" />
+  ;<StyledCompWithoutAs as="random string" />
+  // $ExpectError
+  ;<StyledCompWithoutAs as="section" />
+  // $ExpectError
+  ;<StyledCompWithoutAs as={Section} />
 }

--- a/packages/styled/types/tests.tsx
+++ b/packages/styled/types/tests.tsx
@@ -181,4 +181,26 @@ const Input5 = styled.input`
   `
   ;<StyledWithAs as="section" />
   ;<StyledWithAs as={Section} />
+  // $ExpectError
+  ;<StyledWithAs as="random string" />
+
+  const ComponentWithAs: React.FC<{ as: string; className?: string }> = ({
+    as,
+    className
+  }) => <div className={className}>{as}</div>
+
+  const StyledComp = styled(ComponentWithAs)`
+    background: orange;
+  `
+  ;<StyledComp as="random string" />
+  // $ExpectError
+  ;<StyledComp as={Section} />
+
+  const ComposedWithAs = styled(StyledWithAs)`
+    flex-direction: column;
+  `
+  ;<ComposedWithAs as="section" />
+  ;<ComposedWithAs as={Section} />
+  // $ExpectError
+  ;<ComposedWithAs as="random string" />
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
fix #2238 

<!-- Why are these changes necessary? -->

**Why**:
discussed in the issue

<!-- How were these changes implemented? -->

**How**:
Just removed the `as` prop from packages/styled/types/base.d.ts + added some tests

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
