### PR TITLE
feat: Transfer component defaultProps to EmotionProps

### DIFF
--- a/.changeset/tasty-buckets-move.md
+++ b/.changeset/tasty-buckets-move.md
@@ -1,0 +1,5 @@
+---
+'@emotion/react': patch
+---
+
+Transfer React component defaultProps to EmotionProps

--- a/packages/react/__tests__/__snapshots__/default-props.js.snap
+++ b/packages/react/__tests__/__snapshots__/default-props.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Transfer Component.defaultProps 1`] = `
+<div>
+  <div
+    class="parent"
+  >
+    i will show in parent component
+  </div>
+</div>
+`;
+
+exports[`Transfer Component.defaultProps and override by Component.Props 1`] = `
+<div>
+  <div
+    class="parent"
+  >
+    orrivide defaultProps value
+  </div>
+</div>
+`;
+
+exports[`Transfer Component.defaultProps to easy make judgement 1`] = `
+<div>
+  <div
+    class="parent"
+  >
+    <div>
+      make some judgments
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react/__tests__/default-props.js
+++ b/packages/react/__tests__/default-props.js
@@ -1,0 +1,77 @@
+/** @jsx jsx */
+import { jsx, css } from '@emotion/react'
+import { render } from '@testing-library/react'
+
+test('Transfer Component.defaultProps', () => {
+  let ParentComp = props => {
+    let childProps = props.children.props
+    return <div className="parent">{childProps.defaultPropsParam}</div>
+  }
+  let ChildComp = () => <div>Child</div>
+
+  ChildComp.defaultProps = {
+    defaultPropsParam: 'i will show in parent component'
+  }
+
+  let { container } = render(
+    <ParentComp>
+      <ChildComp
+        css={css`
+          color: red;
+        `}
+      />
+    </ParentComp>
+  )
+  expect(container).toMatchSnapshot()
+})
+
+test('Transfer Component.defaultProps and override by Component.Props', () => {
+  let ParentComp = props => {
+    let childProps = props.children.props
+    return <div className="parent">{childProps.defaultPropsParam}</div>
+  }
+  let ChildComp = () => <div>Child</div>
+
+  ChildComp.defaultProps = {
+    defaultPropsParam: 'i will show in parent component'
+  }
+
+  let { container } = render(
+    <ParentComp>
+      <ChildComp
+        defaultPropsParam={'orrivide defaultProps value'}
+        css={css`
+          color: blue;
+        `}
+      />
+    </ParentComp>
+  )
+  expect(container).toMatchSnapshot()
+})
+
+test('Transfer Component.defaultProps to easy make judgement', () => {
+  let ParentComp = props => {
+    let childProps = props.children.props
+    return (
+      <div className="parent">
+        {childProps.defaultPropsParam ? <div>make some judgments</div> : null}
+      </div>
+    )
+  }
+  let ChildComp = () => <div>Child</div>
+
+  ChildComp.defaultProps = {
+    defaultPropsParam: true
+  }
+
+  let { container } = render(
+    <ParentComp>
+      <ChildComp
+        css={css`
+          color: white;
+        `}
+      />
+    </ParentComp>
+  )
+  expect(container).toMatchSnapshot()
+})

--- a/packages/react/src/emotion-element.js
+++ b/packages/react/src/emotion-element.js
@@ -31,6 +31,17 @@ export const createEmotionProps = (type: React.ElementType, props: Object) => {
 
   let newProps: any = {}
 
+  // handle component defaultProps
+  // it can be override by component props
+  // to support #2316
+  const defaultProps = type?.defaultProps ?? {}
+  for (let key in defaultProps) {
+    if (hasOwnProperty.call(defaultProps, key)) {
+      newProps[key] = defaultProps[key]
+    }
+  }
+
+  // handle component props
   for (let key in props) {
     if (hasOwnProperty.call(props, key)) {
       newProps[key] = props[key]


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: To fix #2316, make emotion user easy to make react children props judgments.

<!-- Why are these changes necessary? -->

**Why**: When emotion user use `css prop` in thier react component, the component will be wraped by `EmotionCssPropInternal[ForwardRef]`, Access `children.props.__EMOTION_TYPE_PLEASE_DO_NOT_USE__.defaultProps` is the only way to get component defaultProps when user want to do some `children props` judgement.

<img src="https://user-images.githubusercontent.com/14012511/114524064-7a30ec80-9c77-11eb-94b6-b8aa045282e8.png" width="650px">

<!-- How were these changes implemented? -->

**How**: Handle `React.ElementType`'s `defaultProps` When `createEmotionProps`, It can be override by `Props`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
/cc @Andarist @mitchellhamilton 

### Append
How to solve the `flow` CI [failed](https://app.circleci.com/pipelines/github/emotion-js/emotion/908/workflows/bcb5f28b-d9f3-4fcb-8e26-3849ec30c04e/jobs/14274) ? add `$FlowFixMe` ?
