### PR TITLE
Fix: topbar width causing horizontal scroll

### DIFF
--- a/site/src/components/SiteHeader.js
+++ b/site/src/components/SiteHeader.js
@@ -40,7 +40,7 @@ export default function SiteHeader() {
             display: 'flex',
             justifyContent: 'center',
             backgroundColor: 'black',
-            width: '100vw',
+            width: '100%',
             zIndex: 100
           }}
         >


### PR DESCRIPTION
**What**:

The width of the black topbar in the site breaks the layout when there is a vertical scroll, causing the whole page to scroll horizontally to accommodate the width of the top bar.

This PR allows the topbar to fit the width page so that the top bar doesn't break the width of the page, preventing the entire site layout from scrolling horizontally.

![scroll](https://user-images.githubusercontent.com/4191549/109235145-da44ff80-77ab-11eb-80bf-ad12b367cb3f.gif)

**Why**:

To prevent horizontal scroll.

**How**:

Changing `width: 100vw` to `width: 100%` on Black Lives Matter div.

**Checklist**:

- [ ] Documentation - N/A
- [ ] Tests - N/A
- [ ] Code complete - N/A
- [ ] Changeset - N/A
