### PR TITLE
fix(styled): Ensure no hydration mismatch with React.useId

### DIFF
--- a/.changeset/purple-tigers-breathe.md
+++ b/.changeset/purple-tigers-breathe.md
@@ -1,0 +1,8 @@
+---
+'@emotion/jest': minor
+---
+
+author: @eps1lon
+author: @Andarist
+
+Adjusted the serialization logic to unwrap rendered elements from Fragments that had to be added to fix hydration mismatches caused by `React.useId` usage (the upcoming API of the React 18).

--- a/.changeset/strange-kids-change.md
+++ b/.changeset/strange-kids-change.md
@@ -1,5 +1,6 @@
 ---
-'@emotion/styled': patch
+'@emotion/react': minor
+'@emotion/styled': minor
 ---
 
-Fix hydration mismatches if `React.useId` is used
+Fixed hydration mismatches if `React.useId` (the upcoming API of the React 18) is used within a tree below our components.

--- a/.changeset/strange-kids-change.md
+++ b/.changeset/strange-kids-change.md
@@ -1,0 +1,5 @@
+---
+'@emotion/styled': patch
+---
+
+Fix hydration mismatches if `React.useId` is used

--- a/package.json
+++ b/package.json
@@ -261,6 +261,8 @@
     "react-router-dom": "^4.2.2",
     "react-scripts": "1.1.5",
     "react-test-renderer": "16.8.6",
+    "react18": "npm:react@alpha",
+    "react18-dom": "npm:react-dom@alpha",
     "svg-tag-names": "^1.1.1",
     "through": "^2.3.8",
     "unified": "^6.1.6",

--- a/packages/jest/src/create-enzyme-serializer.js
+++ b/packages/jest/src/create-enzyme-serializer.js
@@ -3,8 +3,63 @@ import type { Options } from './create-serializer'
 import { createSerializer as createEmotionSerializer } from './create-serializer'
 import * as enzymeTickler from './enzyme-tickler'
 import { createSerializer as createEnzymeToJsonSerializer } from 'enzyme-to-json'
+import { isEmotionCssPropElementType, isStyledElementType } from './utils'
 
