### PR TITLE
feat(babel-plugin-jsx-pragmatic): migrate to typescript

### DIFF
--- a/.changeset/wet-boxes-raise.md
+++ b/.changeset/wet-boxes-raise.md
@@ -2,4 +2,4 @@
 '@emotion/babel-plugin-jsx-pragmatic': minor
 ---
 
-Convert to TypeScript. No breaking changes
+Source code has been migrated to TypeScript. From now on type declarations will be emitted based on that, instead of being hand-written.

--- a/.changeset/wet-boxes-raise.md
+++ b/.changeset/wet-boxes-raise.md
@@ -1,0 +1,5 @@
+---
+'@emotion/babel-plugin-jsx-pragmatic': minor
+---
+
+Convert to TypeScript. No breaking changes

--- a/packages/babel-plugin-jsx-pragmatic/babel__plugin-syntax-jsx.d.ts
+++ b/packages/babel-plugin-jsx-pragmatic/babel__plugin-syntax-jsx.d.ts
@@ -1,0 +1,4 @@
+declare module '@babel/plugin-syntax-jsx' {
+  const plugin: any
+  export default plugin
+}

--- a/packages/babel-plugin-jsx-pragmatic/package.json
+++ b/packages/babel-plugin-jsx-pragmatic/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@babel/core": "^7.13.10"
+    "@babel/core": "^7.13.10",
+    "@types/babel__core": "^7.1.16"
   }
 }

--- a/packages/babel-plugin-jsx-pragmatic/package.json
+++ b/packages/babel-plugin-jsx-pragmatic/package.json
@@ -24,6 +24,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.13.10",
-    "@types/babel__core": "^7.1.16"
+    "@types/babel__core": "^7.1.18"
   }
 }

--- a/packages/babel-plugin-jsx-pragmatic/src/index.ts
+++ b/packages/babel-plugin-jsx-pragmatic/src/index.ts
@@ -1,7 +1,7 @@
 import type {
   NodePath,
   PluginObj,
-  PluginPass as BabelPluginPass,
+  PluginPass,
   types as BabelTypes
 } from '@babel/core'
 import syntaxJsx from '@babel/plugin-syntax-jsx'
@@ -16,31 +16,22 @@ const findLast = <T>(arr: T[], predicate: (item: T) => boolean): T | null => {
   return null
 }
 
-// todo: PR these to @types/babel__core - PluginPass should extend Store
-// https://github.com/babel/babel/blob/4e50b2d9d9c376cee7a2cbf56553fe5b982ea53c/packages/babel-core/src/transformation/store.js
-interface BabelStore {
-  setDynamic(key: string, fn: () => unknown): void
-  set(key: string, val: unknown): void
-  get(key: string): unknown
-}
-
-type PluginPass = BabelPluginPass &
-  BabelStore & {
-    opts: {
-      module: string
-      import: string
-      export?: string
-    }
+interface PluginPassWithOpts extends PluginPass {
+  opts: {
+    module: string
+    import: string
+    export?: string
   }
+}
 
 export default function jsxPragmatic(babel: {
   types: typeof BabelTypes
-}): PluginObj<PluginPass> {
+}): PluginObj<PluginPassWithOpts> {
   const t = babel.types
 
   function addPragmaImport(
     path: NodePath<BabelTypes.Program>,
-    state: PluginPass
+    state: PluginPassWithOpts
   ) {
     const importDeclar = t.importDeclaration(
       [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5594,6 +5594,17 @@
     "@types/babel__template" "*"
     "@types/babel__traverse" "*"
 
+"@types/babel__core@^7.1.16":
+  version "7.1.16"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.16.tgz#bc12c74b7d65e82d29876b5d0baf5c625ac58702"
+  integrity sha512-EAEHtisTMM+KaKwfWdC3oyllIqswlznXCIVCt7/oRNrh+DhgT4UEBNC/jlADNjvw7UnfbcdkGQcPVZ1xYiLcrQ==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
 "@types/babel__generator@*":
   version "7.6.2"
   resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.6.2.tgz#f3d71178e187858f7c45e30380f8f1b7415a12d8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5594,10 +5594,10 @@
     "@types/babel__template" "*"
     "@types/babel__traverse" "*"
 
-"@types/babel__core@^7.1.16":
-  version "7.1.16"
-  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.16.tgz#bc12c74b7d65e82d29876b5d0baf5c625ac58702"
-  integrity sha512-EAEHtisTMM+KaKwfWdC3oyllIqswlznXCIVCt7/oRNrh+DhgT4UEBNC/jlADNjvw7UnfbcdkGQcPVZ1xYiLcrQ==
+"@types/babel__core@^7.1.18":
+  version "7.1.18"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.18.tgz#1a29abcc411a9c05e2094c98f9a1b7da6cdf49f8"
+  integrity sha512-S7unDjm/C7z2A2R9NzfKCK1I+BAALDtxEmsJBwlB3EzNfb929ykjL++1CK9LO++EIp2fQrC8O+BwjKvz6UeDyQ==
   dependencies:
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

Migrates `@emotion/babel-plugin-jsx-pragmatic` to TypeScript.

**Why**:

<!-- How were these changes implemented? -->

Part of #2358

**How**:

<!-- Have you done all of these things?  -->

Renamed the js file to ts, and made changes to make TS happy.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [ ] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->

I've not converted the tests because I don't know how to handle `babel-tester` since it's apparently coming in as some magical workspace thing (I've not worked with workspaces a lot 😅).

I'm sure there will be a way to tell TypeScript that it exists, but that probably will need either a type definition written or the package converted to TypeScript, so have left it for now.

I'll be making a few follow-up PRs to DefinitelyTyped that'll remove the need for some of the types, but they probably won't land for at least a month.