### PR TITLE
feat(eslint-plugin): allow eslint v8

### DIFF
--- a/.changeset/serious-pianos-smoke.md
+++ b/.changeset/serious-pianos-smoke.md
@@ -2,4 +2,4 @@
 '@emotion/eslint-plugin': minor
 ---
 
-allow ESLint v8
+ESLint 8 has been added to the peer dependency range (ESLint 6 and ESLint 7 are still being supported).

--- a/.changeset/serious-pianos-smoke.md
+++ b/.changeset/serious-pianos-smoke.md
@@ -1,0 +1,5 @@
+---
+'@emotion/eslint-plugin': minor
+---
+
+allow ESLint v8

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "repository": "https://github.com/emotion-js/emotion/tree/main/packages/eslint-plugin",
   "peerDependencies": {
-    "eslint": "6 || 7"
+    "eslint": "6 || 7 || 8"
   },
   "devDependencies": {
     "eslint": "^7.10.0"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

Currently npm v7 will error due to the peer dependencies not matching.

**Why**:

<!-- How were these changes implemented? -->
I added ESLint v8 as an allowed version - I've not upgraded the codebase since that'd be significant more work and could involve breaking changes, but will attempt to do so later when I have the bandwidth (probably this weekend).

I've been using the plugin fine with v8 (by forcing the resolution), and the plugin itself is not doing anything super special so its pretty safe to allow v8.

**How**:

<!-- Have you done all of these things?  -->
Adding 8 to the range constraint in the peer dependencies section.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Code complete N/A
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
