### PR TITLE
Export Keyframes type from @emotion/core

### DIFF
--- a/.changeset/quiet-impalas-speak.md
+++ b/.changeset/quiet-impalas-speak.md
@@ -1,5 +1,5 @@
 ---
-"@emotion/core": patch
+"@emotion/core": minor
 ---
 
 Export Keyframes type from @emotion/core

--- a/.changeset/quiet-impalas-speak.md
+++ b/.changeset/quiet-impalas-speak.md
@@ -2,4 +2,4 @@
 "@emotion/core": patch
 ---
 
-Export keyframes type from @emotion/core
+Export Keyframes type from @emotion/core

--- a/.changeset/quiet-impalas-speak.md
+++ b/.changeset/quiet-impalas-speak.md
@@ -1,5 +1,5 @@
 ---
-"@emotion/core": minor
+"@emotion/core": patch
 ---
 
-Export Keyframes type from @emotion/core
+Export `Keyframes` type to avoid TypeScript inserting `import("@emotion/serialize").Keyframes` references into declaration files emitted based on a source files exporting `keyframes` result. This avoids issues with strict package managers that don't allow accessing undeclared dependencies.

--- a/.changeset/quiet-impalas-speak.md
+++ b/.changeset/quiet-impalas-speak.md
@@ -1,0 +1,5 @@
+---
+"@emotion/core": patch
+---
+
+Export keyframes type from @emotion/core

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -24,7 +24,7 @@ export {
   ObjectInterpolation
 } from '@emotion/css'
 
-export { EmotionCache, Interpolation, SerializedStyles, css }
+export { EmotionCache, Interpolation, Keyframes, SerializedStyles, css }
 
 export const ThemeContext: Context<object>
 export const CacheProvider: Provider<EmotionCache>


### PR DESCRIPTION
**What**:

Export `Keyframes` type from @emotion/core for v10.

**Why**:

In order to reference `Keyframes` without having to add a dependency to `@emotion/serialize`. See https://github.com/storybookjs/storybook/pull/16905 for more context.

**How**:

N/A

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Code complete N/A
- [x] Changeset