### PR TITLE
feat: Implement automatic adding of jsxImportSource pragma definition

### DIFF
--- a/.changeset/sweet-plums-behave.md
+++ b/.changeset/sweet-plums-behave.md
@@ -1,0 +1,5 @@
+---
+'@emotion/eslint-plugin': patch
+---
+
+implement automatic adding of jsxImportSource pragma definition

--- a/packages/eslint-plugin/test/rules/jsx-import.test.js
+++ b/packages/eslint-plugin/test/rules/jsx-import.test.js
@@ -30,6 +30,22 @@ ruleTester.run('emotion jsx', rule, {
       `
     },
     {
+      options: ['jsxImportSource'],
+      code: `
+      /** @jsxImportSource @emotion/react */
+
+      let ele = <div css={{}} />
+      `
+    },
+    {
+      options: [{ jsxImportSource: '@emotion/react' }],
+      code: `
+      /** @jsxImportSource @emotion/react */
+
+      let ele = <div css={{}} />
+      `
+    },
+    {
       code: `
 
       let ele = <div notCss={{}} />
@@ -52,6 +68,38 @@ let ele = <div css={{}} />
       output: `
 // @jsx jsx
 import { jsx } from '@emotion/react'
+let ele = <div css={{}} />
+            `.trim()
+    },
+    {
+      options: ['jsxImportSource'],
+      code: `
+let ele = <div css={{}} />
+      `.trim(),
+      errors: [
+        {
+          message:
+            'The css prop can only be used if you set @jsxImportSource pragma'
+        }
+      ],
+      output: `
+/** @jsxImportSource @emotion/react */
+let ele = <div css={{}} />
+            `.trim()
+    },
+    {
+      options: [{ jsxImportSource: '@iChenLei/react' }],
+      code: `
+let ele = <div css={{}} />
+      `.trim(),
+      errors: [
+        {
+          message:
+            'The css prop can only be used if you set @jsxImportSource pragma'
+        }
+      ],
+      output: `
+/** @jsxImportSource @iChenLei/react */
 let ele = <div css={{}} />
             `.trim()
     },


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: To fix https://github.com/emotion-js/emotion/issues/2070

<!-- Why are these changes necessary? -->

**Why**: when using the new fragma jsxImportSource - to automatically add the new pragma definition to the top of the file page, like already is implemented with the `old` pragma /* @jsx jsx */

<!-- How were these changes implemented? -->

**How**: Add eslint rule support.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->

### jsx-runtime
react official blog -> https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
babel support -> https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#customizing-the-automatic-runtime-import


### Add jsxImportSource option
> The default `custom-automatic-runtime` is `@emotion/react`, more `jsx-runtime` support detail you can found in @emotion/react source code like blow
https://github.com/emotion-js/emotion/blob/main/packages/react/src/jsx-dev-runtime.js
https://github.com/emotion-js/emotion/blob/main/packages/react/src/jsx-runtime.js

```diff
- "@emotion/jsx-import": "error"
+ "@emotion/jsx-import": [2, "jsxImportSource"]
```
```js
// .eslintrc.js
module.exports = {
  root: true,
  plugins: [ '@emotion'],
  rules: {
    "@emotion/jsx-import": [1, "jsxImportSource"]
   }
}
```
It works as blow:

![emotion-eslint-02](https://user-images.githubusercontent.com/14012511/115055395-f21b4300-9f13-11eb-86f2-756d2d79ff74.gif)

### Add jsxImportSource custom jsx-runtime option
```diff
- "@emotion/jsx-import": "error"
+ "@emotion/jsx-import": [2, { jsxImportSource: "customreact/jsx-runtime"  }]
```
```js
// .eslintrc.js
module.exports = {
  root: true,
  plugins: [ '@emotion'],
  rules: {
    "@emotion/jsx-import": [2, { jsxImportSource: "customreact/jsx-runtime"  }]
   }
}
```
It works as blow:

![emotion-eslint-01](https://user-images.githubusercontent.com/14012511/115055730-71107b80-9f14-11eb-8f19-18f80997d45e.gif)

/cc @Andarist @mitchellhamilton 

