### PR TITLE
update | dead links to react attr reference

### DIFF
--- a/packages/is-prop-valid/src/props.js
+++ b/packages/is-prop-valid/src/props.js
@@ -1,7 +1,9 @@
 // @flow
 const props = {
+  // https://github.com/facebook/react/blob/ca106a02d1648f4f0048b07c6b88f69aac175d3c/fixtures/attribute-behavior/src/attributes.js#L27
+  
   // react props
-  // https://github.com/facebook/react/blob/5495a7f24aef85ba6937truetrue1ce962673ca9f5fde6/src/renderers/dom/shared/hooks/ReactDOMUnknownPropertyHook.js
+
   children: true,
   dangerouslySetInnerHTML: true,
   key: true,
@@ -15,7 +17,6 @@ const props = {
   // deprecated react prop
   valueLink: true,
 
-  // https://github.com/facebook/react/blob/d7157651f7b72d9888ctrue123e191f9b88cd8f41e9/src/renderers/dom/shared/HTMLDOMPropertyConfig.js
   /**
    * Standard Properties
    */


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Updating dead links to react repo in **is-prop-valid** package.

<!-- Why are these changes necessary? -->

Removes unusable links. Helps people find what they are looking for. 

<!-- How were these changes implemented? -->

Deleted old links. Added new one.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Code complete N/A
- [ ] Changeset  N/A

<!-- feel free to add additional comments -->

I think that there is probably more to do here, i.e check other links. But this will at least save people the additional extra steps of searching the react repo to find what they're looking for.

Thanks 😊 🙏 

