### PR TITLE
chore: add repository directory for all packages.json

### DIFF
--- a/packages/babel-plugin-jsx-pragmatic/package.json
+++ b/packages/babel-plugin-jsx-pragmatic/package.json
@@ -5,7 +5,11 @@
   "main": "dist/emotion-babel-plugin-jsx-pragmatic.cjs.js",
   "module": "dist/emotion-babel-plugin-jsx-pragmatic.esm.js",
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/babel-plugin-jsx-pragmatic",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/babel-plugin-jsx-pragmatic"
+  },
   "scripts": {
     "test:typescript": "exit 0"
   },

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -36,7 +36,11 @@
   "author": "Kye Hohenberger",
   "homepage": "https://emotion.sh",
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/babel-plugin",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/babel-plugin"
+  },
   "keywords": [
     "styles",
     "emotion",

--- a/packages/babel-preset-css-prop/package.json
+++ b/packages/babel-preset-css-prop/package.json
@@ -5,7 +5,11 @@
   "main": "dist/emotion-babel-preset-css-prop.cjs.js",
   "module": "dist/emotion-babel-preset-css-prop.esm.js",
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/babel-preset-css-prop",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/babel-preset-css-prop"
+  },
   "scripts": {
     "test:typescript": "exit 0"
   },

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -10,7 +10,11 @@
   },
   "types": "types/index.d.ts",
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/cache",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/cache"
+  },
   "scripts": {
     "test:typescript": "dtslint types"
   },

--- a/packages/css-prettifier/package.json
+++ b/packages/css-prettifier/package.json
@@ -13,7 +13,11 @@
   "module": "dist/emotion-css-prettifier.esm.js",
   "types": "types/index.d.ts",
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/css-prettifier",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/css-prettifier"
+  },
   "dependencies": {
     "@emotion/memoize": "^0.7.4",
     "stylis": "^4.0.10"

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -39,7 +39,11 @@
   "author": "Kye Hohenberger",
   "homepage": "https://emotion.sh",
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/css",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/css"
+  },
   "keywords": [
     "styles",
     "emotion",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -17,7 +17,11 @@
     "node": ">=6"
   },
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/eslint-plugin",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/eslint-plugin"
+  },
   "peerDependencies": {
     "eslint": "6 || 7"
   },

--- a/packages/hash/package.json
+++ b/packages/hash/package.json
@@ -6,7 +6,11 @@
   "module": "dist/emotion-hash.esm.js",
   "types": "types/index.d.ts",
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/hash",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/hash"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/is-prop-valid/package.json
+++ b/packages/is-prop-valid/package.json
@@ -6,7 +6,11 @@
   "module": "dist/emotion-is-prop-valid.esm.js",
   "types": "types/index.d.ts",
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/is-prop-valid",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/is-prop-valid"
+  },
   "scripts": {
     "test:typescript": "dtslint types"
   },

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -50,7 +50,11 @@
   "author": "Kye Hohenberger",
   "homepage": "https://emotion.sh",
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/jest",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/jest"
+  },
   "keywords": [
     "styles",
     "emotion",

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -6,7 +6,11 @@
   "module": "dist/emotion-memoize.esm.js",
   "types": "types/index.d.ts",
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/memoize",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/memoize"
+  },
   "scripts": {
     "test:typescript": "dtslint types"
   },

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -35,7 +35,11 @@
   },
   "homepage": "https://emotion.sh",
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/native",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/native"
+  },
   "keywords": [
     "styles",
     "emotion",

--- a/packages/primitives-core/package.json
+++ b/packages/primitives-core/package.json
@@ -24,7 +24,11 @@
     "react": "16.14.0"
   },
   "homepage": "https://emotion.sh",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/primitives-core",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/primitives-core"
+  },
   "keywords": [
     "styles",
     "emotion",

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -35,7 +35,11 @@
   },
   "homepage": "https://emotion.sh",
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/primitives",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/primitives"
+  },
   "keywords": [
     "styles",
     "emotion",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -58,7 +58,11 @@
     "react": "16.14.0",
     "svg-tag-names": "^1.1.1"
   },
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/react",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/react"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/serialize/package.json
+++ b/packages/serialize/package.json
@@ -6,7 +6,11 @@
   "module": "dist/emotion-serialize.esm.js",
   "types": "types/index.d.ts",
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/serialize",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/serialize"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,7 +37,11 @@
   "author": "Kye Hohenberger",
   "homepage": "https://emotion.sh",
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/server",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/server"
+  },
   "keywords": [
     "styles",
     "emotion",

--- a/packages/sheet/package.json
+++ b/packages/sheet/package.json
@@ -13,7 +13,11 @@
   "scripts": {
     "test:typescript": "dtslint types"
   },
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/sheet",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/sheet"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -6,7 +6,11 @@
   "module": "dist/emotion-styled.esm.js",
   "types": "types/index.d.ts",
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/styled",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/styled"
+  },
   "scripts": {
     "test:typescript": "dtslint types"
   },

--- a/packages/unitless/package.json
+++ b/packages/unitless/package.json
@@ -5,7 +5,11 @@
   "main": "dist/emotion-unitless.cjs.js",
   "module": "dist/emotion-unitless.esm.js",
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/unitless",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/unitless"
+  },
   "scripts": {
     "test:typescript": "exit 0"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,7 +13,11 @@
   "scripts": {
     "test:typescript": "dtslint types"
   },
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/utils",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/utils"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/weak-memoize/package.json
+++ b/packages/weak-memoize/package.json
@@ -6,7 +6,11 @@
   "module": "dist/emotion-weak-memoize.esm.js",
   "types": "types/index.d.ts",
   "license": "MIT",
-  "repository": "https://github.com/emotion-js/emotion/tree/main/packages/weak-memoize",
+  "repository": {
+    "url": "https://github.com/emotion-js/emotion.git",
+    "type": "git",
+    "directory": "packages/weak-memoize"
+  },
   "scripts": {
     "test:typescript": "dtslint types"
   },


### PR DESCRIPTION
> If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:
> ```json
> "repository": {
>   "type" : "git",
>   "url" : "https://github.com/facebook/react.git",
>   "directory": "packages/react-dom"
> }
> ```
> — https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository

I use a lot https://njt.vercel.app/ to jump to different packages information,
and with this PR we can know exactly what package in what folder lives

Made the changes with a script to make it easier 🙂

https://gist.github.com/iamandrewluca/5cc85b56a595056f0099d04ed6dd8a79
