### PR TITLE
SSR Client Docs Incorrect

### DIFF
--- a/docs/ssr.mdx
+++ b/docs/ssr.mdx
@@ -120,7 +120,11 @@ res
 
 ```jsx
 // Hydration of the ids in `data-emotion-css` will automatically occur when the cache is created
-const cache = createCache()
+const cache = createCache({ 
+  // The key must match your corresponding cache name set earlier
+  key: 'custom'
+})
+
 ReactDOM.hydrate(
   <CacheProvider value={cache}>
     <App />


### PR DESCRIPTION
It looks like the client SSR documentation for the advanced setup was missing the key set for the cache. I've added this in so future users don't get stuck with a giant mystery error while following the guide (took me an hour to debug).

**What**:

Added missing documentation cache key for client side SSR.

**Why**:

The current example triggers a key not found error and breaks on the client-side.

**How**:

By using the current example

**Checklist**:

- [x] Documentation
- [ ] Tests N/A
- [ ] Code completeN/A
- [ ] Changeset N/A