### PR TITLE
Fix slowdown in typechecker from `CSSPropertiesWithMultiValues`

### DIFF
--- a/packages/serialize/types/index.d.ts
+++ b/packages/serialize/types/index.d.ts
@@ -9,8 +9,9 @@ export { RegisteredCache, SerializedStyles }
 export type CSSProperties = CSS.PropertiesFallback<number | string>
 export type CSSPropertiesWithMultiValues = {
   [K in keyof CSSProperties]:
-    | CSSProperties[K]
-    | Array<Extract<CSSProperties[K], string>>
+    CSSProperties[K] extends string
+      ? CSSProperties[K] | Array<CSSProperties[K]>
+      : CSSProperties[K]
 }
 
 export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject }


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes https://github.com/emotion-js/emotion/issues/2257

<!-- Why are these changes necessary? -->

**Why**:

This change greatly improve IDE performance on large projects. It also improves correctness (`Array<never>` isn't the best way to show that you don't want to allow array values).

**How**:

The previous behaviour here was working like this. Here's a slimmed down example.

```ts
type CSSProperties = {
  prop1: number,
  prop2: "val1" | "val2" | string,
}

// After

type CSSPropertiesWithMultiValues = {
  prop1: number | Array<never>,
  prop2: "val1" | "val2" | string | Array<"val1" | "val2" | string>,
}
```

Now it works like this.

```ts
type CSSProperties = {
  prop1: number,
  prop2: "val1" | "val2" | string,
}

// After

type CSSPropertiesWithMultiValues = {
  prop1: number,
  prop2: "val1" | "val2" | string | Array<"val1" | "val2" | string>,
}
```

I'm not actually 100% sure which values don't support strings though. Don't all of the properties support `inherit` or `auto` or some pixel value something along those lines?

I'm assuming they are and this code was written for a reason, but if it's not necessary the conditional type could be removed entirely.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation - N/A
- [x] Tests - N/A
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
