### PR TITLE
Make readonly arrays accepted by cx()

### DIFF
--- a/packages/css/types/create-instance.d.ts
+++ b/packages/css/types/create-instance.d.ts
@@ -14,7 +14,7 @@ export {
 
 export { EmotionCache, Options }
 
-export interface ArrayClassNamesArg extends Array<ClassNamesArg> {}
+export interface ArrayClassNamesArg extends ReadonlyArray<ClassNamesArg> {}
 export type ClassNamesArg =
   | undefined
   | null

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -68,7 +68,7 @@ export function keyframes(
 ): Keyframes
 export function keyframes(...args: Array<CSSInterpolation>): Keyframes
 
-export interface ArrayClassNamesArg extends Array<ClassNamesArg> {}
+export interface ArrayClassNamesArg extends ReadonlyArray<ClassNamesArg> {}
 export type ClassNamesArg =
   | undefined
   | null


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

The type definitions of `ArrayClassNamesArg` that defines what the `cx()` function can accept as argument.

<!-- Why are these changes necessary? -->

Because: 

![image](https://user-images.githubusercontent.com/6702424/110180739-a2bcff80-7e0a-11eb-9274-a788a0be88fa.png)

should not give error. `cx` is pure, the array passed will never be edited. 

<!-- How were these changes implemented? -->

Using `ReadonlyArray` instead or `Array`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

Hi, sorry I give up getting everything checked, I get `yarn install` errors and really need to move on.
As a result I don't expect this to be merged but I submit the PR anyway just to let you know about the issue.

Thank you for your amazing work. 
