### PR TITLE
Do not log failed rule insertions in the speedy mode for more vendor-prefixed pseudo-elements/classes

### DIFF
--- a/.changeset/pink-olives-try.md
+++ b/.changeset/pink-olives-try.md
@@ -2,4 +2,4 @@
 '@emotion/sheet': patch
 ---
 
-Do not log failed rule insertions in the speedy mode for more vendor-prefixed pseudo-elements/classes like `::-moz-placeholder`.
+Do not log failed rule insertions in the speedy mode for even more vendor-prefixed pseudo-elements/classes like `:-moz-focus-inner`, `:-moz-focusring`, and `:-ms-clear`.

--- a/.changeset/pink-olives-try.md
+++ b/.changeset/pink-olives-try.md
@@ -1,0 +1,5 @@
+---
+'@emotion/sheet': patch
+---
+
+Do not log failed rule insertions in the speedy mode for more vendor-prefixed pseudo-elements/classes like `::-moz-placeholder`.

--- a/packages/sheet/src/index.js
+++ b/packages/sheet/src/index.js
@@ -137,7 +137,7 @@ export class StyleSheet {
       } catch (e) {
         if (
           process.env.NODE_ENV !== 'production' &&
-          !/:(-moz-placeholder|-ms-input-placeholder|-moz-read-write|-moz-read-only){/.test(
+          !/:(-moz-placeholder|-moz-focus-inner|-moz-focusring|-ms-input-placeholder|-moz-read-write|-moz-read-only|-ms-clear){/.test(
             rule
           )
         ) {


### PR DESCRIPTION
**What**:
This PR expands a fix that was made in #2149 to swallow errors from invalid insertions.

**Why**:
I added to the list to silence warnings:
- `-moz-focus-inner`
- `-moz-focusring`
- `-ms-clear`

**How**:

Tested via `yarn lint`/`yarn test` & browser.

**Checklist**:

- [x] Code complete
- [x] Changeset