### PR TITLE
Fix incorrectly throwing error on the gradient content values in dev

### DIFF
--- a/.changeset/fair-buses-drop.md
+++ b/.changeset/fair-buses-drop.md
@@ -1,0 +1,5 @@
+---
+'@emotion/serialize': patch
+---
+
+Fix incorrectly throwing error on the gradient content values

--- a/packages/css/test/__snapshots__/warnings.test.js.snap
+++ b/packages/css/test/__snapshots__/warnings.test.js.snap
@@ -14,6 +14,11 @@ exports[`does not warn when valid values are passed for the content property 1`]
   content: "some thing";
   content: 'another thing';
   content: url("http://www.example.com/test.png");
+  content: linear-gradient(hotpink, #8be9fd);
+  content: radial-gradient(hotpink, #8be9fd);
+  content: repeating-linear-gradient(hotpink, #8be9fd);
+  content: repeating-radial-gradient(hotpink, #8be9fd);
+  content: conic-gradient(hotpink, #8be9fd);
   content: counter(chapter_counter);
   content: counters(section_counter, ".");
   content: attr(value string);

--- a/packages/css/test/warnings.test.js
+++ b/packages/css/test/warnings.test.js
@@ -21,6 +21,11 @@ const validValues = [
   '"some thing"',
   "'another thing'",
   'url("http://www.example.com/test.png")',
+  'linear-gradient(hotpink, #8be9fd)',
+  'radial-gradient(hotpink, #8be9fd)',
+  'repeating-linear-gradient(hotpink, #8be9fd)',
+  'repeating-radial-gradient(hotpink, #8be9fd)',
+  'conic-gradient(hotpink, #8be9fd)',
   'counter(chapter_counter)',
   'counters(section_counter, ".")',
   'attr(value string)'

--- a/packages/react/__tests__/__snapshots__/warnings.js.snap
+++ b/packages/react/__tests__/__snapshots__/warnings.js.snap
@@ -14,6 +14,11 @@ exports[`does not warn when valid values are passed for the content property 1`]
   content: "some thing";
   content: 'another thing';
   content: url("http://www.example.com/test.png");
+  content: linear-gradient(hotpink, #8be9fd);
+  content: radial-gradient(hotpink, #8be9fd);
+  content: repeating-linear-gradient(hotpink, #8be9fd);
+  content: repeating-radial-gradient(hotpink, #8be9fd);
+  content: conic-gradient(hotpink, #8be9fd);
   content: counter(chapter_counter);
   content: counters(section_counter, ".");
   content: attr(value string);

--- a/packages/react/__tests__/warnings.js
+++ b/packages/react/__tests__/warnings.js
@@ -21,6 +21,11 @@ const validValues = [
   '"some thing"',
   "'another thing'",
   'url("http://www.example.com/test.png")',
+  'linear-gradient(hotpink, #8be9fd)',
+  'radial-gradient(hotpink, #8be9fd)',
+  'repeating-linear-gradient(hotpink, #8be9fd)',
+  'repeating-radial-gradient(hotpink, #8be9fd)',
+  'conic-gradient(hotpink, #8be9fd)',
   'counter(chapter_counter)',
   'counters(section_counter, ".")',
   'attr(value string)'

--- a/packages/serialize/src/index.js
+++ b/packages/serialize/src/index.js
@@ -61,7 +61,7 @@ let processStyleValue = (
 }
 
 if (process.env.NODE_ENV !== 'production') {
-  let contentValuePattern = /(attr|calc|counters?|url)\(/
+  let contentValuePattern = /(attr|calc|counters?|url|(((repeating-)?(linear|radial))|conic)-gradient)\(/
   let contentValues = [
     'normal',
     'none',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Incorrectly throwing error on gradient content values in dev
<!-- Why are these changes necessary? -->

**Why**:
This change allows using gradient content values in dev. Per doc https://developer.mozilla.org/en-US/docs/Web/CSS/content#values, `<gradient>` is a valid data type for the content property.
<!-- How were these changes implemented? -->

**How**:
Update `contentValuePattern` regex to allow valid gradient function types https://developer.mozilla.org/en-US/docs/Web/CSS/gradient#syntax
```js
let contentValuePattern = /(attr|calc|counters?|url|(((repeating-)?(linear|radial))|conic)-gradient)\(/
```

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation - N/A
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
