### PR TITLE
[@emotion/jest] Pass through `includeStyles` option in `createEnzymeSerializer`

### DIFF
--- a/.changeset/hot-seals-promise.md
+++ b/.changeset/hot-seals-promise.md
@@ -1,0 +1,5 @@
+---
+'@emotion/jest': patch
+---
+
+Fixed `createEnzymeSerializer` missing the `includeStyles` option

--- a/.changeset/hot-seals-promise.md
+++ b/.changeset/hot-seals-promise.md
@@ -2,4 +2,4 @@
 '@emotion/jest': patch
 ---
 
-Fixed `createEnzymeSerializer` missing the `includeStyles` option
+Fixed an issue with `createEnzymeSerializer` not handling the recently added `includeStyles` option.

--- a/packages/jest/src/create-enzyme-serializer.js
+++ b/packages/jest/src/create-enzyme-serializer.js
@@ -66,11 +66,13 @@ const wrappedEnzymeSerializer = {
 
 export function createEnzymeSerializer({
   classNameReplacer,
-  DOMElements = true
+  DOMElements = true,
+  includeStyles = true
 }: Options = {}) {
   const emotionSerializer = createEmotionSerializer({
     classNameReplacer,
-    DOMElements
+    DOMElements,
+    includeStyles
   })
   return {
     test(node: *) {


### PR DESCRIPTION
**What**: Add the missing `includeStyles` option to `createEnzymeSerializer`

**Why**: The option was added to `createSerializer` in #2709, but was not added to `createEnzymeSerializer`

**How**: The option is accepted and passed through to `createEmotionSerializer`


- [ ] Documentation N/A
- [ ] Tests  N/A
- [x] Code complete
- [x] Changeset
