### PR TITLE
Add `insertionPoint` option in `EmotionCache`

### DIFF
--- a/.changeset/sixty-balloons-build.md
+++ b/.changeset/sixty-balloons-build.md
@@ -5,18 +5,19 @@
 
 Add insertionPoint option to the EmotionCache, to insert rules after the specified element.
 
-```
+```jsx
 const head = document.querySelector('head')
 
-const firstStyle = document.createElement('style')
-const lastStyle = document.createElement('style')
-head.appendChild(firstStyle)
-head.appendChild(lastStyle)
+head.innerHTML = `
+  <meta name="emotion-insertion-point" content="" />
+`
 
-// the emotion sheets should be inserted between the first and last style nodes
+const metaTag = document.querySelector("meta[name='emotion-insertion-point']")
+
+// the emotion sheets should be inserted right after the meta tag
 const cache = createCache({
   key: 'my-app',
-  insertionPoint: firstStyle
+  insertionPoint: metaTag
 })
 
 function App() {

--- a/.changeset/sixty-balloons-build.md
+++ b/.changeset/sixty-balloons-build.md
@@ -8,16 +8,15 @@ Add insertionPoint option to the EmotionCache, to insert rules after the specifi
 ```jsx
 const head = document.querySelector('head')
 
-head.innerHTML = `
-  <meta name="emotion-insertion-point" content="" />
-`
+const emotionInsertionPoint = document.createElement('meta')
+emotionInsertionPoint.setAttribute('name', 'emotion-insertion-point')
 
-const metaTag = document.querySelector("meta[name='emotion-insertion-point']")
+head.appendChild(emotionInsertionPoint)
 
 // the emotion sheets should be inserted right after the meta tag
 const cache = createCache({
   key: 'my-app',
-  insertionPoint: metaTag
+  insertionPoint: emotionInsertionPoint
 })
 
 function App() {

--- a/.changeset/sixty-balloons-build.md
+++ b/.changeset/sixty-balloons-build.md
@@ -8,8 +8,10 @@ Add insertionPoint option to the EmotionCache, to insert rules after the specifi
 ```jsx
 const head = document.querySelector('head')
 
+// <meta name="emotion-insertion-point" content="">
 const emotionInsertionPoint = document.createElement('meta')
 emotionInsertionPoint.setAttribute('name', 'emotion-insertion-point')
+emotionInsertionPoint.setAttribute('content', '')
 
 head.appendChild(emotionInsertionPoint)
 

--- a/.changeset/sixty-balloons-build.md
+++ b/.changeset/sixty-balloons-build.md
@@ -1,0 +1,6 @@
+---
+'@emotion/cache': minor
+'@emotion/sheet': minor
+---
+
+Add insertionPoint option to the EmotionCache, to insert rules after the specified element.

--- a/.changeset/sixty-balloons-build.md
+++ b/.changeset/sixty-balloons-build.md
@@ -4,3 +4,26 @@
 ---
 
 Add insertionPoint option to the EmotionCache, to insert rules after the specified element.
+
+```
+const head = document.querySelector('head')
+
+const firstStyle = document.createElement('style')
+const lastStyle = document.createElement('style')
+head.appendChild(firstStyle)
+head.appendChild(lastStyle)
+
+// the emotion sheets should be inserted between the first and last style nodes
+const cache = createCache({
+  key: 'my-app',
+  insertionPoint: firstStyle
+})
+
+function App() {
+  return (
+    <CacheProvider value={cache}>
+      <Main />
+    </CacheProvider>
+  )
+}
+```

--- a/packages/cache/__tests__/__snapshots__/index.js.snap
+++ b/packages/cache/__tests__/__snapshots__/index.js.snap
@@ -1,3 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should accept insertionPoint option 1`] = `
+<html>
+  <head>
+    <style
+      id="first"
+    />
+    <style
+      data-emotion="test-insertion-point"
+      data-s=""
+    >
+      
+      .test-insertion-point-83n355{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;color:blue;}
+    </style>
+    <style
+      id="third"
+    />
+  </head>
+  <body />
+</html>
+`;
+
 exports[`throws correct error with invalid key 1`] = `"Emotion key must only contain lower case alphabetical characters and - but \\".\\" was passed"`;

--- a/packages/cache/__tests__/__snapshots__/index.js.snap
+++ b/packages/cache/__tests__/__snapshots__/index.js.snap
@@ -1,30 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should accept insertionPoint option 1`] = `
-<html>
-  <head>
-    
-    
-    <style
-      id="first"
-    />
-    <style
-      data-emotion="test-insertion-point"
-      data-s=""
-    >
-      
-      .test-insertion-point-83n355{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;color:blue;}
-    </style>
-    
-    
-    <style
-      id="last"
-    />
-    
+<head>
   
-  </head>
-  <body />
-</html>
+    
+  <style
+    id="first"
+  />
+  <style
+    data-emotion="test-insertion-point"
+    data-s=""
+  >
+    
+    .test-insertion-point-83n355{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;color:blue;}
+  </style>
+  
+    
+  <style
+    id="last"
+  />
+  
+  
+</head>
 `;
 
 exports[`throws correct error with invalid key 1`] = `"Emotion key must only contain lower case alphabetical characters and - but \\".\\" was passed"`;

