### PR TITLE
Fixed a transpilation issue that caused `useInsertionEffect` to be referenced directly in the specifiers list of the import statement

### DIFF
--- a/.changeset/dull-trees-crash.md
+++ b/.changeset/dull-trees-crash.md
@@ -1,0 +1,6 @@
+---
+'@emotion/react': patch
+'@emotion/styled': patch
+---
+
+Fixed a transpilation issue that caused `useInsertionEffect` to be referenced directly in the specifiers list of the import statement. This has caused build errors in the consuming tools since the import statement can only reference known exports of a module.

--- a/packages/react/src/global.js
+++ b/packages/react/src/global.js
@@ -14,8 +14,8 @@ type GlobalProps = {
   +styles: Styles | (Object => Styles)
 }
 
-const useInsertionEffect = (React: any).useInsertionEffect
-  ? (React: any).useInsertionEffect
+const useInsertionEffect = React['useInsertion' + 'Effect']
+  ? React['useInsertion' + 'Effect']
   : React.useLayoutEffect
 
 let warnedAboutCssPropForGlobal = false

--- a/packages/react/src/useInsertionEffectMaybe.js
+++ b/packages/react/src/useInsertionEffectMaybe.js
@@ -1,9 +1,9 @@
-import React from 'react'
+import * as React from 'react'
 
 const isBrowser = typeof document !== 'undefined'
 
-const useInsertionEffect = React.useInsertionEffect
-  ? React.useInsertionEffect
+const useInsertionEffect = React['useInsertion' + 'Effect']
+  ? React['useInsertion' + 'Effect']
   : function useInsertionEffect(create) {
       create()
     }

--- a/packages/styled/src/useInsertionEffectMaybe.js
+++ b/packages/styled/src/useInsertionEffectMaybe.js
@@ -1,9 +1,9 @@
-import React from 'react'
+import * as React from 'react'
 
 const isBrowser = typeof document !== 'undefined'
 
-const useInsertionEffect = React.useInsertionEffect
-  ? React.useInsertionEffect
+const useInsertionEffect = React['useInsertion' + 'Effect']
+  ? React['useInsertion' + 'Effect']
   : function useInsertionEffect(create) {
       create()
     }


### PR DESCRIPTION
fixes https://github.com/emotion-js/emotion/issues/2649