### PR TITLE
Preconstruct upgrade: Document the need for Windows Developer Mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@
   - This step can be removed from this document if we upgrade to the latest
     version of Gatsby, which is compatible with sharp 0.28.0+ which does include
     binaries for M1 Macs.
+- (If using Windows) Enable Developer Mode in the Windows settings app. On Windows 11, this can be done by searching the start menu for "Developer settings" and then enabling the Developer Mode toggle switch.
 - Run `yarn` in the repository's root directory to install everything you need for development.
 - Run `yarn build` in the root directory to build the modules.
 


### PR DESCRIPTION
This is necessary per Mitchell: https://github.com/preconstruct/preconstruct/issues/381#issuecomment-793134511

I created a Preconstruct issue about adding this step to the Preconstruct docs: https://github.com/preconstruct/preconstruct/issues/455