### PR TITLE
Document extra installation step for M1 Mac

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,10 @@
 
 ## Installation
 
+- (If using an M1 Mac) Install `vips` via Homebrew: `brew install vips`.
+  - This step will become unnecessary once Sharp starts publishing prebuilt
+    binaries for darwin-arm64v8.
+    [Reference](https://github.com/lovell/sharp/issues/2460#issuecomment-751491241)
 - Run `yarn` in the repository's root directory to install everything you need for development.
 - Run `yarn build` in the root directory to build the modules.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@
 ## Installation
 
 - (If using an M1 Mac) Install `vips` via Homebrew: `brew install vips`.
-  - This step will become unnecessary once Sharp starts publishing prebuilt
-    binaries for darwin-arm64v8.
-    [Reference](https://github.com/lovell/sharp/issues/2460#issuecomment-751491241)
+  - This step can be removed from this document if we upgrade to the latest
+    version of Gatsby, which is compatible with sharp 0.28.0+ which does include
+    binaries for M1 Macs.
 - Run `yarn` in the repository's root directory to install everything you need for development.
 - Run `yarn build` in the root directory to build the modules.
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: `yarn install` fails on M1 Macs unless `libvips` is installed separately.

<!-- Why are these changes necessary? -->

**Why**: So that M1 Mac users can contribute to Emotion.

<!-- How were these changes implemented? -->

**How**: Document the extra step in `CONTRIBUTING.md`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A
- [ ] Changeset N/A <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
