### PR TITLE
Support typings for Jest v27

### DIFF
--- a/.changeset/ninety-bugs-tie.md
+++ b/.changeset/ninety-bugs-tie.md
@@ -1,0 +1,5 @@
+---
+'@emotion/jest': minor
+---
+
+Support typings for Jest v27

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -24,7 +24,7 @@
     "stylis": "^4.0.3"
   },
   "peerDependencies": {
-    "@types/jest": "^26.0.14",
+    "@types/jest": "^26.0.14 || ^27.0.0",
     "enzyme-to-json": "^3.2.1"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->



**What**:

`@emotion/jest` is currently only compatible with Jest 26 when using TypeScript because it optionally peer-depends on `@types/jest@26`:

https://github.com/emotion-js/emotion/blob/4c7b6de1ff294e45d1e9757dbe37b961cded211b/packages/jest/package.json#L26-L27

This PR widens the peer dependency range from `^26.0.14` to `^26.0.14 || ^27.0.0` such that both 26 and 27 are supported.

**Why**:

See above.

**How**:

See above.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
