### PR TITLE
Export Keyframes type from @emotion/react

### DIFF
--- a/.changeset/old-chefs-repeat.md
+++ b/.changeset/old-chefs-repeat.md
@@ -1,5 +1,5 @@
 ---
-"@emotion/react": patch
+"@emotion/react": minor
 ---
 
 Export Keyframes type from @emotion/core

--- a/.changeset/old-chefs-repeat.md
+++ b/.changeset/old-chefs-repeat.md
@@ -1,5 +1,5 @@
 ---
-"@emotion/react": minor
+"@emotion/react": patch
 ---
 
-Export Keyframes type from @emotion/react
+Export `Keyframes` type to avoid TypeScript inserting `import("@emotion/serialize").Keyframes` references into declaration files emitted based on a source files exporting `keyframes` result. This avoids issues with strict package managers that don't allow accessing undeclared dependencies.

--- a/.changeset/old-chefs-repeat.md
+++ b/.changeset/old-chefs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@emotion/react": patch
+---
+
+Export Keyframes type from @emotion/core

--- a/.changeset/old-chefs-repeat.md
+++ b/.changeset/old-chefs-repeat.md
@@ -2,4 +2,4 @@
 "@emotion/react": minor
 ---
 
-Export Keyframes type from @emotion/core
+Export Keyframes type from @emotion/react

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -31,6 +31,7 @@ export {
   EmotionCache,
   FunctionInterpolation,
   Interpolation,
+  Keyframes,
   SerializedStyles
 }
 


### PR DESCRIPTION
**What**:

Export `Keyframes` type from @emotion/core for v10.

**Why**:

In order to reference `Keyframes` without having to add a dependency to `@emotion/serialize`. See https://github.com/storybookjs/storybook/pull/16905 for more context.

**How**:

N/A

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Code complete N/A
- [x] Changeset