### PR TITLE
Support user-level serialized style caching by adding a special handing for singleton function interpolation in serializeStyles

### DIFF
--- a/packages/serialize/src/index.js
+++ b/packages/serialize/src/index.js
@@ -311,6 +311,13 @@ export const serializeStyles = function (
   registered: RegisteredCache | void,
   mergedProps: void | Object
 ): SerializedStyles {
+  // special optimization for a case where the only argument is a function, which might return already serialized style (e.g. {name:'xyz12345', styles:'color:red'})
+  if (args.length === 1 && typeof args[0] === 'function') {
+    const previousCursor = cursor
+    args = [args[0](mergedProps, registered)]
+    cursor = previousCursor
+  }
+
   if (
     args.length === 1 &&
     typeof args[0] === 'object' &&


### PR DESCRIPTION

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Added a special handling for singleton function interpolation in serializeStyles in `@emotion/serialize`

<!-- Why are these changes necessary? -->

**Why**:
`@emotion/styled` is used as the foundation of cutomizable styled components by popular UI libraries like Chakra UI ([code](https://github.com/chakra-ui/chakra-ui/blob/bc86b100486e75828daa72433ab208260029f7b1/packages/system/src/system.ts#L75-L78)) or MUI ([code](https://github.com/mui-org/material-ui/blob/81578f0b52b469e0b0d2cb9df2ebf6820e05e6c6/packages/mui-styled-engine/src/index.js#L1-L4)). These allow us to use developer-friendly APIs like ["sx props"](https://chakra-ui.com/docs/features/the-sx-prop) like the following:

```typescript
import { Box } from "@chakra-ui/react";

<Box sx={{ color: "green.500" }}>Hello</Box>;
```

However, as we are already aware, usage of CSS-in-JS comes with an increased runtime cost ([doc for Chakra UI](https://chakra-ui.com/docs/comparison#the-runtime-trade-off-%EF%B8%8F), [doc for MUI](https://mui.com/system/basics/#performance-tradeoff)).

Although there are several techniques to improve the runtime performance, we can think of caching. Assuming we usually use the same styles several times on the same page, caching based on a few input or even the whole sx prop can be a good strategy.

However, in the current implementation of emotion, there seems to be no way to cache styles to bypass emotion's style serialization and hash process, which can take non trivial amount of time.

Thus, I would like to propose to add a special handling for `serializeStyles` in `@emotion/serialize` so that we can implement arbitrary caching strategy of **serialized styles**.


Note that serialized styles look like the following:

```javascript
{
  name: 'jy55qo',
  styles: 'color:red;margin:10px;border:2px solid green;background-color:gold;opacity:0.5;padding-left:2rem;display:flex;justify-content:center;align-items:center;:hover{color:purple;margin:10px;border:2px solid green;background-color:gold;opacity:0.5;padding-left:2rem;display:flex;justify-content:center;align-items:center;}:focus{color:green;margin:10px;border:1px solid red;background-color:gold;opacity:0.5;padding-left:2rem;display:flex;justify-content:center;align-items:center;}',
  next: undefined
}
```

We already have [a logic to bypass the serialization if the passed argument is already serialized style](https://github.com/emotion-js/emotion/blob/d7d768e056e6cd7a10c2de6ecb2b564e6444dac3/packages/serialize/src/index.js#L314-L321), however this logic is not flexible enough since it does not allow us to use different serialized styles based on props. The proposal in this MR adds a special handling for that case.
## How it works and how the performance would look like?
I created [a repo](https://github.com/naruaway/emotion-styled-cache-demo) to reproduce the behavior. Note that [the caching strategy implemented in the example](https://github.com/naruaway/emotion-styled-cache-demo/blob/main/src/main.tsx) is just an example. I would expect each UI library author would implement different caching strategy depending on each use case.


## Open questions
* Is this the right direction? Is there any other recommended way to implement serialized style caching based on props without changing emotion's implementation?
* Is [the usage of `__unsafe_useEmotionCache` in this way](https://github.com/naruaway/emotion-styled-cache-demo/blob/41a0a0ebf65c76a0d822a7e8eea6fb7b22458cb6/src/main.tsx#L48) actually always safe?


<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