--- a/packages/cache/__tests__/__snapshots__/index.js.snap
+++ b/packages/cache/__tests__/__snapshots__/index.js.snap
@@ -3,6 +3,8 @@
 exports[`should accept insertionPoint option 1`] = `
 <html>
   <head>
+    
+    
     <style
       id="first"
     />
@@ -13,9 +15,13 @@ exports[`should accept insertionPoint option 1`] = `
       
       .test-insertion-point-83n355{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;color:blue;}
     </style>
+    
+    
     <style
       id="last"
     />
+    
+  
   </head>
   <body />
 </html>

--- a/packages/cache/__tests__/__snapshots__/index.js.snap
+++ b/packages/cache/__tests__/__snapshots__/index.js.snap
@@ -14,7 +14,7 @@ exports[`should accept insertionPoint option 1`] = `
       .test-insertion-point-83n355{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;color:blue;}
     </style>
     <style
-      id="third"
+      id="last"
     />
   </head>
   <body />

--- a/packages/cache/__tests__/index.js
+++ b/packages/cache/__tests__/index.js
@@ -18,13 +18,11 @@ function render(ele) {
 
 it('should accept insertionPoint option', () => {
   const head = safeQuerySelector('head')
-  const firstStyle = document.createElement('style')
-  firstStyle.setAttribute('id', 'first')
-  head.appendChild(firstStyle)
 
-  const lastStyle = document.createElement('style')
-  lastStyle.setAttribute('id', 'last')
-  head.appendChild(lastStyle)
+  head.innerHTML = `
+    <style id="first"></style>
+    <style id="last"></style>
+  `
 
   // the sheet should be inserted between the first and last style nodes
   const cache = createCache({

--- a/packages/cache/__tests__/index.js
+++ b/packages/cache/__tests__/index.js
@@ -27,7 +27,7 @@ it('should accept insertionPoint option', () => {
   // the sheet should be inserted between the first and last style nodes
   const cache = createCache({
     key: 'test-insertion-point',
-    insertionPoint: firstStyle
+    insertionPoint: document.getElementById('first')
   })
 
   render(

--- a/packages/cache/__tests__/index.js
+++ b/packages/cache/__tests__/index.js
@@ -4,17 +4,13 @@ import 'test-utils/next-env'
 import { safeQuerySelector } from 'test-utils'
 import createCache from '@emotion/cache'
 import { jsx, CacheProvider } from '@emotion/react'
-import renderer from 'react-test-renderer'
+import { render } from '@testing-library/react'
 
 test('throws correct error with invalid key', () => {
   expect(() => {
     createCache({ key: '.' })
   }).toThrowErrorMatchingSnapshot()
 })
-
-function render(ele) {
-  return renderer.create(ele).toJSON()
-}
 
 it('should accept insertionPoint option', () => {
   const head = safeQuerySelector('head')
@@ -36,5 +32,5 @@ it('should accept insertionPoint option', () => {
     </CacheProvider>
   )
 
-  expect(document.documentElement).toMatchSnapshot()
+  expect(document.head).toMatchSnapshot()
 })

--- a/packages/cache/__tests__/index.js
+++ b/packages/cache/__tests__/index.js
@@ -23,7 +23,7 @@ it('should accept insertionPoint option', () => {
   // the sheet should be inserted between the first and last style nodes
   const cache = createCache({
     key: 'test-insertion-point',
-    insertionPoint: safeQuerySelector('first')
+    insertionPoint: safeQuerySelector('#first')
   })
 
   render(

--- a/packages/cache/__tests__/index.js
+++ b/packages/cache/__tests__/index.js
@@ -22,11 +22,11 @@ it('should accept insertionPoint option', () => {
   firstStyle.setAttribute('id', 'first')
   head.appendChild(firstStyle)
 
-  const thirdStyle = document.createElement('style')
-  thirdStyle.setAttribute('id', 'third')
-  head.appendChild(thirdStyle)
+  const lastStyle = document.createElement('style')
+  lastStyle.setAttribute('id', 'last')
+  head.appendChild(lastStyle)
 
-  // the sheet should be inserted between the first and third style node
+  // the sheet should be inserted between the first and last style nodes
   const cache = createCache({
     key: 'test-insertion-point',
     insertionPoint: firstStyle

--- a/packages/cache/__tests__/index.js
+++ b/packages/cache/__tests__/index.js
@@ -1,8 +1,42 @@
 // @flow
+/** @jsx jsx */
+import 'test-utils/next-env'
+import { safeQuerySelector } from 'test-utils'
 import createCache from '@emotion/cache'
+import { jsx, CacheProvider } from '@emotion/react'
+import renderer from 'react-test-renderer'
 
 test('throws correct error with invalid key', () => {
   expect(() => {
     createCache({ key: '.' })
   }).toThrowErrorMatchingSnapshot()
+})
+
+function render(ele) {
+  return renderer.create(ele).toJSON()
+}
+
+it('should accept insertionPoint option', () => {
+  const head = safeQuerySelector('head')
+  const firstStyle = document.createElement('style')
+  firstStyle.setAttribute('id', 'first')
+  head.appendChild(firstStyle)
+
+  const thirdStyle = document.createElement('style')
+  thirdStyle.setAttribute('id', 'third')
+  head.appendChild(thirdStyle)
+
+  // the sheet should be inserted between the first and third style node
+  const cache = createCache({
+    key: 'test-insertion-point',
+    insertionPoint: firstStyle
+  })
+
+  render(
+    <CacheProvider value={cache}>
+      <div css={{ display: 'flex', color: 'blue' }} />
+    </CacheProvider>
+  )
+
+  expect(document.documentElement).toMatchSnapshot()
 })

--- a/packages/cache/__tests__/index.js
+++ b/packages/cache/__tests__/index.js
@@ -23,7 +23,7 @@ it('should accept insertionPoint option', () => {
   // the sheet should be inserted between the first and last style nodes
   const cache = createCache({
     key: 'test-insertion-point',
-    insertionPoint: document.getElementById('first')
+    insertionPoint: safeQuerySelector('first')
   })
 
   render(

--- a/packages/cache/src/index.js
+++ b/packages/cache/src/index.js
@@ -28,7 +28,8 @@ export type Options = {
   key: string,
   container?: HTMLElement,
   speedy?: boolean,
-  prepend?: boolean
+  prepend?: boolean,
+  insertionPoint?: HTMLElement
 }
 
 let getServerStylisCache = isBrowser
@@ -252,7 +253,8 @@ let createCache = (options: Options): EmotionCache => {
       container: ((container: any): HTMLElement),
       nonce: options.nonce,
       speedy: options.speedy,
-      prepend: options.prepend
+      prepend: options.prepend,
+      insertionPoint: options.insertionPoint
     }),
     nonce: options.nonce,
     inserted,

--- a/packages/cache/types/index.d.ts
+++ b/packages/cache/types/index.d.ts
@@ -36,6 +36,7 @@ export interface Options {
   key: string
   container?: HTMLElement
   speedy?: boolean
+  /** @deprecate use `insertionPoint` instead */
   prepend?: boolean
   insertionPoint?: HTMLElement
 }

--- a/packages/cache/types/index.d.ts
+++ b/packages/cache/types/index.d.ts
@@ -37,6 +37,7 @@ export interface Options {
   container?: HTMLElement
   speedy?: boolean
   prepend?: boolean
+  insertionPoint?: HTMLElement
 }
 
 export default function createCache(options: Options): EmotionCache

--- a/packages/sheet/README.md
+++ b/packages/sheet/README.md
@@ -58,16 +58,15 @@ This defines specific dom node after which the rules are inserted into the `cont
 ```jsx
 const head = document.querySelector('head')
 
-head.innerHTML = `
-  <meta name="emotion-insertion-point" content="" />
-`
+const emotionInsertionPoint = document.createElement('meta')
+emotionInsertionPoint.setAttribute('name', 'emotion-insertion-point')
 
-const metaTag = document.querySelector("meta[name='emotion-insertion-point']")
+head.appendChild(emotionInsertionPoint)
 
 // the emotion sheets should be inserted right after the meta tag
 const cache = createCache({
   key: 'my-app',
-  insertionPoint: metaTag
+  insertionPoint: emotionInsertionPoint
 })
 
 function App() {

--- a/packages/sheet/README.md
+++ b/packages/sheet/README.md
@@ -53,7 +53,31 @@ This defines where rules are inserted into the `container`. By default they are 
 
 #### insertionPoint
 
-This defines specific dom node after which the rules are inserted into the `container`.
+This defines specific dom node after which the rules are inserted into the `container`. You can use a `meta` tag to specify the specific location:
+
+```jsx
+const head = document.querySelector('head')
+
+head.innerHTML = `
+  <meta name="emotion-insertion-point" content="" />
+`
+
+const metaTag = document.querySelector("meta[name='emotion-insertion-point']")
+
+// the emotion sheets should be inserted right after the meta tag
+const cache = createCache({
+  key: 'my-app',
+  insertionPoint: metaTag
+})
+
+function App() {
+  return (
+    <CacheProvider value={cache}>
+      <Main />
+    </CacheProvider>
+  )
+}
+```
 
 ### Methods
 

--- a/packages/sheet/README.md
+++ b/packages/sheet/README.md
@@ -49,6 +49,8 @@ This defines how rules are inserted. If it is true, rules will be inserted with 
 
 #### prepend
 
+**Deprecated:** Please use `insertionPoint` option instead.
+
 This defines where rules are inserted into the `container`. By default they are appended but this can be changed by using `prepend: true` option.
 
 #### insertionPoint
@@ -58,8 +60,10 @@ This defines specific dom node after which the rules are inserted into the `cont
 ```jsx
 const head = document.querySelector('head')
 
+// <meta name="emotion-insertion-point" content="">
 const emotionInsertionPoint = document.createElement('meta')
 emotionInsertionPoint.setAttribute('name', 'emotion-insertion-point')
+emotionInsertionPoint.setAttribute('content', '')
 
 head.appendChild(emotionInsertionPoint)
 

--- a/packages/sheet/README.md
+++ b/packages/sheet/README.md
@@ -51,6 +51,10 @@ This defines how rules are inserted. If it is true, rules will be inserted with 
 
 This defines where rules are inserted into the `container`. By default they are appended but this can be changed by using `prepend: true` option.
 
+#### insertionPoint
+
+This defines specific dom node after which the rules are inserted into the `container`.
+
 ### Methods
 
 #### insert

--- a/packages/sheet/__tests__/__snapshots__/index.js.snap
+++ b/packages/sheet/__tests__/__snapshots__/index.js.snap
@@ -3,6 +3,8 @@
 exports[`StyleSheet should accept insertionPoint option 1`] = `
 <html>
   <head>
