### PR TITLE
feat: Add display names to public React contexts

### DIFF
--- a/.changeset/olive-zebras-pump.md
+++ b/.changeset/olive-zebras-pump.md
@@ -1,5 +1,5 @@
 ---
-'@emotion/react': minor
+'@emotion/react': patch
 ---
 
-Add display names to public React contexts
+Added display names to public React contexts in development builds. This helps to recognize them in React Developer Tools.

--- a/.changeset/olive-zebras-pump.md
+++ b/.changeset/olive-zebras-pump.md
@@ -1,0 +1,5 @@
+---
+'@emotion/react': minor
+---
+
+Add display names to public React contexts

--- a/packages/react/src/context.js
+++ b/packages/react/src/context.js
@@ -18,6 +18,10 @@ let EmotionCacheContext: React.Context<EmotionCache | null> =
       : null
   )
 
+if (process.env.NODE_ENV !== 'production') {
+  EmotionCacheContext.displayName = 'EmotionCacheContext'
+}
+
 export let CacheProvider = EmotionCacheContext.Provider
 
 let withEmotionCache = function withEmotionCache<Props, Ref: React.Ref<*>>(

--- a/packages/react/src/theming.js
+++ b/packages/react/src/theming.js
@@ -4,6 +4,9 @@ import weakMemoize from '@emotion/weak-memoize'
 import hoistNonReactStatics from './isolated-hoist-non-react-statics-do-not-use-this-in-your-code'
 
 export const ThemeContext = /* #__PURE__ */ React.createContext<Object>({})
+if (process.env.NODE_ENV !== 'production') {
+  ThemeContext.displayName = 'EmotionThemeContext'
+}
 
 export const useTheme = () => React.useContext(ThemeContext)
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Give public contexts a distinct name in React DevTools:

Before:
![Screenshot from 2021-07-13 10-00-01](https://user-images.githubusercontent.com/12292047/125418206-78a3a6bf-0b4a-45d1-bc8c-e14fd0e8fdc5.png)


After:
![Screenshot from 2021-07-13 10-08-14](https://user-images.githubusercontent.com/12292047/125418220-232d4fbe-5b61-46a8-ab43-0c35bcd4265a.png)


**Why**:

Easier debugging when inspecting the cache of e.g. `<CacheProvider value={cache}>`.

**How**:

Add a `displayName` property in development to the context.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation N/A
- [x] Tests (manually verified in DevTools)
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
