### PR TITLE
Fix typo in documentation example

### DIFF
--- a/docs/typescript.mdx
+++ b/docs/typescript.mdx
@@ -176,7 +176,7 @@ const Component: FC<ComponentProps> = ({
 }) => <div className={className}>{label}</div>
 
 const StyledComponent0 = styled(Component)`
-  color: ${props => label === 'Important' ? 'red' : 'green'};
+  color: ${props => props.label === 'Important' ? 'red' : 'green'};
 `
 
 const StyledComponent1 = styled(Component)({


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Add a missing `props` in the React component typescript example in documentation.

<!-- Why are these changes necessary? -->

**Why**:
Otherwise the `label` variable is not defined anywhere.

<!-- How were these changes implemented? -->

**How**:
Simply add `props.` before `label`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [X] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A
- [ ] Changeset N/A <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
