### PR TITLE
Fix incorrectly throwing error on valid content values in dev

### DIFF
--- a/.changeset/sweet-donkeys-film.md
+++ b/.changeset/sweet-donkeys-film.md
@@ -1,0 +1,5 @@
+---
+'@emotion/serialize': patch
+---
+
+Fix incorrectly throwing error on valid content values

--- a/.changeset/sweet-donkeys-film.md
+++ b/.changeset/sweet-donkeys-film.md
@@ -2,4 +2,4 @@
 '@emotion/serialize': patch
 ---
 
-Fix incorrectly throwing error on valid content values
+Fixed the issue with incorrectly throwing errors on valid content values containing `open-quote`.

--- a/packages/css/test/__snapshots__/warnings.test.js.snap
+++ b/packages/css/test/__snapshots__/warnings.test.js.snap
@@ -4,7 +4,6 @@ exports[`does not warn when valid values are passed for the content property 1`]
 .emotion-0 {
   content: normal;
   content: none;
-  content: counter;
   content: open-quote;
   content: close-quote;
   content: no-open-quote;
@@ -22,6 +21,7 @@ exports[`does not warn when valid values are passed for the content property 1`]
   content: counter(chapter_counter);
   content: counters(section_counter, ".");
   content: attr(value string);
+  content: open-quote counter(chapter_counter);
 }
 
 <div

--- a/packages/css/test/warnings.test.js
+++ b/packages/css/test/warnings.test.js
@@ -11,7 +11,6 @@ console.error = jest.fn()
 const validValues = [
   'normal',
   'none',
-  'counter',
   'open-quote',
   'close-quote',
   'no-open-quote',
@@ -28,7 +27,8 @@ const validValues = [
   'conic-gradient(hotpink, #8be9fd)',
   'counter(chapter_counter)',
   'counters(section_counter, ".")',
-  'attr(value string)'
+  'attr(value string)',
+  'open-quote counter(chapter_counter)'
 ]
 
 afterEach(() => {

--- a/packages/react/__tests__/__snapshots__/warnings.js.snap
+++ b/packages/react/__tests__/__snapshots__/warnings.js.snap
@@ -4,7 +4,6 @@ exports[`does not warn when valid values are passed for the content property 1`]
 .emotion-0 {
   content: normal;
   content: none;
-  content: counter;
   content: open-quote;
   content: close-quote;
   content: no-open-quote;
@@ -22,6 +21,7 @@ exports[`does not warn when valid values are passed for the content property 1`]
   content: counter(chapter_counter);
   content: counters(section_counter, ".");
   content: attr(value string);
+  content: open-quote counter(chapter_counter);
 }
 
 <div

--- a/packages/react/__tests__/warnings.js
+++ b/packages/react/__tests__/warnings.js
@@ -11,7 +11,6 @@ console.error = jest.fn()
 const validValues = [
   'normal',
   'none',
-  'counter',
   'open-quote',
   'close-quote',
   'no-open-quote',
@@ -28,7 +27,8 @@ const validValues = [
   'conic-gradient(hotpink, #8be9fd)',
   'counter(chapter_counter)',
   'counters(section_counter, ".")',
-  'attr(value string)'
+  'attr(value string)',
+  'open-quote counter(chapter_counter)'
 ]
 
 beforeEach(() => {

--- a/packages/serialize/src/index.js
+++ b/packages/serialize/src/index.js
@@ -61,19 +61,8 @@ let processStyleValue = (
 }
 
 if (process.env.NODE_ENV !== 'production') {
-  let contentValuePattern = /(attr|calc|counters?|url|(((repeating-)?(linear|radial))|conic)-gradient)\(/
-  let contentValues = [
-    'normal',
-    'none',
-    'counter',
-    'open-quote',
-    'close-quote',
-    'no-open-quote',
-    'no-close-quote',
-    'initial',
-    'inherit',
-    'unset'
-  ]
+  let contentValuePattern = /(attr|counters?|url|(((repeating-)?(linear|radial))|conic)-gradient)\(|(no-)?(open|close)-quote/
+  let contentValues = ['normal', 'none', 'initial', 'inherit', 'unset']
 
   let oldProcessStyleValue = processStyleValue
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Fix incorrectly throwing error on valid content values in dev
<!-- Why are these changes necessary? -->

**Why**:
This change allows using multiple valid content values like `content: open-quote counter(chapter_counter);` in dev. Per doc https://developer.mozilla.org/en-US/docs/Web/CSS/content, several values can be used simultaneously, except for `normal`, `none` and global values.
<!-- How were these changes implemented? -->

**How**:
- Update `contentValuePattern` regex for the cases of multiple content values
- Remove invalid regex pattern `calc`
- Remove invalid content value `counter` in `contentValues`
```js
let contentValuePattern = /(attr|counters?|url|(((repeating-)?(linear|radial))|conic)-gradient)\(|(no-)?(open|close)-quote/
let contentValues = ['normal', 'none', 'initial', 'inherit', 'unset']
```
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation - N/A
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
