### PR TITLE
Export the EmotionCacheContext

### DIFF
--- a/.changeset/real-geckos-joke.md
+++ b/.changeset/real-geckos-joke.md
@@ -1,0 +1,5 @@
+---
+'@emotion/react': patch
+---
+
+Export the EmotionCacheContext.

--- a/packages/react/src/context.js
+++ b/packages/react/src/context.js
@@ -5,7 +5,7 @@ import { useContext, forwardRef } from 'react'
 import createCache from '@emotion/cache'
 import { isBrowser } from './utils'
 
-let EmotionCacheContext: React.Context<EmotionCache | null> =
+export let EmotionCacheContext: React.Context<EmotionCache | null> =
   /* #__PURE__ */ React.createContext(
     // we're doing this to avoid preconstruct's dead code elimination in this one case
     // because this module is primarily intended for the browser and node

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -1,7 +1,7 @@
 // @flow
 import pkg from '../package.json'
 export type { SerializedStyles } from '@emotion/utils'
-export { withEmotionCache, CacheProvider } from './context'
+export { withEmotionCache, CacheProvider, EmotionCacheContext } from './context'
 export { jsx } from './jsx'
 export { jsx as createElement } from './jsx'
 export { Global } from './global'

--- a/scripts/ssr-benchmarks/bench.js
+++ b/scripts/ssr-benchmarks/bench.js
@@ -2,7 +2,7 @@ let React = require('react')
 let styled = require('@emotion/styled').default
 let { renderToString } = require('react-dom/server')
 let Benchmark = require('benchmark')
-let { jsx, css, CacheProvider } = require('@emotion/react')
+let { jsx, css, CacheProvider, EmotionCacheContext } = require('@emotion/react')
 let { createTriangle } = require('./triangle')
 let { css: cssClassName } = require('@emotion/css')
 let { renderStylesToString } = require('@emotion/server')
@@ -70,13 +70,11 @@ let CssFuncTriangle = createTriangle(({ x, y, size, color, ...props }) => {
     ...props
   })
 })
-// $FlowFixMe
-let CacheContext = CacheProvider._context
 
 let hasOwnProperty = Object.prototype.hasOwnProperty
 
 let ExperimentTriangle = createTriangle(({ x, y, size, color, ...props }) => {
-  let cache = CacheContext._currentValue
+  let cache = EmotionCacheContext._currentValue
 
   let className = ''
   const serialized = css`


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Just exporting the EmotionCacheContext.

<!-- Why are these changes necessary? -->

**Why**: So that Emotion users can more easily hook into it to build their own APIs without having to use `create-emotion`. For example [this issue could be resolved without an upstream change](https://github.com/emotion-js/emotion/issues/1853#issuecomment-873059628) because the `useCx` hook wouldn't need to rely on the internal `_context` property on the Provider (which is undocumented).

<!-- How were these changes implemented? -->

**How**: Just a two line change to export the cache context.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->

Alternatives to this are:
1. Exporting `useEmotionCacheContext` instead of the context itself

Not sure if there are other alternatives other than adding `useCx` upstream but I'm not sure if that's desired at this point. This is a stop-gap in case it's not viable to add directly into Emotion for whatever reason.