-const enzymeSerializer = createEnzymeToJsonSerializer({})
+const enzymeToJsonSerializer = createEnzymeToJsonSerializer({
+  map: json => {
+    if (typeof json.node.type === 'string') {
+      return json
+    }
+    const isRealStyled = json.node.type.__emotion_real === json.node.type
+    if (isRealStyled) {
+      return {
+        ...json,
+        children: json.children.slice(-1)
+      }
+    }
+    return json
+  }
+})
+
+// this is a hack, leveraging the internal/implementation knowledge about the enzyme's ShallowWrapper
+// there is no sane way to get this information otherwise though
+const getUnrenderedElement = shallowWrapper => {
+  const symbols = Object.getOwnPropertySymbols(shallowWrapper)
+  const elementValues = symbols.filter(sym => {
+    const val = shallowWrapper[sym]
+    return !!val && val.$$typeof === Symbol.for('react.element')
+  })
+  if (elementValues.length !== 1) {
+    throw new Error(
+      "Could not get unrendered element reliably from the Enzyme's ShallowWrapper. This is a bug in Emotion - please open an issue with repro steps included:\n" +
+        'https://github.com/emotion-js/emotion/issues/new?assignees=&labels=bug%2C+needs+triage&template=--bug-report.md&title='
+    )
+  }
+  return shallowWrapper[elementValues[0]]
+}
+
+const wrappedEnzymeSerializer = {
+  test: enzymeToJsonSerializer.test,
+  print: (enzymeWrapper, printer) => {
+    const isShallow = !!enzymeWrapper.dive
+
+    if (isShallow) {
+      const unrendered = getUnrenderedElement(enzymeWrapper)
+      if (
+        (isEmotionCssPropElementType(unrendered) ||
+          isStyledElementType(unrendered)) &&
+        enzymeWrapper.getElement().type === Symbol.for('react.fragment')
+      ) {
+        return enzymeToJsonSerializer.print(
+          enzymeWrapper.children().last(),
+          printer
+        )
+      }
+    }
+
+    return enzymeToJsonSerializer.print(enzymeWrapper, printer)
+  }
+}
 
 export function createEnzymeSerializer({
   classNameReplacer,
@@ -16,7 +71,7 @@ export function createEnzymeSerializer({
   })
   return {
     test(node: *) {
-      return enzymeSerializer.test(node) || emotionSerializer.test(node)
+      return wrappedEnzymeSerializer.test(node) || emotionSerializer.test(node)
     },
     serialize(
       node: *,
@@ -26,9 +81,9 @@ export function createEnzymeSerializer({
       refs: *,
       printer: Function
     ) {
-      if (enzymeSerializer.test(node)) {
+      if (wrappedEnzymeSerializer.test(node)) {
         const tickled = enzymeTickler.tickle(node)
-        return enzymeSerializer.print(
+        return wrappedEnzymeSerializer.print(
           tickled,
           // https://github.com/facebook/jest/blob/470ef2d29c576d6a10de344ec25d5a855f02d519/packages/pretty-format/src/index.ts#L281
           valChild => printer(valChild, config, indentation, depth, refs)

--- a/packages/jest/src/create-enzyme-serializer.js
+++ b/packages/jest/src/create-enzyme-serializer.js
@@ -3,7 +3,11 @@ import type { Options } from './create-serializer'
 import { createSerializer as createEmotionSerializer } from './create-serializer'
 import * as enzymeTickler from './enzyme-tickler'
 import { createSerializer as createEnzymeToJsonSerializer } from 'enzyme-to-json'
-import { isEmotionCssPropElementType, isStyledElementType } from './utils'
+import {
+  isEmotionCssPropElementType,
+  isStyledElementType,
+  unwrapFromPotentialFragment
+} from './utils'
 
 const enzymeToJsonSerializer = createEnzymeToJsonSerializer({
   map: json => {
@@ -43,15 +47,14 @@ const wrappedEnzymeSerializer = {
   print: (enzymeWrapper, printer) => {
     const isShallow = !!enzymeWrapper.dive
 
-    if (isShallow) {
+    if (isShallow && enzymeWrapper.root() === enzymeWrapper) {
       const unrendered = getUnrenderedElement(enzymeWrapper)
       if (
-        (isEmotionCssPropElementType(unrendered) ||
-          isStyledElementType(unrendered)) &&
-        enzymeWrapper.getElement().type === Symbol.for('react.fragment')
+        isEmotionCssPropElementType(unrendered) ||
+        isStyledElementType(unrendered)
       ) {
         return enzymeToJsonSerializer.print(
-          enzymeWrapper.children().last(),
+          unwrapFromPotentialFragment(enzymeWrapper),
           printer
         )
       }

--- a/packages/jest/src/create-serializer.js
+++ b/packages/jest/src/create-serializer.js
@@ -115,46 +115,45 @@ function isShallowEnzymeElement(
   })
 }
 
-const createConvertEmotionElements =
-  (keys: string[], printer: *) => (node: any) => {
-    if (isPrimitive(node)) {
-      return node
-    }
-    if (isEmotionCssPropEnzymeElement(node)) {
-      const className = enzymeTickler.getTickledClassName(node.props.css)
-      const labels = getLabelsFromClassName(keys, className || '')
-
-      if (isShallowEnzymeElement(node, keys, labels)) {
-        const emotionType = node.props.__EMOTION_TYPE_PLEASE_DO_NOT_USE__
-        // emotionType will be a string for DOM elements
-        const type =
-          typeof emotionType === 'string'
-            ? emotionType
-            : emotionType.displayName || emotionType.name || 'Component'
-        return {
-          ...node,
-          props: filterEmotionProps({
-            ...node.props,
-            className
-          }),
-          type
-        }
-      } else {
-        return node.children[0]
-      }
-    }
-    if (isEmotionCssPropElementType(node)) {
-      return {
-        ...node,
-        props: filterEmotionProps(node.props),
-        type: node.props.__EMOTION_TYPE_PLEASE_DO_NOT_USE__
-      }
-    }
-    if (isReactElement(node)) {
-      return copyProps({}, node)
-    }
+const createConvertEmotionElements = (keys: string[]) => (node: any) => {
+  if (isPrimitive(node)) {
     return node
   }
+  if (isEmotionCssPropEnzymeElement(node)) {
+    const className = enzymeTickler.getTickledClassName(node.props.css)
+    const labels = getLabelsFromClassName(keys, className || '')
+
+    if (isShallowEnzymeElement(node, keys, labels)) {
+      const emotionType = node.props.__EMOTION_TYPE_PLEASE_DO_NOT_USE__
+      // emotionType will be a string for DOM elements
+      const type =
+        typeof emotionType === 'string'
+          ? emotionType
+          : emotionType.displayName || emotionType.name || 'Component'
+      return {
+        ...node,
+        props: filterEmotionProps({
+          ...node.props,
+          className
+        }),
+        type
+      }
+    } else {
+      return node.children[node.children.length - 1]
+    }
+  }
+  if (isEmotionCssPropElementType(node)) {
+    return {
+      ...node,
+      props: filterEmotionProps(node.props),
+      type: node.props.__EMOTION_TYPE_PLEASE_DO_NOT_USE__
+    }
+  }
+  if (isReactElement(node)) {
+    return copyProps({}, node)
+  }
+  return node
+}
 
 function clean(node: any, classNames: string[]) {
   if (Array.isArray(node)) {
@@ -199,7 +198,7 @@ export function createSerializer({
   ) {
     const elements = getStyleElements()
     const keys = getKeys(elements)
-    const convertEmotionElements = createConvertEmotionElements(keys, printer)
+    const convertEmotionElements = createConvertEmotionElements(keys)
     const converted = deepTransform(val, convertEmotionElements)
     const nodes = getNodes(converted)
     const classNames = getClassNamesFromNodes(nodes)

--- a/packages/jest/src/enzyme-tickler.js
+++ b/packages/jest/src/enzyme-tickler.js
@@ -12,8 +12,12 @@ export const tickle = wrapper => {
       return
     }
 
-    const wrapped = (isShallow ? el.dive() : el.children()).first()
-    tickledCssProps.set(cssProp, wrapped.props().className)
+    const rendered = (isShallow ? el.dive() : el.children()).last()
+    const unwrapped =
+      rendered.type() === Symbol.for('react.fragment')
+        ? rendered.children().last()
+        : rendered
+    tickledCssProps.set(cssProp, unwrapped.props().className)
   })
   return wrapper
 }

--- a/packages/jest/src/enzyme-tickler.js
+++ b/packages/jest/src/enzyme-tickler.js
@@ -1,3 +1,5 @@
+import { unwrapFromPotentialFragment } from './utils'
+
 const tickledCssProps = new WeakMap()
 
 export const getTickledClassName = cssProp => tickledCssProps.get(cssProp)
@@ -13,11 +15,10 @@ export const tickle = wrapper => {
     }
 
     const rendered = (isShallow ? el.dive() : el.children()).last()
-    const unwrapped =
-      rendered.type() === Symbol.for('react.fragment')
-        ? rendered.children().last()
-        : rendered
-    tickledCssProps.set(cssProp, unwrapped.props().className)
+    tickledCssProps.set(
+      cssProp,
+      unwrapFromPotentialFragment(rendered).props().className
+    )
   })
   return wrapper
 }

--- a/packages/jest/src/utils.js
+++ b/packages/jest/src/utils.js
@@ -62,7 +62,7 @@ function getClassNamesFromEnzyme(selectors, nodeWithFragment) {
   // TODO: Does approach work with older Emotion versions? Does it cause false positives with components named "Fragment" that aren't `React.Fragment`?
   const node =
     nodeWithFragment.name() === 'Fragment'
-      ? nodeWithFragment.children()
+      ? nodeWithFragment.children().at(1)
       : nodeWithFragment
   // We need to dive in to get the className if we have a styled element from a shallow render
   const isShallow = shouldDive(node)

--- a/packages/jest/src/utils.js
+++ b/packages/jest/src/utils.js
@@ -58,7 +58,12 @@ function getClassNameProp(node) {
   return (node && node.prop('className')) || ''
 }
 
-function getClassNamesFromEnzyme(selectors, node) {
+function getClassNamesFromEnzyme(selectors, nodeWithFragment) {
+  // TODO: Does approach work with older Emotion versions? Does it cause false positives with components named "Fragment" that aren't `React.Fragment`?
+  const node =
+    nodeWithFragment.name() === 'Fragment'
+      ? nodeWithFragment.children()
+      : nodeWithFragment
   // We need to dive in to get the className if we have a styled element from a shallow render
   const isShallow = shouldDive(node)
   const nodeWithClassName = findNodeWithClassName(

--- a/packages/jest/src/utils.js
+++ b/packages/jest/src/utils.js
@@ -58,7 +58,7 @@ function getClassNameProp(node) {
   return (node && node.prop('className')) || ''
 }
 
-export function unwrapFromPotentialFragment(node) {
+export function unwrapFromPotentialFragment(node: *) {
   if (node.type() === Symbol.for('react.fragment')) {
     return node.children().last()
   }

--- a/packages/jest/src/utils.js
+++ b/packages/jest/src/utils.js
@@ -59,13 +59,8 @@ function getClassNameProp(node) {
 }
 
 function unwrapFromPotentialFragment(node) {
-  // this symbol is rather stable and won't change, it is how jest was handling this initially:
-  // https://github.com/facebook/jest/blob/b0d28888154aec2e05cfb3249520b9a2a1a7c12d/packages/pretty-format/src/plugins/react_element.js#L20
-  // in environments without Symbols this would fail (React fallbacks to integers then for the element types) but we don't support such environments
-  // since then jest has started using `react-is` package and that could be used here too
   if (node.type() === Symbol.for('react.fragment')) {
-    // the rendered element always comes second as the first slot is reserved for the potential style element
-    return node.childAt(1)
+    return node.children().last()
   }
   return node
 }
@@ -99,9 +94,16 @@ export function isReactElement(val: any): boolean {
 export function isEmotionCssPropElementType(val: any): boolean {
   return (
     val.$$typeof === Symbol.for('react.element') &&
-    val.type.$$typeof === Symbol.for('react.forward_ref') &&
     val.type.displayName === 'EmotionCssPropInternal'
   )
+}
+
+export function isStyledElementType(val: any): boolean {
+  if (val.$$typeof !== Symbol.for('react.element')) {
+    return false
+  }
+  const { type } = val
+  return type.__emotion_real === type
 }
 
 export function isEmotionCssPropEnzymeElement(val: any): boolean {

--- a/packages/jest/src/utils.js
+++ b/packages/jest/src/utils.js
@@ -58,7 +58,7 @@ function getClassNameProp(node) {
   return (node && node.prop('className')) || ''
 }
 
-function unwrapFromPotentialFragment(node) {
+export function unwrapFromPotentialFragment(node) {
   if (node.type() === Symbol.for('react.fragment')) {
     return node.children().last()
   }

--- a/packages/jest/test/__snapshots__/react-enzyme.test.js.snap
+++ b/packages/jest/test/__snapshots__/react-enzyme.test.js.snap
@@ -48,6 +48,7 @@ exports[`enzyme mount displayName 1`] = `
 
 exports[`enzyme mount empty styled 1`] = `
 <Greeting>
+  <Noop />
   <div
     className="emotion-0 emotion-1"
   >
@@ -97,6 +98,7 @@ exports[`enzyme mount nested styled 1`] = `
 
 <div>
   <Greeting>
+    <Noop />
     <div
       className="emotion-0 emotion-1"
     >
@@ -120,6 +122,7 @@ exports[`enzyme mount nested styled with css prop 1`] = `
   <Button
     className="emotion-0"
   >
+    <Noop />
     <button
       className="emotion-1 emotion-2"
     >
@@ -135,6 +138,7 @@ exports[`enzyme mount styled 1`] = `
 }
 
 <Greeting>
+  <Noop />
   <div
     className="emotion-0 emotion-1"
   >
@@ -156,6 +160,7 @@ exports[`enzyme mount styled with css prop 1`] = `
 <Button
   className="emotion-0"
 >
+  <Noop />
   <button
     className="emotion-1 emotion-2"
   >
@@ -178,6 +183,7 @@ exports[`enzyme mount theming 1`] = `
       }
     }
   >
+    <Noop />
     <button
       className="emotion-0 emotion-1"
     >
@@ -198,6 +204,7 @@ exports[`enzyme mount theming 1`] = `
         }
       }
     >
+      <Noop />
       <button
         className="emotion-0 emotion-1"
       >
@@ -447,6 +454,7 @@ exports[`enzyme shallow displayName 1`] = `
 
 exports[`enzyme shallow empty styled 1`] = `
 <Fragment>
+  <Noop />
   <div
     className="emotion-0 emotion-1"
   >
@@ -503,6 +511,7 @@ exports[`enzyme shallow styled 1`] = `
 }
 
 <Fragment>
+  <Noop />
   <div
     className="emotion-0 emotion-1"
   >

--- a/packages/jest/test/__snapshots__/react-enzyme.test.js.snap
+++ b/packages/jest/test/__snapshots__/react-enzyme.test.js.snap
@@ -7,14 +7,9 @@ exports[`enzyme mount basic 1`] = `
 
 <Greeting>
   <div
-    css="unknown styles"
+    className="emotion-0"
   >
-    <Noop />
-    <div
-      className="emotion-0"
-    >
-      hello
-    </div>
+    hello
   </div>
 </Greeting>
 `;
@@ -25,14 +20,13 @@ exports[`enzyme mount conditional styles 1`] = `
 }
 
 <div
-  css="unknown styles"
+  className="emotion-0"
 >
-  <Noop />
-  <div
-    className="emotion-0"
+  <span
+    className="emotion-1"
   >
-    <Noop />
-  </div>
+    Test content
+  </span>
 </div>
 `;
 
@@ -42,24 +36,18 @@ exports[`enzyme mount displayName 1`] = `
 }
 
 <CustomDisplayName
-  css="unknown styles"
+  className="emotion-0"
 >
-  <Noop />
-  <CustomDisplayName
+  <div
     className="emotion-0"
   >
-    <div
-      className="emotion-0"
-    >
-      Hello
-    </div>
-  </CustomDisplayName>
+    Hello
+  </div>
 </CustomDisplayName>
 `;
 
 exports[`enzyme mount empty styled 1`] = `
 <Greeting>
-  <Noop />
   <div
     className="emotion-0 emotion-1"
   >
@@ -76,14 +64,9 @@ exports[`enzyme mount nested 1`] = `
 <div>
   <Greeting>
     <div
-      css="unknown styles"
+      className="emotion-0"
     >
-      <Noop />
-      <div
-        className="emotion-0"
-      >
-        hello
-      </div>
+      hello
     </div>
   </Greeting>
 </div>
@@ -96,18 +79,13 @@ exports[`enzyme mount nested displayName 1`] = `
 
 <div>
   <CustomDisplayName
-    css="unknown styles"
+    className="emotion-0"
   >
-    <Noop />
-    <CustomDisplayName
+    <div
       className="emotion-0"
     >
-      <div
-        className="emotion-0"
-      >
-        Hello
-      </div>
-    </CustomDisplayName>
+      Hello
+    </div>
   </CustomDisplayName>
 </div>
 `;
@@ -119,7 +97,6 @@ exports[`enzyme mount nested styled 1`] = `
 
 <div>
   <Greeting>
-    <Noop />
     <div
       className="emotion-0 emotion-1"
     >
@@ -141,19 +118,13 @@ exports[`enzyme mount nested styled with css prop 1`] = `
 
 <div>
   <Button
-    css="unknown styles"
+    className="emotion-0"
   >
-    <Noop />
-    <Button
-      className="emotion-0"
+    <button
+      className="emotion-1 emotion-2"
     >
-      <Noop />
-      <button
-        className="emotion-1 emotion-2"
-      >
-        iChenLei
-      </button>
-    </Button>
+      iChenLei
+    </button>
   </Button>
 </div>
 `;
@@ -164,7 +135,6 @@ exports[`enzyme mount styled 1`] = `
 }
 
 <Greeting>
-  <Noop />
   <div
     className="emotion-0 emotion-1"
   >
@@ -184,19 +154,13 @@ exports[`enzyme mount styled with css prop 1`] = `
 }
 
 <Button
-  css="unknown styles"
+  className="emotion-0"
 >
-  <Noop />
-  <Button
-    className="emotion-0"
+  <button
+    className="emotion-1 emotion-2"
   >
-    <Noop />
-    <button
-      className="emotion-1 emotion-2"
-    >
-      iChenLei
-    </button>
-  </Button>
+    iChenLei
+  </button>
 </Button>
 `;
 
@@ -214,7 +178,6 @@ exports[`enzyme mount theming 1`] = `
       }
     }
   >
-    <Noop />
     <button
       className="emotion-0 emotion-1"
     >
@@ -235,7 +198,6 @@ exports[`enzyme mount theming 1`] = `
         }
       }
     >
-      <Noop />
       <button
         className="emotion-0 emotion-1"
       >
@@ -253,14 +215,9 @@ exports[`enzyme mount with array of styles as css prop 1`] = `
 }
 
 <div
-  css="unknown styles"
+  className="emotion-0"
 >
-  <Noop />
-  <div
-    className="emotion-0"
-  >
-    Test content
-  </div>
+  Test content
 </div>
 `;
 
@@ -272,18 +229,13 @@ exports[`enzyme mount with array of styles in a composite inner child 1`] = `
 
 <div>
   <Inner
-    css="unknown styles"
+    className="emotion-0"
   >
-    <Noop />
-    <Inner
+    <span
       className="emotion-0"
     >
-      <span
-        className="emotion-0"
-      >
-        Test content
-      </span>
-    </Inner>
+      Test content
+    </span>
   </Inner>
 </div>
 `;
@@ -304,14 +256,9 @@ exports[`enzyme mount with prop containing css element 1`] = `
 >
   <div>
     <p
-      css="unknown styles"
+      className="emotion-0"
     >
-      <Noop />
-      <p
-        className="emotion-0"
-      >
-        Hello
-      </p>
+      Hello
     </p>
      
     World!
@@ -337,16 +284,10 @@ exports[`enzyme mount with prop containing css element not at the top level 1`] 
   >
     <div>
       <p
-        css="unknown styles"
+        className="emotion-0"
         id="something"
       >
-        <Noop />
-        <p
-          className="emotion-0"
-          id="something"
-        >
-          Hello
-        </p>
+        Hello
       </p>
        
       World!
@@ -378,16 +319,10 @@ exports[`enzyme mount with prop containing css element with other label 1`] = `
     }
   >
     <p
-      css="unknown styles"
+      className="emotion-0"
       id="something"
     >
-      <Noop />
-      <p
-        className="emotion-0"
-        id="something"
-      >
-        Hello
-      </p>
+      Hello
     </p>
      
     World!
@@ -412,16 +347,10 @@ exports[`enzyme mount with prop containing css element with other props 1`] = `
 >
   <div>
     <p
-      css="unknown styles"
+      className="emotion-0"
       id="something"
     >
-      <Noop />
-      <p
-        className="emotion-0"
-        id="something"
-      >
-        Hello
-      </p>
+      Hello
     </p>
      
     World!
@@ -449,18 +378,13 @@ exports[`enzyme mount with styles on top level 1`] = `
 }
 
 <Greeting
-  css="unknown styles"
+  className="emotion-0"
 >
-  <Noop />
-  <Greeting
+  <div
     className="emotion-0"
   >
-    <div
-      className="emotion-0"
-    >
-      Hello
-    </div>
-  </Greeting>
+    Hello
+  </div>
 </Greeting>
 `;
 
@@ -474,28 +398,22 @@ exports[`enzyme parent and child using css property 1`] = `
 }
 
 <div
-  css="unknown styles"
+  className="emotion-0"
 >
-  <Noop />
+  Test content
   <div
-    className="emotion-0"
-  >
-    Test content
-    <div
-      css="unknown styles"
-    >
-      <Noop />
-      <div
-        className="emotion-1"
-      />
-    </div>
-  </div>
+    className="emotion-1"
+  />
 </div>
 `;
 
 exports[`enzyme shallow basic 1`] = `
+.emotion-0 {
+  background-color: red;
+}
+
 <div
-  css="unknown styles"
+  className="emotion-0"
 >
   hello
 </div>
@@ -506,18 +424,15 @@ exports[`enzyme shallow conditional styles 1`] = `
   background-color: black;
 }
 
-<Fragment>
-  <Noop />
-  <div
-    className="emotion-0"
+<div
+  className="emotion-0"
+>
+  <span
+    css="unknown styles"
   >
-    <span
-      css="unknown styles"
-    >
-      Test content
-    </span>
-  </div>
-</Fragment>
+    Test content
+  </span>
+</div>
 `;
 
 exports[`enzyme shallow displayName 1`] = `
@@ -525,23 +440,17 @@ exports[`enzyme shallow displayName 1`] = `
   color: hotpink;
 }
 
-<Fragment>
-  <Noop />
-  <CustomDisplayName
-    className="emotion-0"
-  />
-</Fragment>
+<CustomDisplayName
+  className="emotion-0"
+/>
 `;
 
 exports[`enzyme shallow empty styled 1`] = `
-<Fragment>
-  <Noop />
-  <div
-    className="emotion-0 emotion-1"
-  >
-    Hello
-  </div>
-</Fragment>
+<div
+  className="emotion-0 emotion-1"
+>
+  Hello
+</div>
 `;
 
 exports[`enzyme shallow nested 1`] = `
@@ -553,9 +462,13 @@ exports[`enzyme shallow nested 1`] = `
 `;
 
 exports[`enzyme shallow nested displayName 1`] = `
+.emotion-0 {
+  color: hotpink;
+}
+
 <div>
   <CustomDisplayName
-    css="unknown styles"
+    className="emotion-0"
   />
 </div>
 `;
@@ -569,9 +482,13 @@ exports[`enzyme shallow nested styled 1`] = `
 `;
 
 exports[`enzyme shallow nested styled with css prop 1`] = `
+.emotion-0 {
+  background-color: black;
+}
+
 <div>
   <Button
-    css="unknown styles"
+    className="emotion-0"
   >
     iChenLei
   </Button>
@@ -583,14 +500,11 @@ exports[`enzyme shallow styled 1`] = `
   background-color: red;
 }
 
-<Fragment>
-  <Noop />
-  <div
-    className="emotion-0 emotion-1"
-  >
-    Hello
-  </div>
-</Fragment>
+<div
+  className="emotion-0 emotion-1"
+>
+  Hello
+</div>
 `;
 
 exports[`enzyme shallow styled with css prop 1`] = `
@@ -598,14 +512,11 @@ exports[`enzyme shallow styled with css prop 1`] = `
   background-color: black;
 }
 
-<Fragment>
-  <Noop />
-  <Button
-    className="emotion-0"
-  >
-    iChenLei
-  </Button>
-</Fragment>
+<Button
+  className="emotion-0"
+>
+  iChenLei
+</Button>
 `;
 
 exports[`enzyme shallow theming 1`] = `
@@ -645,20 +556,22 @@ exports[`enzyme shallow with array of styles as css prop 1`] = `
   color: white;
 }
 
-<Fragment>
-  <Noop />
-  <div
-    className="emotion-0"
-  >
-    Test content
-  </div>
-</Fragment>
+<div
+  className="emotion-0"
+>
+  Test content
+</div>
 `;
 
 exports[`enzyme shallow with array of styles in a composite inner child 1`] = `
+.emotion-0 {
+  background-color: black;
+  color: white;
+}
+
 <div>
   <Inner
-    css="unknown styles"
+    className="emotion-0"
   >
     Test content
   </Inner>
@@ -666,9 +579,13 @@ exports[`enzyme shallow with array of styles in a composite inner child 1`] = `
 `;
 
 exports[`enzyme shallow with prop containing css element 1`] = `
+.emotion-0 {
+  background-color: blue;
+}
+
 <div>
   <p
-    css="unknown styles"
+    className="emotion-0"
   >
     Hello
   </p>
@@ -695,6 +612,10 @@ exports[`enzyme shallow with prop containing css element not at the top level 1`
 `;
 
 exports[`enzyme shallow with prop containing css element with other label 1`] = `
+.emotion-0 {
+  background-color: blue;
+}
+
 <Thing
   content={
     <div
@@ -703,7 +624,7 @@ exports[`enzyme shallow with prop containing css element with other label 1`] = 
   }
 >
   <p
-    css="unknown styles"
+    className="emotion-0"
     id="something"
   >
     Hello
@@ -714,9 +635,13 @@ exports[`enzyme shallow with prop containing css element with other label 1`] = 
 `;
 
 exports[`enzyme shallow with prop containing css element with other props 1`] = `
+.emotion-0 {
+  background-color: blue;
+}
+
 <div>
   <p
-    css="unknown styles"
+    className="emotion-0"
     id="something"
   >
     Hello
@@ -737,14 +662,11 @@ exports[`enzyme shallow with styles on top level 1`] = `
   background-color: red;
 }
 
-<Fragment>
-  <Noop />
-  <Greeting
-    className="emotion-0"
-  >
-    Hello
-  </Greeting>
-</Fragment>
+<Greeting
+  className="emotion-0"
+>
+  Hello
+</Greeting>
 `;
 
 exports[`enzyme with prop containing css element in fragment 1`] = `

--- a/packages/jest/test/__snapshots__/react-enzyme.test.js.snap
+++ b/packages/jest/test/__snapshots__/react-enzyme.test.js.snap
@@ -7,9 +7,14 @@ exports[`enzyme mount basic 1`] = `
 
 <Greeting>
   <div
-    className="emotion-0"
+    css="unknown styles"
   >
-    hello
+    <Noop />
+    <div
+      className="emotion-0"
+    >
+      hello
+    </div>
   </div>
 </Greeting>
 `;
@@ -20,13 +25,14 @@ exports[`enzyme mount conditional styles 1`] = `
 }
 
 <div
-  className="emotion-0"
+  css="unknown styles"
 >
-  <span
-    className="emotion-1"
+  <Noop />
+  <div
+    className="emotion-0"
   >
-    Test content
-  </span>
+    <Noop />
+  </div>
 </div>
 `;
 
@@ -36,13 +42,18 @@ exports[`enzyme mount displayName 1`] = `
 }
 
 <CustomDisplayName
-  className="emotion-0"
+  css="unknown styles"
 >
-  <div
+  <Noop />
+  <CustomDisplayName
     className="emotion-0"
   >
-    Hello
-  </div>
+    <div
+      className="emotion-0"
+    >
+      Hello
+    </div>
+  </CustomDisplayName>
 </CustomDisplayName>
 `;
 
@@ -65,9 +76,14 @@ exports[`enzyme mount nested 1`] = `
 <div>
   <Greeting>
     <div
-      className="emotion-0"
+      css="unknown styles"
     >
-      hello
+      <Noop />
+      <div
+        className="emotion-0"
+      >
+        hello
+      </div>
     </div>
   </Greeting>
 </div>
@@ -80,13 +96,18 @@ exports[`enzyme mount nested displayName 1`] = `
 
 <div>
   <CustomDisplayName
-    className="emotion-0"
+    css="unknown styles"
   >
-    <div
+    <Noop />
+    <CustomDisplayName
       className="emotion-0"
     >
-      Hello
-    </div>
+      <div
+        className="emotion-0"
+      >
+        Hello
+      </div>
+    </CustomDisplayName>
   </CustomDisplayName>
 </div>
 `;
@@ -120,14 +141,19 @@ exports[`enzyme mount nested styled with css prop 1`] = `
 
 <div>
   <Button
-    className="emotion-0"
+    css="unknown styles"
   >
     <Noop />
-    <button
-      className="emotion-1 emotion-2"
+    <Button
+      className="emotion-0"
     >
-      iChenLei
-    </button>
+      <Noop />
+      <button
+        className="emotion-1 emotion-2"
+      >
+        iChenLei
+      </button>
+    </Button>
   </Button>
 </div>
 `;
@@ -158,14 +184,19 @@ exports[`enzyme mount styled with css prop 1`] = `
 }
 
 <Button
-  className="emotion-0"
+  css="unknown styles"
 >
   <Noop />
-  <button
-    className="emotion-1 emotion-2"
+  <Button
+    className="emotion-0"
   >
-    iChenLei
-  </button>
+    <Noop />
+    <button
+      className="emotion-1 emotion-2"
+    >
+      iChenLei
+    </button>
+  </Button>
 </Button>
 `;
 
@@ -222,9 +253,14 @@ exports[`enzyme mount with array of styles as css prop 1`] = `
 }
 
 <div
-  className="emotion-0"
+  css="unknown styles"
 >
-  Test content
+  <Noop />
+  <div
+    className="emotion-0"
+  >
+    Test content
+  </div>
 </div>
 `;
 
@@ -236,13 +272,18 @@ exports[`enzyme mount with array of styles in a composite inner child 1`] = `
 
 <div>
   <Inner
-    className="emotion-0"
+    css="unknown styles"
   >
-    <span
+    <Noop />
+    <Inner
       className="emotion-0"
     >
-      Test content
-    </span>
+      <span
+        className="emotion-0"
+      >
+        Test content
+      </span>
+    </Inner>
   </Inner>
 </div>
 `;
@@ -263,9 +304,14 @@ exports[`enzyme mount with prop containing css element 1`] = `
 >
   <div>
     <p
-      className="emotion-0"
+      css="unknown styles"
     >
-      Hello
+      <Noop />
+      <p
+        className="emotion-0"
+      >
+        Hello
+      </p>
     </p>
      
     World!
@@ -291,10 +337,16 @@ exports[`enzyme mount with prop containing css element not at the top level 1`] 
   >
     <div>
       <p
-        className="emotion-0"
+        css="unknown styles"
         id="something"
       >
-        Hello
+        <Noop />
+        <p
+          className="emotion-0"
+          id="something"
+        >
+          Hello
+        </p>
       </p>
        
       World!
@@ -326,10 +378,16 @@ exports[`enzyme mount with prop containing css element with other label 1`] = `
     }
   >
     <p
-      className="emotion-0"
+      css="unknown styles"
       id="something"
     >
-      Hello
+      <Noop />
+      <p
+        className="emotion-0"
+        id="something"
+      >
+        Hello
+      </p>
     </p>
      
     World!
@@ -354,10 +412,16 @@ exports[`enzyme mount with prop containing css element with other props 1`] = `
 >
   <div>
     <p
-      className="emotion-0"
+      css="unknown styles"
       id="something"
     >
-      Hello
+      <Noop />
+      <p
+        className="emotion-0"
+        id="something"
+      >
+        Hello
+      </p>
     </p>
      
     World!
@@ -385,13 +449,18 @@ exports[`enzyme mount with styles on top level 1`] = `
 }
 
 <Greeting
-  className="emotion-0"
+  css="unknown styles"
 >
-  <div
+  <Noop />
+  <Greeting
     className="emotion-0"
   >
-    Hello
-  </div>
+    <div
+      className="emotion-0"
+    >
+      Hello
+    </div>
+  </Greeting>
 </Greeting>
 `;
 
@@ -405,22 +474,28 @@ exports[`enzyme parent and child using css property 1`] = `
 }
 
 <div
-  className="emotion-0"
+  css="unknown styles"
 >
-  Test content
+  <Noop />
   <div
-    className="emotion-1"
-  />
+    className="emotion-0"
+  >
+    Test content
+    <div
+      css="unknown styles"
+    >
+      <Noop />
+      <div
+        className="emotion-1"
+      />
+    </div>
+  </div>
 </div>
 `;
 
 exports[`enzyme shallow basic 1`] = `
-.emotion-0 {
-  background-color: red;
-}
-
 <div
-  className="emotion-0"
+  css="unknown styles"
 >
   hello
 </div>
@@ -431,15 +506,18 @@ exports[`enzyme shallow conditional styles 1`] = `
   background-color: black;
 }
 
-<div
-  className="emotion-0"
->
-  <span
-    css="unknown styles"
+<Fragment>
+  <Noop />
+  <div
+    className="emotion-0"
   >
-    Test content
-  </span>
-</div>
+    <span
+      css="unknown styles"
+    >
+      Test content
+    </span>
+  </div>
+</Fragment>
 `;
 
 exports[`enzyme shallow displayName 1`] = `
@@ -447,9 +525,12 @@ exports[`enzyme shallow displayName 1`] = `
   color: hotpink;
 }
 
-<CustomDisplayName
-  className="emotion-0"
-/>
+<Fragment>
+  <Noop />
+  <CustomDisplayName
+    className="emotion-0"
+  />
+</Fragment>
 `;
 
 exports[`enzyme shallow empty styled 1`] = `
@@ -472,13 +553,9 @@ exports[`enzyme shallow nested 1`] = `
 `;
 
 exports[`enzyme shallow nested displayName 1`] = `
-.emotion-0 {
-  color: hotpink;
-}
-
 <div>
   <CustomDisplayName
-    className="emotion-0"
+    css="unknown styles"
   />
 </div>
 `;
@@ -492,13 +569,9 @@ exports[`enzyme shallow nested styled 1`] = `
 `;
 
 exports[`enzyme shallow nested styled with css prop 1`] = `
-.emotion-0 {
-  background-color: black;
-}
-
 <div>
   <Button
-    className="emotion-0"
+    css="unknown styles"
   >
     iChenLei
   </Button>
@@ -525,11 +598,14 @@ exports[`enzyme shallow styled with css prop 1`] = `
   background-color: black;
 }
 
-<Button
-  className="emotion-0"
->
-  iChenLei
-</Button>
+<Fragment>
+  <Noop />
+  <Button
+    className="emotion-0"
+  >
+    iChenLei
+  </Button>
+</Fragment>
 `;
 
 exports[`enzyme shallow theming 1`] = `
@@ -569,22 +645,20 @@ exports[`enzyme shallow with array of styles as css prop 1`] = `
   color: white;
 }
 
-<div
-  className="emotion-0"
->
-  Test content
-</div>
+<Fragment>
+  <Noop />
+  <div
+    className="emotion-0"
+  >
+    Test content
+  </div>
+</Fragment>
 `;
 
 exports[`enzyme shallow with array of styles in a composite inner child 1`] = `
-.emotion-0 {
-  background-color: black;
-  color: white;
-}
-
 <div>
   <Inner
-    className="emotion-0"
+    css="unknown styles"
   >
     Test content
   </Inner>
@@ -592,13 +666,9 @@ exports[`enzyme shallow with array of styles in a composite inner child 1`] = `
 `;
 
 exports[`enzyme shallow with prop containing css element 1`] = `
-.emotion-0 {
-  background-color: blue;
-}
-
 <div>
   <p
-    className="emotion-0"
+    css="unknown styles"
   >
     Hello
   </p>
@@ -625,10 +695,6 @@ exports[`enzyme shallow with prop containing css element not at the top level 1`
 `;
 
 exports[`enzyme shallow with prop containing css element with other label 1`] = `
-.emotion-0 {
-  background-color: blue;
-}
-
 <Thing
   content={
     <div
@@ -637,7 +703,7 @@ exports[`enzyme shallow with prop containing css element with other label 1`] = 
   }
 >
   <p
-    className="emotion-0"
+    css="unknown styles"
     id="something"
   >
     Hello
@@ -648,13 +714,9 @@ exports[`enzyme shallow with prop containing css element with other label 1`] = 
 `;
 
 exports[`enzyme shallow with prop containing css element with other props 1`] = `
-.emotion-0 {
-  background-color: blue;
-}
-
 <div>
   <p
-    className="emotion-0"
+    css="unknown styles"
     id="something"
   >
     Hello
@@ -675,11 +737,14 @@ exports[`enzyme shallow with styles on top level 1`] = `
   background-color: red;
 }
 
-<Greeting
-  className="emotion-0"
->
-  Hello
-</Greeting>
+<Fragment>
+  <Noop />
+  <Greeting
+    className="emotion-0"
+  >
+    Hello
+  </Greeting>
+</Fragment>
 `;
 
 exports[`enzyme with prop containing css element in fragment 1`] = `
@@ -689,10 +754,13 @@ exports[`enzyme with prop containing css element in fragment 1`] = `
 
 <div>
   x
-  <div
-    className="emotion-0"
-  >
-    y
-  </div>
+  Array [
+    "",
+    <div
+      className="emotion-0"
+    >
+      y
+    </div>,
+  ]
 </div>
 `;

--- a/packages/jest/test/__snapshots__/react-enzyme.test.js.snap
+++ b/packages/jest/test/__snapshots__/react-enzyme.test.js.snap
@@ -446,11 +446,13 @@ exports[`enzyme shallow displayName 1`] = `
 `;
 
 exports[`enzyme shallow empty styled 1`] = `
-<div
-  className="emotion-0 emotion-1"
->
-  Hello
-</div>
+<Fragment>
+  <div
+    className="emotion-0 emotion-1"
+  >
+    Hello
+  </div>
+</Fragment>
 `;
 
 exports[`enzyme shallow nested 1`] = `
@@ -500,11 +502,13 @@ exports[`enzyme shallow styled 1`] = `
   background-color: red;
 }
 
-<div
-  className="emotion-0 emotion-1"
->
-  Hello
-</div>
+<Fragment>
+  <div
+    className="emotion-0 emotion-1"
+  >
+    Hello
+  </div>
+</Fragment>
 `;
 
 exports[`enzyme shallow styled with css prop 1`] = `

--- a/packages/jest/test/__snapshots__/react-enzyme.test.js.snap
+++ b/packages/jest/test/__snapshots__/react-enzyme.test.js.snap
@@ -56,6 +56,67 @@ exports[`enzyme mount empty styled 1`] = `
 </Greeting>
 `;
 
+exports[`enzyme mount fragment with multiple css prop elements 1`] = `
+.emotion-0 {
+  background-color: hotpink;
+}
+
+.emotion-1 {
+  background-color: green;
+}
+
+.emotion-2 {
+  background-color: blue;
+}
+
+<Component>
+  <div
+    className="emotion-0"
+  />
+  <div
+    className="emotion-1"
+  />
+  <div
+    className="emotion-2"
+  />
+</Component>
+`;
+
+exports[`enzyme mount multiple selected components 1`] = `
+Array [
+  .emotion-0 {
+  background-color: hotpink;
+}
+
+<li
+    className="emotion-0"
+    data-item={true}
+  >
+    hello
+  </li>,
+  .emotion-0 {
+  background-color: blue;
+}
+
+<li
+    className="emotion-0"
+    data-item={true}
+  >
+    beautiful
+  </li>,
+  .emotion-0 {
+  background-color: green;
+}
+
+<li
+    className="emotion-0"
+    data-item={true}
+  >
+    world
+  </li>,
+]
+`;
+
 exports[`enzyme mount nested 1`] = `
 .emotion-0 {
   background-color: red;
@@ -126,6 +187,25 @@ exports[`enzyme mount nested styled with css prop 1`] = `
       iChenLei
     </button>
   </Button>
+</div>
+`;
+
+exports[`enzyme mount parent and child using css property 1`] = `
+.emotion-0 {
+  background-color: black;
+}
+
+.emotion-1 {
+  color: white;
+}
+
+<div
+  className="emotion-0"
+>
+  Test content
+  <div
+    className="emotion-1"
+  />
 </div>
 `;
 
@@ -207,6 +287,8 @@ exports[`enzyme mount theming 1`] = `
   </ThemeProvider>
 </div>
 `;
+
+exports[`enzyme mount unmatched selector 1`] = `null`;
 
 exports[`enzyme mount with array of styles as css prop 1`] = `
 .emotion-0 {
@@ -388,25 +470,6 @@ exports[`enzyme mount with styles on top level 1`] = `
 </Greeting>
 `;
 
-exports[`enzyme parent and child using css property 1`] = `
-.emotion-0 {
-  background-color: black;
-}
-
-.emotion-1 {
-  color: white;
-}
-
-<div
-  className="emotion-0"
->
-  Test content
-  <div
-    className="emotion-1"
-  />
-</div>
-`;
-
 exports[`enzyme shallow basic 1`] = `
 .emotion-0 {
   background-color: red;
@@ -453,6 +516,67 @@ exports[`enzyme shallow empty styled 1`] = `
 </div>
 `;
 
+exports[`enzyme shallow fragment with multiple css prop elements 1`] = `
+.emotion-0 {
+  background-color: hotpink;
+}
+
+.emotion-1 {
+  background-color: green;
+}
+
+.emotion-2 {
+  background-color: blue;
+}
+
+<Fragment>
+  <div
+    className="emotion-0"
+  />
+  <div
+    className="emotion-1"
+  />
+  <div
+    className="emotion-2"
+  />
+</Fragment>
+`;
+
+exports[`enzyme shallow multiple selected components 1`] = `
+Array [
+  .emotion-0 {
+  background-color: hotpink;
+}
+
+<li
+    className="emotion-0"
+    data-item={true}
+  >
+    hello
+  </li>,
+  .emotion-0 {
+  background-color: blue;
+}
+
+<li
+    className="emotion-0"
+    data-item={true}
+  >
+    beautiful
+  </li>,
+  .emotion-0 {
+  background-color: green;
+}
+
+<li
+    className="emotion-0"
+    data-item={true}
+  >
+    world
+  </li>,
+]
+`;
+
 exports[`enzyme shallow nested 1`] = `
 <div>
   <Greeting>
@@ -492,6 +616,25 @@ exports[`enzyme shallow nested styled with css prop 1`] = `
   >
     iChenLei
   </Button>
+</div>
+`;
+
+exports[`enzyme shallow parent and child using css property 1`] = `
+.emotion-0 {
+  background-color: black;
+}
+
+.emotion-1 {
+  color: white;
+}
+
+<div
+  className="emotion-0"
+>
+  Test content
+  <div
+    className="emotion-1"
+  />
 </div>
 `;
 
@@ -549,6 +692,8 @@ exports[`enzyme shallow theming 1`] = `
   </ThemeProvider>
 </div>
 `;
+
+exports[`enzyme shallow unmatched selector 1`] = `null`;
 
 exports[`enzyme shallow with array of styles as css prop 1`] = `
 .emotion-0 {

--- a/packages/react/__tests__/rehydration.js
+++ b/packages/react/__tests__/rehydration.js
@@ -657,7 +657,7 @@ describe('react18', () => {
     const finalHTML = disableBrowserEnvTemporarily(() => {
       resetAllModules()
 
-      function DivWithId({ className }) {
+      function DivWithId({ className }: { className?: string }) {
         const id = (React: any).useId()
         return <div id={id} className={className} />
       }
@@ -675,7 +675,7 @@ describe('react18', () => {
 
     resetAllModules()
 
-    function DivWithId({ className }) {
+    function DivWithId({ className }: { className?: string }) {
       const id = (React: any).useId()
       return <div id={id} className={className} />
     }

--- a/packages/react/__tests__/rehydration.js
+++ b/packages/react/__tests__/rehydration.js
@@ -20,6 +20,7 @@ let jsx
 let styled
 let CacheProvider
 let Global
+let ClassNames
 let createEmotionServer
 
 const resetAllModules = () => {
@@ -35,6 +36,7 @@ const resetAllModules = () => {
   jsx = emotionReact.jsx
   CacheProvider = emotionReact.CacheProvider
   Global = emotionReact.Global
+  ClassNames = emotionReact.ClassNames
   createEmotionServer = require('@emotion/server/create-instance').default
   styled = require('@emotion/styled').default
 }
@@ -618,7 +620,7 @@ describe('react18', () => {
     global.IS_REACT_ACT_ENVIRONMENT = previousIsReactActEnvironment
   })
 
-  test('no hydration mismatch when using useId', () => {
+  test('no hydration mismatch for styled when using useId', () => {
     const finalHTML = disableBrowserEnvTemporarily(() => {
       resetAllModules()
 
@@ -645,6 +647,102 @@ describe('react18', () => {
 
     ;(React: any).unstable_act(() => {
       ReactDOM.hydrateRoot(safeQuerySelector('#root'), <StyledDivWithId />)
+    })
+
+    expect((console.error: any).mock.calls).toMatchInlineSnapshot(`Array []`)
+    expect((console.warn: any).mock.calls).toMatchInlineSnapshot(`Array []`)
+  })
+
+  test('no hydration mismatch for css prop when using useId', () => {
+    const finalHTML = disableBrowserEnvTemporarily(() => {
+      resetAllModules()
+
+      function DivWithId({ className }) {
+        const id = (React: any).useId()
+        return <div id={id} className={className} />
+      }
+
+      return ReactDOMServer.renderToString(
+        <DivWithId
+          css={{
+            border: '1px solid black'
+          }}
+        />
+      )
+    })
+
+    safeQuerySelector('body').innerHTML = `<div id="root">${finalHTML}</div>`
+
+    resetAllModules()
+
+    function DivWithId({ className }) {
+      const id = (React: any).useId()
+      return <div id={id} className={className} />
+    }
+
+    ;(React: any).unstable_act(() => {
+      ReactDOM.hydrateRoot(
+        safeQuerySelector('#root'),
+        <DivWithId
+          css={{
+            border: '1px solid black'
+          }}
+        />
+      )
+    })
+
+    expect((console.error: any).mock.calls).toMatchInlineSnapshot(`Array []`)
+    expect((console.warn: any).mock.calls).toMatchInlineSnapshot(`Array []`)
+  })
+
+  test('no hydration mismatch for ClassNames when using useId', () => {
+    const finalHTML = disableBrowserEnvTemporarily(() => {
+      resetAllModules()
+
+      const DivWithId = ({ className }) => {
+        const id = (React: any).useId()
+        return <div id={id} className={className} />
+      }
+
+      return ReactDOMServer.renderToString(
+        <ClassNames>
+          {({ css }) => {
+            return (
+              <DivWithId
+                className={css({
+                  border: '1px solid black'
+                })}
+              />
+            )
+          }}
+        </ClassNames>
+      )
+    })
+
+    safeQuerySelector('body').innerHTML = `<div id="root">${finalHTML}</div>`
+
+    resetAllModules()
+
+    const DivWithId = ({ className }) => {
+      const id = (React: any).useId()
+      return <div id={id} className={className} />
+    }
+
+    ;(React: any).unstable_act(() => {
+      ReactDOM.hydrateRoot(
+        safeQuerySelector('#root'),
+        <ClassNames>
+          {({ css }) => {
+            return (
+              <DivWithId
+                className={css({
+                  border: '1px solid black'
+                })}
+              />
+            )
+          }}
+        </ClassNames>
+      )
     })
 
     expect((console.error: any).mock.calls).toMatchInlineSnapshot(`Array []`)

--- a/packages/react/__tests__/rehydration.js
+++ b/packages/react/__tests__/rehydration.js
@@ -65,6 +65,11 @@ const disableBrowserEnvTemporarily = <T>(fn: () => T): T => {
   }
 }
 
+beforeEach(() => {
+  safeQuerySelector('head').innerHTML = ''
+  safeQuerySelector('body').innerHTML = ''
+})
+
 test("cache created in render doesn't cause a hydration mismatch", () => {
   safeQuerySelector('body').innerHTML = [
     '<div id="root">',
@@ -481,7 +486,6 @@ test('duplicated global styles can be removed safely after rehydrating HTML SSRe
     }
   })
 
-  safeQuerySelector('head').innerHTML = ''
   safeQuerySelector('body').innerHTML = `<div id="root">${app}</div>`
 
   expect(safeQuerySelector('html')).toMatchInlineSnapshot(`

--- a/packages/react/__tests__/rehydration.js
+++ b/packages/react/__tests__/rehydration.js
@@ -647,20 +647,7 @@ describe('react18', () => {
       ReactDOM.hydrateRoot(safeQuerySelector('#root'), <StyledDivWithId />)
     })
 
-    expect((console.error: any).mock.calls).toMatchInlineSnapshot(`
-      Array [
-        Array [
-          "Warning: Prop \`%s\` did not match. Server: %s Client: %s%s",
-          "id",
-          "\\"R:2\\"",
-          "\\"R:0\\"",
-          "
-          at div
-          at className (/home/eps1lon/Development/forks/emotion/packages/react/__tests__/rehydration.js:639:57)
-          at Styled(DivWithId) (/home/eps1lon/Development/forks/emotion/packages/react/src/context.js:38:19)",
-        ],
-      ]
-    `)
+    expect((console.error: any).mock.calls).toMatchInlineSnapshot(`Array []`)
     expect((console.warn: any).mock.calls).toMatchInlineSnapshot(`Array []`)
   })
 })

--- a/packages/react/src/class-names.js
+++ b/packages/react/src/class-names.js
@@ -88,6 +88,8 @@ type Props = {
   }) => React.Node
 }
 
+const Noop = () => null
+
 export const ClassNames: React.AbstractComponent<Props> =
   /* #__PURE__ */ withEmotionCache((props, cache) => {
     let rules = ''
@@ -125,21 +127,25 @@ export const ClassNames: React.AbstractComponent<Props> =
     }
     let ele = props.children(content)
     hasRendered = true
+    let possiblyStyleElement = <Noop />
     if (!isBrowser && rules.length !== 0) {
-      return (
-        <>
-          <style
-            {...{
-              [`data-emotion`]: `${cache.key} ${serializedHashes.substring(1)}`,
-              dangerouslySetInnerHTML: { __html: rules },
-              nonce: cache.sheet.nonce
-            }}
-          />
-          {ele}
-        </>
+      possiblyStyleElement = (
+        <style
+          {...{
+            [`data-emotion`]: `${cache.key} ${serializedHashes.substring(1)}`,
+            dangerouslySetInnerHTML: { __html: rules },
+            nonce: cache.sheet.nonce
+          }}
+        />
       )
     }
-    return ele
+    // Need to return the same number of siblings or else `React.useId` will cause hydration mismatches.
+    return (
+      <>
+        {possiblyStyleElement}
+        {ele}
+      </>
+    )
   })
 
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/react/src/emotion-element.js
+++ b/packages/react/src/emotion-element.js
@@ -57,6 +57,8 @@ export const createEmotionProps = (type: React.ElementType, props: Object) => {
   return newProps
 }
 
+const Noop = () => null
+
 let Emotion = /* #__PURE__ */ withEmotionCache<any, any>(
   (props, cache, ref) => {
     let cssProp = props.css
@@ -121,6 +123,7 @@ let Emotion = /* #__PURE__ */ withEmotionCache<any, any>(
     newProps.className = className
 
     const ele = React.createElement(type, newProps)
+    let possiblyStyleElement = <Noop />
     if (!isBrowser && rules !== undefined) {
       let serializedNames = serialized.name
       let next = serialized.next
@@ -128,20 +131,23 @@ let Emotion = /* #__PURE__ */ withEmotionCache<any, any>(
         serializedNames += ' ' + next.name
         next = next.next
       }
-      return (
-        <>
-          <style
-            {...{
-              [`data-emotion`]: `${cache.key} ${serializedNames}`,
-              dangerouslySetInnerHTML: { __html: rules },
-              nonce: cache.sheet.nonce
-            }}
-          />
-          {ele}
-        </>
+      possiblyStyleElement = (
+        <style
+          {...{
+            [`data-emotion`]: `${cache.key} ${serializedNames}`,
+            dangerouslySetInnerHTML: { __html: rules },
+            nonce: cache.sheet.nonce
+          }}
+        />
       )
     }
-    return ele
+    // Need to return the same number of siblings or else `React.useId` will cause hydration mismatches.
+    return (
+      <>
+        {possiblyStyleElement}
+        {ele}
+      </>
+    )
   }
 )
 

--- a/packages/styled/src/base.js
+++ b/packages/styled/src/base.js
@@ -132,6 +132,7 @@ let createStyled: CreateStyled = (tag: any, options?: StyledOptions) => {
         newProps.ref = ref
 
         const ele = React.createElement(finalTag, newProps)
+        let possiblyStyleElement = <></>
         if (!isBrowser && rules !== undefined) {
           let serializedNames = serialized.name
           let next = serialized.next
@@ -139,20 +140,23 @@ let createStyled: CreateStyled = (tag: any, options?: StyledOptions) => {
             serializedNames += ' ' + next.name
             next = next.next
           }
-          return (
-            <>
-              <style
-                {...{
-                  [`data-emotion`]: `${cache.key} ${serializedNames}`,
-                  dangerouslySetInnerHTML: { __html: rules },
-                  nonce: cache.sheet.nonce
-                }}
-              />
-              {ele}
-            </>
+          possiblyStyleElement = (
+            <style
+              {...{
+                [`data-emotion`]: `${cache.key} ${serializedNames}`,
+                dangerouslySetInnerHTML: { __html: rules },
+                nonce: cache.sheet.nonce
+              }}
+            />
           )
         }
-        return ele
+        // Need to return the same number of siblings or else `React.useId` will cause hydration mismatches.
+        return (
+          <>
+            {possiblyStyleElement}
+            {ele}
+          </>
+        )
       }
     )
 

--- a/packages/styled/src/base.js
+++ b/packages/styled/src/base.js
@@ -18,6 +18,7 @@ You can read more about this here:
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#ES2018_revision_of_illegal_escape_sequences`
 
 let isBrowser = typeof document !== 'undefined'
+const Noop = () => null
 
 let createStyled: CreateStyled = (tag: any, options?: StyledOptions) => {
   if (process.env.NODE_ENV !== 'production') {
@@ -132,7 +133,7 @@ let createStyled: CreateStyled = (tag: any, options?: StyledOptions) => {
         newProps.ref = ref
 
         const ele = React.createElement(finalTag, newProps)
-        let possiblyStyleElement = <></>
+        let possiblyStyleElement = <Noop />
         if (!isBrowser && rules !== undefined) {
           let serializedNames = serialized.name
           let next = serialized.next

--- a/yarn.lock
+++ b/yarn.lock
@@ -23995,6 +23995,23 @@ react-timer-mixin@^0.13.4:
   resolved "https://registry.npmjs.org/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz#75a00c3c94c13abe29b43d63b4c65a88fc8264d3"
   integrity sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q==
 
+"react18-dom@npm:react-dom@alpha":
+  version "18.0.0-alpha-327d5c484-20211106"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.0.0-alpha-327d5c484-20211106.tgz#f8855d8e73876b5dbf6545ca02e14d8644a48008"
+  integrity sha512-yI2Kxy4/+nAFYHtC5uVIwXPURABwBhtqbEgjgRa9cITHsmZIO7AqDee0a5nXVSr8wWmtmbN1vSh29aDicuO03A==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    scheduler "0.21.0-alpha-327d5c484-20211106"
+
+"react18@npm:react@alpha":
+  version "18.0.0-alpha-327d5c484-20211106"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.0.0-alpha-327d5c484-20211106.tgz#f0e29b20b8c371697207a9f7b73a7ab625bee4b7"
+  integrity sha512-CB3JnXquQ9FYkd8IpTlvdpyk+HN1fOUDB7NabXTfbycqqRxuKhtijv7W7F/mbTzPLLMrxV5LwUqrLFc25Zy+UQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
 react@16.14.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
@@ -25335,6 +25352,14 @@ scheduler@0.19.1, scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
   integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@0.21.0-alpha-327d5c484-20211106:
+  version "0.21.0-alpha-327d5c484-20211106"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.21.0-alpha-327d5c484-20211106.tgz#16340fd4c7387ff58ad897b64715c0e3098e9489"
+  integrity sha512-VzlBG9d8m/2GwzXMjh7FoV6lpv/vOKdUYFCw3FCVY2aP/lN4oJkKwOlf4on2vEk855ckx+s3bR4eJLrlD7kZSw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes https://github.com/reactwg/react-18/discussions/111#discussioncomment-1581040
<!-- Why are these changes necessary? -->

**Why**:

If `React.useId` is used then emotion currently causes hydration mismatches

**How**:

Render same amount of siblings on client and server (`<style />` is replaced with `<React.Fragment />` on the client). 
Pattern is copied from https://github.com/vercel/next.js/pull/31102/files#diff-63632e6e580e69692941c89bab0a0e0436ade3f9543ef610925f795928d9d5fdR579-R612.
Fix is verified in https://codesandbox.io/s/friendly-bassi-6buos?file=/src/App.js:410-429

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- ~[ ]~ Documentation Don't think this needs documentation
- [x] Tests Unclear if you have a hydration test suite.
   Broken with `@emotion/styled@11.3.0`: https://codesandbox.io/s/sad-breeze-qznnl?file=/src/Sidebar.js
   Fixed with this PR: https://codesandbox.io/s/serene-platform-r4eyr?file=/src/Sidebar.js
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
