### PR TITLE
[DOC] Updated doc to add a cache option use-case

### DIFF
--- a/.changeset/calm-islands-rule.md
+++ b/.changeset/calm-islands-rule.md
@@ -1,0 +1,5 @@
+---
+'@emotion/cache': patch
+---
+
+Updated doc to add a cache option use-case

--- a/.changeset/calm-islands-rule.md
+++ b/.changeset/calm-islands-rule.md
@@ -1,5 +1,0 @@
----
-'@emotion/cache': patch
----
-
-Updated doc to add a cache option use-case

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -53,7 +53,7 @@ The prefix before class names. It will also be set as the value of the `data-emo
 
 `HTMLElement`
 
-A DOM node that emotion will insert all of its style tags into. This is useful for inserting styles into iframes.
+A DOM node that emotion will insert all of its style tags into. This is useful for inserting styles into iframes or windows.
 
 ### `prepend`
 


### PR DESCRIPTION
**What**:

I added the "style injection in windows" use-case to the documentation of the CacheProvider options

**Why**:

I was searching for this features but I didn't understand that this option was related to my use-case at first read.

**Checklist**:

- [x] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A
- [x] Changeset 

Could you see other use-cases to add ? Maybe style injection in tabs (I haven't tried  it though) ?