### PR TITLE
`ts-migration`: Make `registered` optional in `serializeStyles`

### DIFF
--- a/packages/serialize/src/index.ts
+++ b/packages/serialize/src/index.ts
@@ -385,12 +385,12 @@ let cursor: Cursor | undefined
 
 export function serializeStyles<Props>(
   args: Array<TemplateStringsArray | Interpolation<Props>>,
-  registered: RegisteredCache,
+  registered?: RegisteredCache,
   mergedProps?: Props
 ): SerializedStyles
 export function serializeStyles(
   args: Array<TemplateStringsArray | Interpolation<unknown>>,
-  registered: RegisteredCache,
+  registered?: RegisteredCache,
   mergedProps?: unknown
 ): SerializedStyles {
   if (


### PR DESCRIPTION
Closes #2756.