### PR TITLE
fix(eslint-plugin): ignore `css` function when checking for object style

### DIFF
--- a/.changeset/long-ladybugs-pull.md
+++ b/.changeset/long-ladybugs-pull.md
@@ -2,4 +2,4 @@
 '@emotion/eslint-plugin': patch
 ---
 
-Adjusts `syntax-preference` eslint rule to support "ignoring" usage of the `css` function when checking the `css` prop for object syntax.
+Improved `syntax-preference` rule to support `css` function and check style types for arguments of `css` & styled calls.

--- a/.changeset/long-ladybugs-pull.md
+++ b/.changeset/long-ladybugs-pull.md
@@ -1,0 +1,5 @@
+---
+'@emotion/eslint-plugin': patch
+---
+
+Adjusts `syntax-preference` eslint rule to support "ignoring" usage of the `css` function when checking the `css` prop for object syntax.

--- a/packages/eslint-plugin/src/rules/syntax-preference.js
+++ b/packages/eslint-plugin/src/rules/syntax-preference.js
@@ -65,6 +65,13 @@ const checkCssPropExpressionPreferringObject = (context, node) => {
       )
       return
     case 'CallExpression':
+      // assume the call is to the "css", which might be under a different name
+      if (node.arguments.length === 1) {
+        checkCssPropExpressionPreferringObject(context, node.arguments[0])
+
+        return
+      }
+
       context.report({
         node,
         message: MSG_PREFER_OBJECT_STYLE

--- a/packages/eslint-plugin/test/rules/syntax-preference.test.js
+++ b/packages/eslint-plugin/test/rules/syntax-preference.test.js
@@ -140,6 +140,10 @@ ruleTester.run('syntax-preference (object)', rule, {
     {
       code: `const Foo = () => <div css={{ color: 'hotpink' }} />`,
       options: ['object']
+    },
+    {
+      code: `const Foo = () => <div css={css({ color: 'hotpink' })} />`,
+      options: ['object']
     }
   ],
 
@@ -196,6 +200,20 @@ ruleTester.run('syntax-preference (object)', rule, {
     },
     {
       code: `const Foo = () => <div css={['background-color: green;', css\`color: hotpink;\`]} />`,
+      options: ['object'],
+      errors: [
+        {
+          message: 'Styles should be written using objects.',
+          type: 'Literal'
+        },
+        {
+          message: 'Styles should be written using objects.',
+          type: 'TaggedTemplateExpression'
+        }
+      ]
+    },
+    {
+      code: `const Foo = () => <div css={css(['background-color: green;', css\`color: hotpink;\`])} />`,
       options: ['object'],
       errors: [
         {

--- a/packages/eslint-plugin/test/rules/syntax-preference.test.js
+++ b/packages/eslint-plugin/test/rules/syntax-preference.test.js
@@ -51,6 +51,14 @@ ruleTester.run('syntax-preference (string)', rule, {
     {
       code: `const Foo = () => <div css={[styles, otherStyles]} />`,
       options: ['string']
+    },
+    {
+      code: `css\`color: hotpink;\``,
+      options: ['string']
+    },
+    {
+      code: `css(cls, css\`color: hotpink;\`)`,
+      options: ['string']
     }
   ],
 
@@ -61,7 +69,7 @@ ruleTester.run('syntax-preference (string)', rule, {
       errors: [
         {
           message: 'Styles should be written using strings.',
-          type: 'CallExpression'
+          type: 'ObjectExpression'
         }
       ]
     },
@@ -71,7 +79,7 @@ ruleTester.run('syntax-preference (string)', rule, {
       errors: [
         {
           message: 'Styles should be written using strings.',
-          type: 'CallExpression'
+          type: 'ObjectExpression'
         }
       ]
     },
@@ -113,6 +121,16 @@ ruleTester.run('syntax-preference (string)', rule, {
           message: 'Prefer wrapping your string styles with `css` call.',
           type: 'Literal'
         },
+        {
+          message: 'Styles should be written using strings.',
+          type: 'ObjectExpression'
+        }
+      ]
+    },
+    {
+      code: `css(cls, { color: 'hotpink' })`,
+      options: ['string'],
+      errors: [
         {
           message: 'Styles should be written using strings.',
           type: 'ObjectExpression'


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Adjusts `syntax-preference` eslint rule to support "ignoring" usage of the `css` function when checking if the `object` style is being used for the `css` prop.

<!-- Why are these changes necessary? -->

**Why**:

When using the `css` helper with the `css` prop, `@emotion/syntax-preference` doesn't think it's in object form:

```
ESLint: Styles should be written using objects.(@emotion/syntax-preference)
```

(See #2243)

<!-- How were these changes implemented? -->

**How**:

I've adjusted `checkCssPropExpressionPreferringObject` to double-back on itself if the `node` is a `CallExpression` with a single argument, so effectively it "ignores" the function and looks at the argument instead.

I went with checking for a single argument over `callee.name === 'css'` to support if people imported the function under a different name. The potential trade-off is if people have their own wrapper function that takes only a single argument, the rule will complain if that argument isn't an object or array.

I've got no strong issue with either pro/con, so happy to change the check to be the other way around.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation (N/A)
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->

Fixes #2243
