### PR TITLE
docs: fix cache-provider demo rendering

### DIFF
--- a/site/src/components/Playground.js
+++ b/site/src/components/Playground.js
@@ -31,6 +31,8 @@ export const scope = {
         return require('@emotion/is-prop-valid')
       case 'facepaint':
         return require('facepaint')
+      case 'stylis':
+        return require('stylis')
       default:
         // eslint-disable-next-line no-throw-literal
         throw `Module "${moduleName}" not found`


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
The demo playground in https://emotion.sh/docs/cache-provider is not rendered properly. 

<!-- Why are these changes necessary? -->

**Why**:
The playground (react-live) requires the demo to include `stylis` as the dependency.

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
