### PR TITLE
Add fetchpriority prop

### DIFF
--- a/packages/is-prop-valid/src/props.js
+++ b/packages/is-prop-valid/src/props.js
@@ -293,6 +293,7 @@ const props = {
   end: true,
   exponent: true,
   externalResourcesRequired: true,
+  fetchPriority: true,
   fill: true,
   fillOpacity: true,
   fillRule: true,


### PR DESCRIPTION
**What**:

Adding the currently still non-standard `fetchpriority` prop.

**Why**:

Priority hints are currently an unoffical W3C draft driven by Google (https://wicg.github.io/priority-hints/) but already supported in some Chromium-based browsers (https://caniuse.com/?search=fetchpriority). See also this article: https://web.dev/priority-hints/.

**How**:

Simply added the prop to `packages/is-prop-valid/src/props.js`, for now under the "Non-standard Properties".

**Checklist**:

- [N/A] Documentation
- [N/A] Tests
- [X] Code complete
- [N/A] Changeset

