### PR TITLE
`styled.shouldForwardProp`: require prop to be a string

### DIFF
--- a/.changeset/good-cars-roll.md
+++ b/.changeset/good-cars-roll.md
@@ -1,0 +1,6 @@
+---
+'@emotion/native': patch
+'@emotion/styled': patch
+---
+
+Change the argument of the `shouldForwardProp` option of `styled` from `PropertyKey` to `string` in the TypeScript definitions.

--- a/.changeset/purple-ladybugs-think.md
+++ b/.changeset/purple-ladybugs-think.md
@@ -1,0 +1,5 @@
+---
+'@emotion/is-prop-valid': patch
+---
+
+Change the type of the argument to `isPropValid` from `PropertyKey` to `string` in the TypeScript definitions.

--- a/packages/is-prop-valid/types/index.d.ts
+++ b/packages/is-prop-valid/types/index.d.ts
@@ -1,5 +1,5 @@
 // Definitions by: Junyoung Clare Jang <https://github.com/Ailrun>
 // TypeScript Version: 2.1
 
-declare function isPropValid(string: PropertyKey): boolean
+declare function isPropValid(prop: string): boolean
 export default isPropValid

--- a/packages/native/types/base.d.ts
+++ b/packages/native/types/base.d.ts
@@ -61,13 +61,13 @@ export type Interpolation<
 /** Same as StyledOptions but shouldForwardProp must be a type guard */
 export interface FilteringStyledOptions<
   Props,
-  ForwardedProps extends keyof Props = keyof Props
+  ForwardedProps extends keyof Props & string = keyof Props & string
 > {
-  shouldForwardProp?(propName: PropertyKey): propName is ForwardedProps
+  shouldForwardProp?(propName: string): propName is ForwardedProps
 }
 
 export interface StyledOptions<Props> {
-  shouldForwardProp?(propName: PropertyKey): boolean
+  shouldForwardProp?(propName: string): boolean
 }
 
 /**
@@ -146,7 +146,8 @@ export interface CreateStyledComponent<
 export interface CreateStyled {
   <
     C extends React.ComponentClass<React.ComponentProps<C>>,
-    ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>
+    ForwardedProps extends keyof React.ComponentProps<C> &
+      string = keyof React.ComponentProps<C> & string
   >(
     component: C,
     options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps>
@@ -175,7 +176,8 @@ export interface CreateStyled {
 
   <
     C extends React.ComponentType<React.ComponentProps<C>>,
-    ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>
+    ForwardedProps extends keyof React.ComponentProps<C> &
+      string = keyof React.ComponentProps<C> & string
   >(
     component: C,
     options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps>

--- a/packages/styled/types/base.d.ts
+++ b/packages/styled/types/base.d.ts
@@ -16,16 +16,16 @@ export { ComponentSelector, Interpolation }
 /** Same as StyledOptions but shouldForwardProp must be a type guard */
 export interface FilteringStyledOptions<
   Props,
-  ForwardedProps extends keyof Props = keyof Props
+  ForwardedProps extends keyof Props & string = keyof Props & string
 > {
   label?: string
-  shouldForwardProp?(propName: PropertyKey): propName is ForwardedProps
+  shouldForwardProp?(propName: string): propName is ForwardedProps
   target?: string
 }
 
 export interface StyledOptions<Props> {
   label?: string
-  shouldForwardProp?(propName: PropertyKey): boolean
+  shouldForwardProp?(propName: string): boolean
   target?: string
 }
 
@@ -118,7 +118,8 @@ export interface CreateStyledComponent<
 export interface CreateStyled {
   <
     C extends React.ComponentClass<React.ComponentProps<C>>,
-    ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>
+    ForwardedProps extends keyof React.ComponentProps<C> &
+      string = keyof React.ComponentProps<C> & string
   >(
     component: C,
     options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps>
@@ -147,7 +148,8 @@ export interface CreateStyled {
 
   <
     C extends React.ComponentType<React.ComponentProps<C>>,
-    ForwardedProps extends keyof React.ComponentProps<C> = keyof React.ComponentProps<C>
+    ForwardedProps extends keyof React.ComponentProps<C> &
+      string = keyof React.ComponentProps<C> & string
   >(
     component: C,
     options: FilteringStyledOptions<React.ComponentProps<C>, ForwardedProps>
@@ -168,7 +170,8 @@ export interface CreateStyled {
 
   <
     Tag extends keyof JSX.IntrinsicElements,
-    ForwardedProps extends keyof JSX.IntrinsicElements[Tag] = keyof JSX.IntrinsicElements[Tag]
+    ForwardedProps extends keyof JSX.IntrinsicElements[Tag] &
+      string = keyof JSX.IntrinsicElements[Tag] & string
   >(
     tag: Tag,
     options: FilteringStyledOptions<JSX.IntrinsicElements[Tag], ForwardedProps>


### PR DESCRIPTION
This change was originally made [here](https://github.com/emotion-js/emotion/pull/2732/commits/a485db3ca57c03642986f879ddcf3814c9c1fc5e). Andarist and I discussed moving the change out of that PR and making the change in `main` rather than `ts-migration`.

The rationale behind the change is that we expect non-string props to be exceedingly rare / virtually non-existent.