### PR TITLE
Improve shouldForwardProp example

### DIFF
--- a/docs/styled.mdx
+++ b/docs/styled.mdx
@@ -170,7 +170,7 @@ const H1 = styled('h1', {
   shouldForwardProp: prop =>
     isPropValid(prop) && prop !== 'color'
 })(props => ({
-  color: 'hotpink'
+  color: props.color
 }))
 
 render(<H1 color="lightgreen">This is lightgreen.</H1>)


### PR DESCRIPTION
**What**: 
I changed the example of `shouldForwardProp` in the [Customizing prop forwarding](https://emotion.sh/docs/styled#customizing-prop-forwarding) section.

**Why**:
The `H1` component gets the color props `lightgreen` but the static props `hotpink` is used in the styled tag
which results in an inconsistency between the actual color of the text and the color that the text says.

**How**:
I changed the static props `hotpink` to `props.color`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [X] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A
- [ ] Changeset N/A

