### PR TITLE
fix(serialize): registered parameter of serializeStyles should be optional

### DIFF
--- a/.changeset/friendly-carrots-buy.md
+++ b/.changeset/friendly-carrots-buy.md
@@ -1,0 +1,5 @@
+---
+"@emotion/serialize": patch
+---
+
+Changed the `registered` paramater to be declared as optional in the TypeScript definition to match the runtime requirement.

--- a/.changeset/friendly-carrots-buy.md
+++ b/.changeset/friendly-carrots-buy.md
@@ -2,4 +2,4 @@
 "@emotion/serialize": patch
 ---
 
-Changed the `registered` paramater to be declared as optional in the TypeScript definition to match the runtime requirement.
+Changed the `registered` parameter to be declared as optional in the TypeScript definition to match the runtime requirement.

--- a/packages/serialize/types/index.d.ts
+++ b/packages/serialize/types/index.d.ts
@@ -64,6 +64,6 @@ export type Interpolation<Props> =
 
 export function serializeStyles<Props>(
   args: Array<TemplateStringsArray | Interpolation<Props>>,
-  registered: RegisteredCache,
+  registered?: RegisteredCache,
   props?: Props
 ): SerializedStyles


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

According to [its implementation](https://github.com/emotion-js/emotion/blob/26ded6109fcd8ca9875cc2ce4564fee678a3f3c5/packages/serialize/src/index.js#L311) and [how css function uses it](https://github.com/emotion-js/emotion/blob/26ded6109fcd8ca9875cc2ce4564fee678a3f3c5/packages/react/src/css.js#L7), the `registered` paramter of `serializeStyles` should be optional

**Why**:

To implement a custom `css` function working with frameworks other than react, current type is generating type erorrs like:

```
Expected 2-3 arguments, but got 1.ts(2554)
index.d.ts(67, 3): An argument for 'registered' was not provided.
(alias) serializeStyles<P>(args: (TemplateStringsArray | Interpolation<P>)[], registered: RegisteredCache, props?: P | undefined): SerializedStyles
import serializeStyles
```

<!-- How were these changes implemented? -->

**How**:

I added a single optional placeholder to this parameter, so that custom bindings like emotion-to-solid.js can work strong typed.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
