### PR TITLE
Prevent flush from raising error on detached tag

### DIFF
--- a/packages/sheet/src/index.js
+++ b/packages/sheet/src/index.js
@@ -155,7 +155,7 @@ export class StyleSheet {
 
   flush() {
     // $FlowFixMe
-    this.tags.forEach(tag => tag.parentNode.removeChild(tag))
+    this.tags.forEach(tag => tag.parentNode && tag.parentNode.removeChild(tag))
     this.tags = []
     this.ctr = 0
     if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
It prevents `flush()` from raising the following error: `TypeError: tag.parentNode is null`. Such error happens when the `tag` that is being flushed had already been detached from its parent node by a third party library, which may be application code or a library that handles the page routing—I'm experiencing this issue with [Turbolinks](https://github.com/turbolinks/turbolinks).

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: it prevents `flush()` from raising the following error: `TypeError: tag.parentNode is null` when the style tag had been already detached by its parent node

<!-- Why are these changes necessary? -->

**Why**: because it makes play better with third party code that manipulate the style tags somehow

<!-- How were these changes implemented? -->

**How**: it skips the `.removeChild(tag)` call on the tag's parent node when there is no parent node

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests
- [x ] Code complete
- [ ] Changeset N/A <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->

Should I add a test?