+    
+      
     <style
       id="first"
     />
@@ -20,9 +22,13 @@ exports[`StyleSheet should accept insertionPoint option 1`] = `
       
       * { box-sizing: border-box; }
     </style>
+    
+      
     <style
       id="last"
     />
+    
+    
   </head>
   <body />
 </html>

--- a/packages/sheet/__tests__/__snapshots__/index.js.snap
+++ b/packages/sheet/__tests__/__snapshots__/index.js.snap
@@ -21,7 +21,7 @@ exports[`StyleSheet should accept insertionPoint option 1`] = `
       * { box-sizing: border-box; }
     </style>
     <style
-      id="third"
+      id="last"
     />
   </head>
   <body />

--- a/packages/sheet/__tests__/__snapshots__/index.js.snap
+++ b/packages/sheet/__tests__/__snapshots__/index.js.snap
@@ -240,3 +240,28 @@ exports[`StyleSheet should use the container option instead of document.head to 
   </body>
 </html>
 `;
+
+exports[`StyleSheet should work if insertionPoint is last element 1`] = `
+<html>
+  <head>
+    <style
+      id="last"
+    />
+    <style
+      data-emotion=""
+      data-s=""
+    >
+      
+      html { color: hotpink; }
+    </style>
+    <style
+      data-emotion=""
+      data-s=""
+    >
+      
+      * { box-sizing: border-box; }
+    </style>
+  </head>
+  <body />
+</html>
+`;

--- a/packages/sheet/__tests__/__snapshots__/index.js.snap
+++ b/packages/sheet/__tests__/__snapshots__/index.js.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`StyleSheet should accept insertionPoint option 1`] = `
+<html>
+  <head>
+    <style
+      id="first"
+    />
+    <style
+      data-emotion=""
+      data-s=""
+    >
+      
+      html { color: hotpink; }
+    </style>
+    <style
+      data-emotion=""
+      data-s=""
+    >
+      
+      * { box-sizing: border-box; }
+    </style>
+    <style
+      id="third"
+    />
+  </head>
+  <body />
+</html>
+`;
+
 exports[`StyleSheet should accept prepend option 1`] = `
 <html>
   <head>

--- a/packages/sheet/__tests__/index.js
+++ b/packages/sheet/__tests__/index.js
@@ -130,7 +130,7 @@ describe('StyleSheet', () => {
     // the sheet should be inserted between the first and last style nodes
     const sheet = new StyleSheet({
       ...defaultOptions,
-      insertionPoint: safeQuerySelector('first')
+      insertionPoint: safeQuerySelector('#first')
     })
     sheet.insert(rule)
     sheet.insert(rule2)

--- a/packages/sheet/__tests__/index.js
+++ b/packages/sheet/__tests__/index.js
@@ -141,6 +141,25 @@ describe('StyleSheet', () => {
     head.removeChild(thirdStyle)
   })
 
+  it('should work if insertionPoint is last element', () => {
+    const head = safeQuerySelector('head')
+    const lastStyle = document.createElement('style')
+    lastStyle.setAttribute('id', 'last')
+    head.appendChild(lastStyle)
+
+    // the sheet should be inserted between the first and third style node
+    const sheet = new StyleSheet({
+      ...defaultOptions,
+      insertionPoint: lastStyle
+    })
+    sheet.insert(rule)
+    sheet.insert(rule2)
+    expect(document.documentElement).toMatchSnapshot()
+
+    sheet.flush()
+    head.removeChild(lastStyle)
+  })
+
   it('should be able to hydrate styles', () => {
     const fooStyle = document.createElement('style')
     fooStyle.textContent = '.foo { color: hotpink; }'

--- a/packages/sheet/__tests__/index.js
+++ b/packages/sheet/__tests__/index.js
@@ -17,6 +17,11 @@ afterEach(() => {
   jest.clearAllMocks()
 })
 
+beforeEach(() => {
+  safeQuerySelector('head').innerHTML = ''
+  safeQuerySelector('body').innerHTML = ''
+})
+
 describe('StyleSheet', () => {
   it('should be speedy by default in production', () => {
     process.env.NODE_ENV = 'production'
@@ -98,8 +103,6 @@ describe('StyleSheet', () => {
     expect(sheet.tags).toHaveLength(1)
     expect(sheet.tags[0].parentNode).toBe(container)
     sheet.flush()
-    // $FlowFixMe
-    document.body.removeChild(container)
   })
 
   it('should accept prepend option', () => {
@@ -114,31 +117,26 @@ describe('StyleSheet', () => {
     expect(document.documentElement).toMatchSnapshot()
 
     sheet.flush()
-    head.removeChild(otherStyle)
   })
 
   it('should accept insertionPoint option', () => {
     const head = safeQuerySelector('head')
-    const firstStyle = document.createElement('style')
-    firstStyle.setAttribute('id', 'first')
-    head.appendChild(firstStyle)
 
-    const lastStyle = document.createElement('style')
-    lastStyle.setAttribute('id', 'last')
-    head.appendChild(lastStyle)
+    head.innerHTML = `
+      <style id="first"></style>
+      <style id="last"></style>
+    `
 
     // the sheet should be inserted between the first and last style nodes
     const sheet = new StyleSheet({
       ...defaultOptions,
-      insertionPoint: firstStyle
+      insertionPoint: document.getElementById('first')
     })
     sheet.insert(rule)
     sheet.insert(rule2)
     expect(document.documentElement).toMatchSnapshot()
 
     sheet.flush()
-    head.removeChild(firstStyle)
-    head.removeChild(lastStyle)
   })
 
   it('should work if insertionPoint is last element', () => {
@@ -157,7 +155,6 @@ describe('StyleSheet', () => {
     expect(document.documentElement).toMatchSnapshot()
 
     sheet.flush()
-    head.removeChild(lastStyle)
   })
 
   it('should be able to hydrate styles', () => {
@@ -222,7 +219,6 @@ describe('StyleSheet', () => {
     expect(document.documentElement).toMatchSnapshot()
 
     sheet.flush()
-    head.removeChild(otherStyle)
   })
 
   it('should not crash when flushing when styles are already detached', () => {

--- a/packages/sheet/__tests__/index.js
+++ b/packages/sheet/__tests__/index.js
@@ -117,6 +117,30 @@ describe('StyleSheet', () => {
     head.removeChild(otherStyle)
   })
 
+  it('should accept insertionPoint option', () => {
+    const head = safeQuerySelector('head')
+    const firstStyle = document.createElement('style')
+    firstStyle.setAttribute('id', 'first')
+    head.appendChild(firstStyle)
+
+    const thirdStyle = document.createElement('style')
+    thirdStyle.setAttribute('id', 'third')
+    head.appendChild(thirdStyle)
+
+    // the sheet should be inserted between the first and third style node
+    const sheet = new StyleSheet({
+      ...defaultOptions,
+      insertionPoint: firstStyle
+    })
+    sheet.insert(rule)
+    sheet.insert(rule2)
+    expect(document.documentElement).toMatchSnapshot()
+
+    sheet.flush()
+    head.removeChild(firstStyle)
+    head.removeChild(thirdStyle)
+  })
+
   it('should be able to hydrate styles', () => {
     const fooStyle = document.createElement('style')
     fooStyle.textContent = '.foo { color: hotpink; }'

--- a/packages/sheet/__tests__/index.js
+++ b/packages/sheet/__tests__/index.js
@@ -123,11 +123,11 @@ describe('StyleSheet', () => {
     firstStyle.setAttribute('id', 'first')
     head.appendChild(firstStyle)
 
-    const thirdStyle = document.createElement('style')
-    thirdStyle.setAttribute('id', 'third')
-    head.appendChild(thirdStyle)
+    const lastStyle = document.createElement('style')
+    lastStyle.setAttribute('id', 'last')
+    head.appendChild(lastStyle)
 
-    // the sheet should be inserted between the first and third style node
+    // the sheet should be inserted between the first and last style nodes
     const sheet = new StyleSheet({
       ...defaultOptions,
       insertionPoint: firstStyle
@@ -138,7 +138,7 @@ describe('StyleSheet', () => {
 
     sheet.flush()
     head.removeChild(firstStyle)
-    head.removeChild(thirdStyle)
+    head.removeChild(lastStyle)
   })
 
   it('should work if insertionPoint is last element', () => {
@@ -147,7 +147,7 @@ describe('StyleSheet', () => {
     lastStyle.setAttribute('id', 'last')
     head.appendChild(lastStyle)
 
-    // the sheet should be inserted between the first and third style node
+    // the sheet should be inserted after the first node
     const sheet = new StyleSheet({
       ...defaultOptions,
       insertionPoint: lastStyle

--- a/packages/sheet/__tests__/index.js
+++ b/packages/sheet/__tests__/index.js
@@ -130,7 +130,7 @@ describe('StyleSheet', () => {
     // the sheet should be inserted between the first and last style nodes
     const sheet = new StyleSheet({
       ...defaultOptions,
-      insertionPoint: document.getElementById('first')
+      insertionPoint: safeQuerySelector('first')
     })
     sheet.insert(rule)
     sheet.insert(rule2)

--- a/packages/sheet/src/index.js
+++ b/packages/sheet/src/index.js
@@ -44,7 +44,8 @@ export type Options = {
   key: string,
   container: HTMLElement,
   speedy?: boolean,
-  prepend?: boolean
+  prepend?: boolean,
+  insertionPoint?: HTMLElement
 }
 
 function createStyleElement(options: {
@@ -70,6 +71,7 @@ export class StyleSheet {
   nonce: string | void
   prepend: boolean | void
   before: Element | null
+  insertionPoint: HTMLElement | void
   constructor(options: Options) {
     this.isSpeedy =
       options.speedy === undefined
@@ -82,13 +84,20 @@ export class StyleSheet {
     this.key = options.key
     this.container = options.container
     this.prepend = options.prepend
+    this.insertionPoint = options.insertionPoint
     this.before = null
   }
 
   _insertTag = (tag: HTMLStyleElement) => {
     let before
     if (this.tags.length === 0) {
-      before = this.prepend ? this.container.firstChild : this.before
+      if (!!this.insertionPoint) {
+        before = this.insertionPoint.nextSibling
+      } else if (this.prepend) {
+        before = this.container.firstChild
+      } else {
+        before = this.prepend ? this.container.firstChild : this.before
+      }
     } else {
       before = this.tags[this.tags.length - 1].nextSibling
     }

--- a/packages/sheet/src/index.js
+++ b/packages/sheet/src/index.js
@@ -96,7 +96,7 @@ export class StyleSheet {
       } else if (this.prepend) {
         before = this.container.firstChild
       } else {
-        before = this.prepend ? this.container.firstChild : this.before
+        before = this.before
       }
     } else {
       before = this.tags[this.tags.length - 1].nextSibling

--- a/packages/sheet/src/index.js
+++ b/packages/sheet/src/index.js
@@ -91,7 +91,7 @@ export class StyleSheet {
   _insertTag = (tag: HTMLStyleElement) => {
     let before
     if (this.tags.length === 0) {
-      if (!!this.insertionPoint) {
+      if (this.insertionPoint) {
         before = this.insertionPoint.nextSibling
       } else if (this.prepend) {
         before = this.container.firstChild

--- a/packages/sheet/types/index.d.ts
+++ b/packages/sheet/types/index.d.ts
@@ -6,7 +6,9 @@ export interface Options {
   key: string
   container: HTMLElement
   speedy?: boolean
+  /** @deprecate use `insertionPoint` instead */
   prepend?: boolean
+  insertionPoint?: HTMLElement
 }
 
 export class StyleSheet {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes https://github.com/emotion-js/emotion/issues/2037 (it is closed, but the feature request haven't been implemented before). 

It adds an option to the `EmotionCache` for specifying an insertion point - dom node after which the style rules will be inserted.
<!-- Why are these changes necessary? -->

**Why**:

It is necessary feature for applications that have third-party styles coming from one place, which should be injected first, then the app's styles coming from emotion, for example, coming from a UI library (as @mui/material) that needs to be injected next, and then any other overrides for the default styles.

<!-- How were these changes implemented? -->

**How**:

It's pretty much self explanatory, the style rules are being injected after the specified node. This option wins over `prepend`, if both are being specified, as I would say is more specific.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
