### PR TITLE
Chore: Remove selection styles in the doc

### DIFF
--- a/site/src/utils/dracula-prism.js
+++ b/site/src/utils/dracula-prism.js
@@ -57,24 +57,6 @@ pre[class*="language-"] {
   hyphens: none;
 }
 
-pre[class*="language-"]::-moz-selection,
-pre[class*="language-"] ::-moz-selection,
-code[class*="language-"]::-moz-selection,
-code[class*="language-"] ::-moz-selection {
-  text-shadow: none;
-  color: white;
-  background-color: #faebf8;
-}
-
-pre[class*="language-"]::selection,
-pre[class*="language-"] ::selection,
-code[class*="language-"]::selection,
-code[class*="language-"] ::selection {
-  text-shadow: none;
-  color: white;
-  background-color: #faebf8;
-}
-
 @media print {
   code[class*="language-"],
   pre[class*="language-"] {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Removes the selection styles on `pre` and `code` elements to approve readability.

<!-- Why are these changes necessary? -->

**Why**: It's quite unreadable when selecting text on these elements, 
![image](https://user-images.githubusercontent.com/10952903/113535009-d60ace00-9604-11eb-971a-f4e8e4882b2a.png)

<!-- How were these changes implemented? -->

**How**: By removing the `::selection` selectors on these elements.

I'm encountering this issue when I'm reading the doc. If the design needs to be updated, I'd be happy to do it. Please feel free to close this PR if it's not necessary.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests N/A
- [x] Code complete
- [ ] Changeset N/A <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
