### PR TITLE
Added `@emotion/babel-plugin` as a dependency of `@emotion/react`

### DIFF
--- a/.changeset/perfect-cameras-greet.md
+++ b/.changeset/perfect-cameras-greet.md
@@ -1,0 +1,5 @@
+---
+'@emotion/react': patch
+---
+
+Added `@emotion/babel-plugin` as a dependency - this is an actual dependency of the `@emotion/react/macro` entrypoint and it has to be explicitly declared to fix compatibility with strict package managers.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
+    "@emotion/babel-plugin": "^11.7.1",
     "@emotion/cache": "^11.7.1",
     "@emotion/serialize": "^1.0.2",
     "@emotion/sheet": "^1.1.0",


### PR DESCRIPTION
This is using the same strategy (declaring dep and not a peer dep) as `@emotion/css`:
https://github.com/emotion-js/emotion/blob/4efa2cb3f45456bc793fb7b7f4d2382d9742cc35/packages/css/package.json#L21
and `@emotion/styled`:
https://github.com/emotion-js/emotion/blob/4efa2cb3f45456bc793fb7b7f4d2382d9742cc35/packages/styled/package.json#L15