### PR TITLE
Update "no component selectors" error message

### DIFF
--- a/.changeset/big-years-relate.md
+++ b/.changeset/big-years-relate.md
@@ -1,0 +1,5 @@
+---
+'@emotion/serialize': patch
+---
+
+Changed the error message "Component selectors can only be used in conjunction with @emotion/babel-plugin" to reference the new swc Emotion plugin which will support component selectors soon.

--- a/.changeset/big-years-relate.md
+++ b/.changeset/big-years-relate.md
@@ -2,4 +2,4 @@
 '@emotion/serialize': patch
 ---
 
-Changed the error message "Component selectors can only be used in conjunction with @emotion/babel-plugin" to reference the new swc Emotion plugin which will support component selectors soon.
+Changed the error message "Component selectors can only be used in conjunction with @emotion/babel-plugin" to reference the new SWC Emotion plugin which will support component selectors soon.

--- a/packages/css/test/no-babel/__snapshots__/index.test.js.snap
+++ b/packages/css/test/no-babel/__snapshots__/index.test.js.snap
@@ -12,11 +12,11 @@ exports[`css @supports 1`] = `
 />
 `;
 
-exports[`css component as selectors (object syntax) 1`] = `"Component selectors can only be used in conjunction with @emotion/babel-plugin."`;
+exports[`css component as selectors (object syntax) 1`] = `"Component selectors can only be used in conjunction with @emotion/babel-plugin, the swc Emotion plugin, or another Emotion-aware compiler transform."`;
 
 exports[`css component as selectors (object syntax) 2`] = `"The above error occurred in the <Styled(div)> component:"`;
 
-exports[`css component selectors without target 1`] = `"Component selectors can only be used in conjunction with @emotion/babel-plugin."`;
+exports[`css component selectors without target 1`] = `"Component selectors can only be used in conjunction with @emotion/babel-plugin, the swc Emotion plugin, or another Emotion-aware compiler transform."`;
 
 exports[`css composition 1`] = `
 .emotion-0 {

--- a/packages/serialize/src/index.js
+++ b/packages/serialize/src/index.js
@@ -106,6 +106,11 @@ if (process.env.NODE_ENV !== 'production') {
   }
 }
 
+const noComponentSelectorMessage =
+  'Component selectors can only be used in conjunction with ' +
+  '@emotion/babel-plugin, the swc Emotion plugin, or another Emotion-aware ' +
+  'compiler transform.'
+
 function handleInterpolation(
   mergedProps: void | Object,
   registered: RegisteredCache | void,
@@ -119,9 +124,7 @@ function handleInterpolation(
       process.env.NODE_ENV !== 'production' &&
       interpolation.toString() === 'NO_COMPONENT_SELECTOR'
     ) {
-      throw new Error(
-        'Component selectors can only be used in conjunction with @emotion/babel-plugin.'
-      )
+      throw new Error(noComponentSelectorMessage)
     }
     return interpolation
   }
@@ -247,9 +250,7 @@ function createStringFromObject(
           key === 'NO_COMPONENT_SELECTOR' &&
           process.env.NODE_ENV !== 'production'
         ) {
-          throw new Error(
-            'Component selectors can only be used in conjunction with @emotion/babel-plugin.'
-          )
+          throw new Error(noComponentSelectorMessage)
         }
         if (
           Array.isArray(value) &&


### PR DESCRIPTION
Closes #2705. To be clear, #2705 is a Next/swc issue, not an Emotion issue. I am just improving the error message so that people using the swc Emotion transform don't think they HAVE to use Babel.