### PR TITLE
docs(babel-preset-css-prop): correcting invalid information in examples

### DIFF
--- a/.changeset/rich-walls-beam.md
+++ b/.changeset/rich-walls-beam.md
@@ -2,4 +2,4 @@
 '@emotion/babel-preset-css-prop': patch
 ---
 
-correct invalid examples for @emotion/babel-preset-css-prop
+Fixed invalid examples

--- a/.changeset/rich-walls-beam.md
+++ b/.changeset/rich-walls-beam.md
@@ -1,5 +1,5 @@
 ---
-'@emotion/babel-preset-css-prop': major
+'@emotion/babel-preset-css-prop': patch
 ---
 
 correct invalid examples for @emotion/babel-preset-css-prop

--- a/.changeset/rich-walls-beam.md
+++ b/.changeset/rich-walls-beam.md
@@ -1,0 +1,5 @@
+---
+'@emotion/babel-preset-css-prop': major
+---
+
+correct invalid examples for @emotion/babel-preset-css-prop

--- a/packages/babel-preset-css-prop/README.md
+++ b/packages/babel-preset-css-prop/README.md
@@ -153,13 +153,15 @@ Options for both `@emotion/babel-plugin` and `@babel/plugin-transform-react-jsx`
 ```json
 {
   "presets": [
-    "@emotion/babel-preset-css-prop",
-    {
-      "autoLabel": "dev-only",
-      "labelFormat": "[local]",
-      "useBuiltIns": false,
-      "throwIfNamespace": true
-    }
+    [
+      "@emotion/babel-preset-css-prop",
+      {
+        "autoLabel": "dev-only",
+        "labelFormat": "[local]",
+        "useBuiltIns": false,
+        "throwIfNamespace": true
+      }
+    ]
   ]
 }
 ```


### PR DESCRIPTION
fixed #2245 

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Incorrect information was corrected in the example.

<!-- Why are these changes necessary? -->

**Why**: The information needs to be modified because the open source user can be confused due to incorrect information.

<!-- How were these changes implemented? -->

**How**: Successfully modified examples part in README in @emotion/babel-preset-css-prop.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [X] Documentation
- [X] Tests
- [X] Code complete
- [X] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
