### PR TITLE
expose __unsafe_useEmotionCache from @emotion/react

### DIFF
--- a/.changeset/forty-pumas-refuse.md
+++ b/.changeset/forty-pumas-refuse.md
@@ -2,4 +2,4 @@
 '@emotion/react': patch
 ---
 
-expose \_\_unsafe_useEmotionCache from @emotion/react, see https://github.com/emotion-js/emotion/pull/2441
+Exposed `__unsafe_useEmotionCache` which can be used to access the current Emotion's cache in an easier way than before. Using this might break 0-config SSR and is not recommended to be used unless there you know what you are doing and you are OK with the mentioned downside.

--- a/.changeset/forty-pumas-refuse.md
+++ b/.changeset/forty-pumas-refuse.md
@@ -1,0 +1,5 @@
+---
+'@emotion/react': patch
+---
+
+expose \_\_unsafe_useEmotionCache from @emotion/react, see https://github.com/emotion-js/emotion/pull/2441

--- a/packages/react/src/context.js
+++ b/packages/react/src/context.js
@@ -20,6 +20,11 @@ let EmotionCacheContext: React.Context<EmotionCache | null> =
 
 export let CacheProvider = EmotionCacheContext.Provider
 
+export let __unsafe_useEmotionCache =
+  function useEmotionCache(): EmotionCache | null {
+    return useContext(EmotionCacheContext)
+  }
+
 let withEmotionCache = function withEmotionCache<Props, Ref: React.Ref<*>>(
   func: (props: Props, cache: EmotionCache, ref: Ref) => React.Node
 ): React.AbstractComponent<Props> {

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -1,7 +1,11 @@
 // @flow
 import pkg from '../package.json'
 export type { SerializedStyles } from '@emotion/utils'
-export { withEmotionCache, CacheProvider } from './context'
+export {
+  withEmotionCache,
+  CacheProvider,
+  __unsafe_useEmotionCache
+} from './context'
 export { jsx } from './jsx'
 export { jsx as createElement } from './jsx'
 export { Global } from './global'


### PR DESCRIPTION
**What**:

Expose `__unsafe_useEmotionCache()` from `@emotion/react`

**Why**:

Needed for seamless integration of [tss-react](https://github.com/garronej/tss-react) with `@emotion/react`.  
[tss-react](https://github.com/garronej/tss-react) will be the new [`makeStyles`](https://material-ui.com/styles/basics/#hook-api) in `@material-ui` v5.

**How**:

I exposed a proxy to `useContext(EmotionCacheContext)`  

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N.A? Being an interoperability feature, I don't think it has to be documented. But does it? 
- [x] Tests
- [x] Code complete
- [x] Changeset Semantically it should be a minor but tell me if you feel that it should be a patch, I will rebase.

<!-- feel free to add additional comments -->

Hi @Andarist,
I implemented `makeStyles` on top of `@emotion/react` as [you discussed](https://github.com/mui-org/material-ui/issues/24109#issuecomment-780855014) with @oliviertassinari.  
It's [tss-react](https://github.com/garronej/tss-react).  
In v5 of material-ui `makeStyle` will be dropped and tss-react [will be mentioned](https://github.com/garronej/tss-react/issues/3#issuecomment-879022879) in the v4 to v5 migration guide for the teams that don't want to make the switch to the styled API.  
It would be great if I could have access to the cache, `tss-react` have just been released and [it has already been requested](https://github.com/garronej/tss-react/issues/6) that it supports custom cache.  
Of course I could expose my own provider but it would be much better if `tss-react` could blend in transparently with `@emotion/react`.  
