### PR TITLE
`ts-migration`: Put TS hacks in `@emotion/eslint-plugin` to make Preconstruct not error

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -22,7 +22,7 @@
     "eslint": "6 || 7 || 8"
   },
   "dependencies": {
-    "@typescript-eslint/experimental-utils": "^4.30.0"
+    "@typescript-eslint/utils": "^5.25.0"
   },
   "devDependencies": {
     "@types/eslint": "^7.0.0",

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -5,7 +5,7 @@ import styledImport from './rules/styled-import'
 import jsxImport from './rules/jsx-import'
 import pkgRenaming from './rules/pkg-renaming'
 
-export let rules = {
+export const rules = {
   'import-from-emotion': importFromEmotion,
   'no-vanilla': noVanilla,
   'syntax-preference': syntaxPreference,

--- a/packages/eslint-plugin/src/rules/import-from-emotion.ts
+++ b/packages/eslint-plugin/src/rules/import-from-emotion.ts
@@ -1,5 +1,5 @@
 import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/experimental-utils'
-import { createRule } from '../utils'
+import { createRule, EmotionESLintRule } from '../utils'
 
 export default createRule({
   name: __filename,
@@ -65,4 +65,4 @@ export default createRule({
       }
     }
   }
-})
+}) as EmotionESLintRule

--- a/packages/eslint-plugin/src/rules/import-from-emotion.ts
+++ b/packages/eslint-plugin/src/rules/import-from-emotion.ts
@@ -1,18 +1,19 @@
-import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/experimental-utils'
-import { createRule, EmotionESLintRule } from '../utils'
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils'
+import { createRule } from '../utils'
 
-export default createRule({
+const messages = {
+  incorrectImport: `emotion's exports should be imported directly from emotion rather than from react-emotion`
+}
+
+export default createRule<never[], keyof typeof messages>({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Ensure styled is imported from @emotion/styled',
       recommended: false
     },
     fixable: 'code',
-    messages: {
-      incorrectImport: `emotion's exports should be imported directly from emotion rather than from react-emotion`
-    },
+    messages,
     schema: [],
     type: 'problem'
   },
@@ -65,4 +66,4 @@ export default createRule({
       }
     }
   }
-}) as EmotionESLintRule
+})

--- a/packages/eslint-plugin/src/rules/jsx-import.ts
+++ b/packages/eslint-plugin/src/rules/jsx-import.ts
@@ -1,5 +1,5 @@
-import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/experimental-utils'
-import { createRule, EmotionESLintRule, REPO_URL } from '../utils'
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils'
+import { createRule, REPO_URL } from '../utils'
 
 const JSX_ANNOTATION_REGEX = /\*?\s*@jsx\s+([^\s]+)/
 const JSX_IMPORT_SOURCE_REGEX = /\*?\s*@jsxImportSource\s+([^\s]+)/
@@ -9,13 +9,13 @@ const JSX_IMPORT_SOURCE_REGEX = /\*?\s*@jsxImportSource\s+([^\s]+)/
 // to
 // <div css={css`color:hotpink;`} /> + import { css }
 
-declare module '@typescript-eslint/experimental-utils/dist/ts-eslint/Rule' {
+declare module '@typescript-eslint/utils/dist/ts-eslint/Rule' {
   export interface SharedConfigurationSettings {
     react?: { pragma?: string }
   }
 }
 
-interface JSXConfig {
+type JSXConfig = {
   runtime: string
   importSource?: string
 }
@@ -32,7 +32,6 @@ export default createRule<RuleOptions, keyof typeof messages>({
   name: __filename,
   meta: {
     docs: {
-      category: 'Possible Errors',
       description: 'Ensure jsx from @emotion/react is imported',
       recommended: false
     },
@@ -273,4 +272,4 @@ export default createRule<RuleOptions, keyof typeof messages>({
       }
     }
   }
-}) as EmotionESLintRule
+})

--- a/packages/eslint-plugin/src/rules/jsx-import.ts
+++ b/packages/eslint-plugin/src/rules/jsx-import.ts
@@ -1,5 +1,5 @@
 import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/experimental-utils'
-import { createRule, REPO_URL } from '../utils'
+import { createRule, EmotionESLintRule, REPO_URL } from '../utils'
 
 const JSX_ANNOTATION_REGEX = /\*?\s*@jsx\s+([^\s]+)/
 const JSX_IMPORT_SOURCE_REGEX = /\*?\s*@jsxImportSource\s+([^\s]+)/
@@ -273,4 +273,4 @@ export default createRule<RuleOptions, keyof typeof messages>({
       }
     }
   }
-})
+}) as EmotionESLintRule

--- a/packages/eslint-plugin/src/rules/no-vanilla.ts
+++ b/packages/eslint-plugin/src/rules/no-vanilla.ts
@@ -1,4 +1,4 @@
-import { createRule } from '../utils'
+import { createRule, EmotionESLintRule } from '../utils'
 
 export default createRule({
   name: __filename,
@@ -27,4 +27,4 @@ export default createRule({
       }
     }
   }
-})
+}) as EmotionESLintRule

--- a/packages/eslint-plugin/src/rules/no-vanilla.ts
+++ b/packages/eslint-plugin/src/rules/no-vanilla.ts
@@ -1,16 +1,17 @@
-import { createRule, EmotionESLintRule } from '../utils'
+import { createRule } from '../utils'
 
-export default createRule({
+const messages = {
+  vanillaEmotion: 'Vanilla emotion should not be used'
+}
+
+export default createRule<never[], keyof typeof messages>({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Ensure vanilla emotion is not used',
       recommended: false
     },
-    messages: {
-      vanillaEmotion: 'Vanilla emotion should not be used'
-    },
+    messages,
     schema: [],
     type: 'problem'
   },
@@ -27,4 +28,4 @@ export default createRule({
       }
     }
   }
-}) as EmotionESLintRule
+})

--- a/packages/eslint-plugin/src/rules/pkg-renaming.ts
+++ b/packages/eslint-plugin/src/rules/pkg-renaming.ts
@@ -1,5 +1,5 @@
-import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils'
-import { createRule, EmotionESLintRule } from '../utils'
+import { AST_NODE_TYPES } from '@typescript-eslint/utils'
+import { createRule } from '../utils'
 
 const simpleMappings = new Map<unknown, string>([
   ['@emotion/core', '@emotion/react'],
@@ -14,20 +14,21 @@ const simpleMappings = new Map<unknown, string>([
   ['emotion-server', '@emotion/server']
 ])
 
-export default createRule({
+const messages = {
+  renamePackage: `{{ beforeName }} has been renamed to {{ afterName }}, please import it from {{ afterName }} instead`,
+  exportChange: `The default export of "{{ name }}" in Emotion 10 has been moved to a named export, \`css\`, from "{{ replacement }}" in Emotion 11, please import it from "{{ replacement }}"`,
+  emotionTheming: `"emotion-theming" has been moved into "@emotion/react", please import its exports from "@emotion/react"`
+}
+
+export default createRule<never[], keyof typeof messages>({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Internal rule',
       recommended: false
     },
     fixable: 'code',
-    messages: {
-      renamePackage: `{{ beforeName }} has been renamed to {{ afterName }}, please import it from {{ afterName }} instead`,
-      exportChange: `The default export of "{{ name }}" in Emotion 10 has been moved to a named export, \`css\`, from "{{ replacement }}" in Emotion 11, please import it from "{{ replacement }}"`,
-      emotionTheming: `"emotion-theming" has been moved into "@emotion/react", please import its exports from "@emotion/react"`
-    },
+    messages,
     schema: [],
     type: 'problem'
   },
@@ -85,4 +86,4 @@ export default createRule({
       }
     }
   }
-}) as EmotionESLintRule
+})

--- a/packages/eslint-plugin/src/rules/pkg-renaming.ts
+++ b/packages/eslint-plugin/src/rules/pkg-renaming.ts
@@ -1,5 +1,5 @@
 import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils'
-import { createRule } from '../utils'
+import { createRule, EmotionESLintRule } from '../utils'
 
 const simpleMappings = new Map<unknown, string>([
   ['@emotion/core', '@emotion/react'],
@@ -85,4 +85,4 @@ export default createRule({
       }
     }
   }
-})
+}) as EmotionESLintRule

--- a/packages/eslint-plugin/src/rules/styled-import.ts
+++ b/packages/eslint-plugin/src/rules/styled-import.ts
@@ -1,5 +1,5 @@
 import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils'
-import { createRule } from '../utils'
+import { createRule, EmotionESLintRule } from '../utils'
 
 export default createRule({
   name: __filename,
@@ -37,4 +37,4 @@ export default createRule({
       }
     }
   }
-})
+}) as EmotionESLintRule

--- a/packages/eslint-plugin/src/rules/styled-import.ts
+++ b/packages/eslint-plugin/src/rules/styled-import.ts
@@ -1,18 +1,19 @@
-import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils'
-import { createRule, EmotionESLintRule } from '../utils'
+import { AST_NODE_TYPES } from '@typescript-eslint/utils'
+import { createRule } from '../utils'
 
-export default createRule({
+const messages = {
+  incorrectImport: 'styled should be imported from @emotion/styled'
+}
+
+export default createRule<never[], keyof typeof messages>({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Ensure styled is imported from @emotion/styled',
       recommended: false
     },
     fixable: 'code',
-    messages: {
-      incorrectImport: 'styled should be imported from @emotion/styled'
-    },
+    messages,
     schema: [],
     type: 'problem'
   },
@@ -37,4 +38,4 @@ export default createRule({
       }
     }
   }
-}) as EmotionESLintRule
+})

--- a/packages/eslint-plugin/src/rules/syntax-preference.ts
+++ b/packages/eslint-plugin/src/rules/syntax-preference.ts
@@ -3,7 +3,7 @@ import {
   TSESLint,
   TSESTree
 } from '@typescript-eslint/experimental-utils'
-import { createRule } from '../utils'
+import { createRule, EmotionESLintRule } from '../utils'
 
 /**
  * @fileoverview Choose between string or object syntax
@@ -265,4 +265,4 @@ export default createRule<RuleOptions, MessageId>({
         return {}
     }
   }
-})
+}) as EmotionESLintRule

--- a/packages/eslint-plugin/src/rules/syntax-preference.ts
+++ b/packages/eslint-plugin/src/rules/syntax-preference.ts
@@ -1,9 +1,5 @@
-import {
-  AST_NODE_TYPES,
-  TSESLint,
-  TSESTree
-} from '@typescript-eslint/experimental-utils'
-import { createRule, EmotionESLintRule } from '../utils'
+import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils'
+import { createRule } from '../utils'
 
 /**
  * @fileoverview Choose between string or object syntax
@@ -235,7 +231,6 @@ export default createRule<RuleOptions, MessageId>({
   name: __filename,
   meta: {
     docs: {
-      category: 'Stylistic Issues',
       description: 'Choose between styles written as strings or objects',
       recommended: false
     },
@@ -265,4 +260,4 @@ export default createRule<RuleOptions, MessageId>({
         return {}
     }
   }
-}) as EmotionESLintRule
+})

--- a/packages/eslint-plugin/src/utils.ts
+++ b/packages/eslint-plugin/src/utils.ts
@@ -1,4 +1,4 @@
-import { ESLintUtils } from '@typescript-eslint/experimental-utils'
+import { ESLintUtils } from '@typescript-eslint/utils'
 import { parse as parsePath } from 'path'
 
 const { version } = require('../package.json')
@@ -10,18 +10,3 @@ export const createRule = ESLintUtils.RuleCreator(name => {
 
   return `${REPO_URL}/blob/@emotion/eslint-plugin@${version}/packages/eslint-plugin/docs/rules/${ruleName}.md`
 })
-
-// This is based off of RuleModule from `@typescript-eslint/experimental-utils`.
-// All exported rules should use this type to prevent the error:
-//
-// TS2742: The inferred type of 'rules' cannot be named without a reference to
-// '@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/types/dist/ast-spec'.
-// This is likely not portable. A type annotation is necessary.
-//
-// Really, there is no need to generate TypeScript declarations for this
-// package, but there does not seem to be a way to disable declaration
-// generation when using Preconstruct
-export interface EmotionESLintRule {
-  meta: unknown
-  create(context: unknown): unknown
-}

--- a/packages/eslint-plugin/src/utils.ts
+++ b/packages/eslint-plugin/src/utils.ts
@@ -10,3 +10,18 @@ export const createRule = ESLintUtils.RuleCreator(name => {
 
   return `${REPO_URL}/blob/@emotion/eslint-plugin@${version}/packages/eslint-plugin/docs/rules/${ruleName}.md`
 })
+
+// This is based off of RuleModule from `@typescript-eslint/experimental-utils`.
+// All exported rules should use this type to prevent the error:
+//
+// TS2742: The inferred type of 'rules' cannot be named without a reference to
+// '@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/types/dist/ast-spec'.
+// This is likely not portable. A type annotation is necessary.
+//
+// Really, there is no need to generate TypeScript declarations for this
+// package, but there does not seem to be a way to disable declaration
+// generation when using Preconstruct
+export interface EmotionESLintRule {
+  meta: unknown
+  create(context: unknown): unknown
+}

--- a/packages/eslint-plugin/test/rules/import-from-emotion.test.ts
+++ b/packages/eslint-plugin/test/rules/import-from-emotion.test.ts
@@ -2,9 +2,9 @@
  * @jest-environment node
  */
 
-import { TSESLint } from '@typescript-eslint/experimental-utils'
+import { TSESLint } from '@typescript-eslint/utils'
 import rule from '../../src/rules/import-from-emotion'
-import { RuleModuleForTesting, espreeParser } from '../test-utils'
+import { espreeParser } from '../test-utils'
 
 const ruleTester = new TSESLint.RuleTester({
   parser: espreeParser,
@@ -17,7 +17,7 @@ const ruleTester = new TSESLint.RuleTester({
   }
 })
 
-ruleTester.run('emotion jsx', rule as unknown as RuleModuleForTesting, {
+ruleTester.run('emotion jsx', rule, {
   valid: [
     {
       code: `import { css } from 'emotion'`

--- a/packages/eslint-plugin/test/rules/import-from-emotion.test.ts
+++ b/packages/eslint-plugin/test/rules/import-from-emotion.test.ts
@@ -4,7 +4,7 @@
 
 import { TSESLint } from '@typescript-eslint/experimental-utils'
 import rule from '../../src/rules/import-from-emotion'
-import { espreeParser } from '../test-utils'
+import { RuleModuleForTesting, espreeParser } from '../test-utils'
 
 const ruleTester = new TSESLint.RuleTester({
   parser: espreeParser,
@@ -17,7 +17,7 @@ const ruleTester = new TSESLint.RuleTester({
   }
 })
 
-ruleTester.run('emotion jsx', rule, {
+ruleTester.run('emotion jsx', rule as unknown as RuleModuleForTesting, {
   valid: [
     {
       code: `import { css } from 'emotion'`

--- a/packages/eslint-plugin/test/rules/jsx-import.test.ts
+++ b/packages/eslint-plugin/test/rules/jsx-import.test.ts
@@ -4,7 +4,7 @@
 
 import { TSESLint } from '@typescript-eslint/experimental-utils'
 import rule from '../../src/rules/jsx-import'
-import { espreeParser } from '../test-utils'
+import { RuleModuleForTesting, espreeParser } from '../test-utils'
 
 const ruleTester = new TSESLint.RuleTester({
   parser: espreeParser,
@@ -17,7 +17,7 @@ const ruleTester = new TSESLint.RuleTester({
   }
 })
 
-ruleTester.run('emotion jsx', rule, {
+ruleTester.run('emotion jsx', rule as unknown as RuleModuleForTesting, {
   valid: [
     {
       code: `

--- a/packages/eslint-plugin/test/rules/jsx-import.test.ts
+++ b/packages/eslint-plugin/test/rules/jsx-import.test.ts
@@ -2,9 +2,9 @@
  * @jest-environment node
  */
 
-import { TSESLint } from '@typescript-eslint/experimental-utils'
+import { TSESLint } from '@typescript-eslint/utils'
 import rule from '../../src/rules/jsx-import'
-import { RuleModuleForTesting, espreeParser } from '../test-utils'
+import { espreeParser } from '../test-utils'
 
 const ruleTester = new TSESLint.RuleTester({
   parser: espreeParser,
@@ -17,7 +17,7 @@ const ruleTester = new TSESLint.RuleTester({
   }
 })
 
-ruleTester.run('emotion jsx', rule as unknown as RuleModuleForTesting, {
+ruleTester.run('emotion jsx', rule, {
   valid: [
     {
       code: `

--- a/packages/eslint-plugin/test/rules/no-vanilla.test.ts
+++ b/packages/eslint-plugin/test/rules/no-vanilla.test.ts
@@ -4,7 +4,7 @@
 
 import { TSESLint } from '@typescript-eslint/experimental-utils'
 import rule from '../../src/rules/no-vanilla'
-import { espreeParser } from '../test-utils'
+import { RuleModuleForTesting, espreeParser } from '../test-utils'
 
 const ruleTester = new TSESLint.RuleTester({
   parser: espreeParser,
@@ -17,7 +17,7 @@ const ruleTester = new TSESLint.RuleTester({
   }
 })
 
-ruleTester.run('no-vanilla', rule, {
+ruleTester.run('no-vanilla', rule as unknown as RuleModuleForTesting, {
   valid: [{ code: `import { css } from '@emotion/react'` }],
   invalid: [
     {

--- a/packages/eslint-plugin/test/rules/no-vanilla.test.ts
+++ b/packages/eslint-plugin/test/rules/no-vanilla.test.ts
@@ -2,9 +2,9 @@
  * @jest-environment node
  */
 
-import { TSESLint } from '@typescript-eslint/experimental-utils'
+import { TSESLint } from '@typescript-eslint/utils'
 import rule from '../../src/rules/no-vanilla'
-import { RuleModuleForTesting, espreeParser } from '../test-utils'
+import { espreeParser } from '../test-utils'
 
 const ruleTester = new TSESLint.RuleTester({
   parser: espreeParser,
@@ -17,7 +17,7 @@ const ruleTester = new TSESLint.RuleTester({
   }
 })
 
-ruleTester.run('no-vanilla', rule as unknown as RuleModuleForTesting, {
+ruleTester.run('no-vanilla', rule, {
   valid: [{ code: `import { css } from '@emotion/react'` }],
   invalid: [
     {

--- a/packages/eslint-plugin/test/rules/pkg-renaming.test.ts
+++ b/packages/eslint-plugin/test/rules/pkg-renaming.test.ts
@@ -4,7 +4,7 @@
 
 import { TSESLint } from '@typescript-eslint/experimental-utils'
 import rule from '../../src/rules/pkg-renaming'
-import { espreeParser } from '../test-utils'
+import { RuleModuleForTesting, espreeParser } from '../test-utils'
 
 const ruleTester = new TSESLint.RuleTester({
   parser: espreeParser,
@@ -17,7 +17,7 @@ const ruleTester = new TSESLint.RuleTester({
   }
 })
 
-ruleTester.run('pkg-renaming', rule, {
+ruleTester.run('pkg-renaming', rule as unknown as RuleModuleForTesting, {
   valid: [
     {
       code: `

--- a/packages/eslint-plugin/test/rules/pkg-renaming.test.ts
+++ b/packages/eslint-plugin/test/rules/pkg-renaming.test.ts
@@ -2,9 +2,9 @@
  * @jest-environment node
  */
 
-import { TSESLint } from '@typescript-eslint/experimental-utils'
+import { TSESLint } from '@typescript-eslint/utils'
 import rule from '../../src/rules/pkg-renaming'
-import { RuleModuleForTesting, espreeParser } from '../test-utils'
+import { espreeParser } from '../test-utils'
 
 const ruleTester = new TSESLint.RuleTester({
   parser: espreeParser,
@@ -17,7 +17,7 @@ const ruleTester = new TSESLint.RuleTester({
   }
 })
 
-ruleTester.run('pkg-renaming', rule as unknown as RuleModuleForTesting, {
+ruleTester.run('pkg-renaming', rule, {
   valid: [
     {
       code: `

--- a/packages/eslint-plugin/test/rules/styled-import.test.ts
+++ b/packages/eslint-plugin/test/rules/styled-import.test.ts
@@ -2,9 +2,9 @@
  * @jest-environment node
  */
 
-import { TSESLint } from '@typescript-eslint/experimental-utils'
+import { TSESLint } from '@typescript-eslint/utils'
 import rule from '../../src/rules/styled-import'
-import { RuleModuleForTesting, espreeParser } from '../test-utils'
+import { espreeParser } from '../test-utils'
 
 const ruleTester = new TSESLint.RuleTester({
   parser: espreeParser,
@@ -17,7 +17,7 @@ const ruleTester = new TSESLint.RuleTester({
   }
 })
 
-ruleTester.run('emotion styled', rule as unknown as RuleModuleForTesting, {
+ruleTester.run('emotion styled', rule, {
   valid: [
     {
       code: `

--- a/packages/eslint-plugin/test/rules/styled-import.test.ts
+++ b/packages/eslint-plugin/test/rules/styled-import.test.ts
@@ -4,7 +4,7 @@
 
 import { TSESLint } from '@typescript-eslint/experimental-utils'
 import rule from '../../src/rules/styled-import'
-import { espreeParser } from '../test-utils'
+import { RuleModuleForTesting, espreeParser } from '../test-utils'
 
 const ruleTester = new TSESLint.RuleTester({
   parser: espreeParser,
@@ -17,7 +17,7 @@ const ruleTester = new TSESLint.RuleTester({
   }
 })
 
-ruleTester.run('emotion styled', rule, {
+ruleTester.run('emotion styled', rule as unknown as RuleModuleForTesting, {
   valid: [
     {
       code: `

--- a/packages/eslint-plugin/test/rules/syntax-preference.test.ts
+++ b/packages/eslint-plugin/test/rules/syntax-preference.test.ts
@@ -8,9 +8,9 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-import { AST_NODE_TYPES, TSESLint } from '@typescript-eslint/experimental-utils'
+import { AST_NODE_TYPES, TSESLint } from '@typescript-eslint/utils'
 import rule from '../../src/rules/syntax-preference'
-import { RuleModuleForTesting, espreeParser } from '../test-utils'
+import { espreeParser } from '../test-utils'
 
 const ruleTester = new TSESLint.RuleTester({
   parser: espreeParser,
@@ -27,275 +27,263 @@ const ruleTester = new TSESLint.RuleTester({
 // Tests
 // ------------------------------------------------------------------------------
 
-ruleTester.run(
-  'syntax-preference (string)',
-  rule as unknown as RuleModuleForTesting,
-  {
-    valid: [
-      // give me some code that won't trigger a warning
-      {
-        code: 'const H1 = styled.h1` color: red; `',
-        options: ['string']
-      },
-      {
-        code: "const H1 = styled('h1')` color: red; `",
-        options: ['string']
-      },
-      {
-        code: 'const query = gql` { user(id: 5) { firstName, lastName } }`',
-        options: ['string']
-      },
-      {
-        code: `const Foo = () => <div css={css\`color: hotpink;\`} />`,
-        options: ['string']
-      },
-      {
-        code: `const Foo = () => <div css={[styles, otherStyles]} />`,
-        options: ['string']
-      },
-      {
-        code: `css\`color: hotpink;\``,
-        options: ['string']
-      },
-      {
-        code: `css(cls, css\`color: hotpink;\`)`,
-        options: ['string']
-      }
-    ],
+ruleTester.run('syntax-preference (string)', rule, {
+  valid: [
+    // give me some code that won't trigger a warning
+    {
+      code: 'const H1 = styled.h1` color: red; `',
+      options: ['string']
+    },
+    {
+      code: "const H1 = styled('h1')` color: red; `",
+      options: ['string']
+    },
+    {
+      code: 'const query = gql` { user(id: 5) { firstName, lastName } }`',
+      options: ['string']
+    },
+    {
+      code: `const Foo = () => <div css={css\`color: hotpink;\`} />`,
+      options: ['string']
+    },
+    {
+      code: `const Foo = () => <div css={[styles, otherStyles]} />`,
+      options: ['string']
+    },
+    {
+      code: `css\`color: hotpink;\``,
+      options: ['string']
+    },
+    {
+      code: `css(cls, css\`color: hotpink;\`)`,
+      options: ['string']
+    }
+  ],
 
-    invalid: [
-      {
-        code: "const H1 = styled.h1({ color: 'red' })",
-        options: ['string'],
-        errors: [
-          {
-            messageId: 'preferStringStyle',
-            type: AST_NODE_TYPES.ObjectExpression
-          }
-        ]
-      },
-      {
-        code: "const H1 = styled('h1')({ color: 'red' })",
-        options: ['string'],
-        errors: [
-          {
-            messageId: 'preferStringStyle',
-            type: AST_NODE_TYPES.ObjectExpression
-          }
-        ]
-      },
-      {
-        code: `const Foo = () => <div css={{ color: 'hotpink' }} />`,
-        options: ['string'],
-        errors: [
-          {
-            messageId: 'preferStringStyle',
-            type: AST_NODE_TYPES.ObjectExpression
-          }
-        ]
-      },
-      {
-        code: `const Foo = () => <div css={'color: hotpink;'} />`,
-        options: ['string'],
-        errors: [
-          {
-            messageId: 'preferWrappingWithCSS',
-            type: AST_NODE_TYPES.Literal
-          }
-        ]
-      },
-      {
-        code: `const Foo = () => <div css="'color: hotpink;'" />`,
-        options: ['string'],
-        errors: [
-          {
-            messageId: 'preferWrappingWithCSS',
-            type: AST_NODE_TYPES.Literal
-          }
-        ]
-      },
-      {
-        code: `const Foo = () => <div css={['background-color: green;', { color: 'hotpink' }]} />`,
-        options: ['string'],
-        errors: [
-          {
-            messageId: 'preferWrappingWithCSS',
-            type: AST_NODE_TYPES.Literal
-          },
-          {
-            messageId: 'preferStringStyle',
-            type: AST_NODE_TYPES.ObjectExpression
-          }
-        ]
-      },
-      {
-        code: `css(cls, { color: 'hotpink' })`,
-        options: ['string'],
-        errors: [
-          {
-            messageId: 'preferStringStyle',
-            type: AST_NODE_TYPES.ObjectExpression
-          }
-        ]
-      },
-      {
-        code: `const Foo = () => <div css />`,
-        options: ['string'],
-        errors: [
-          {
-            messageId: 'emptyCssProp',
-            type: AST_NODE_TYPES.JSXAttribute
-          }
-        ]
-      }
-    ]
-  }
-)
+  invalid: [
+    {
+      code: "const H1 = styled.h1({ color: 'red' })",
+      options: ['string'],
+      errors: [
+        {
+          messageId: 'preferStringStyle',
+          type: AST_NODE_TYPES.ObjectExpression
+        }
+      ]
+    },
+    {
+      code: "const H1 = styled('h1')({ color: 'red' })",
+      options: ['string'],
+      errors: [
+        {
+          messageId: 'preferStringStyle',
+          type: AST_NODE_TYPES.ObjectExpression
+        }
+      ]
+    },
+    {
+      code: `const Foo = () => <div css={{ color: 'hotpink' }} />`,
+      options: ['string'],
+      errors: [
+        {
+          messageId: 'preferStringStyle',
+          type: AST_NODE_TYPES.ObjectExpression
+        }
+      ]
+    },
+    {
+      code: `const Foo = () => <div css={'color: hotpink;'} />`,
+      options: ['string'],
+      errors: [
+        {
+          messageId: 'preferWrappingWithCSS',
+          type: AST_NODE_TYPES.Literal
+        }
+      ]
+    },
+    {
+      code: `const Foo = () => <div css="'color: hotpink;'" />`,
+      options: ['string'],
+      errors: [
+        {
+          messageId: 'preferWrappingWithCSS',
+          type: AST_NODE_TYPES.Literal
+        }
+      ]
+    },
+    {
+      code: `const Foo = () => <div css={['background-color: green;', { color: 'hotpink' }]} />`,
+      options: ['string'],
+      errors: [
+        {
+          messageId: 'preferWrappingWithCSS',
+          type: AST_NODE_TYPES.Literal
+        },
+        {
+          messageId: 'preferStringStyle',
+          type: AST_NODE_TYPES.ObjectExpression
+        }
+      ]
+    },
+    {
+      code: `css(cls, { color: 'hotpink' })`,
+      options: ['string'],
+      errors: [
+        {
+          messageId: 'preferStringStyle',
+          type: AST_NODE_TYPES.ObjectExpression
+        }
+      ]
+    },
+    {
+      code: `const Foo = () => <div css />`,
+      options: ['string'],
+      errors: [
+        {
+          messageId: 'emptyCssProp',
+          type: AST_NODE_TYPES.JSXAttribute
+        }
+      ]
+    }
+  ]
+})
 
-ruleTester.run(
-  'syntax-preference (object)',
-  rule as unknown as RuleModuleForTesting,
-  {
-    valid: [
-      // give me some code that won't trigger a warning
-      {
-        code: "const H1 = styled.h1({ color: 'red' })",
-        options: ['object']
-      },
-      {
-        code: "const H1 = styled('h1')({ color: 'red' })",
-        options: ['object']
-      },
-      {
-        code: 'const query = gql` { user(id: 5) { firstName, lastName } }`',
-        options: ['object']
-      },
-      {
-        code: `const Foo = () => <div css={{ color: 'hotpink' }} />`,
-        options: ['object']
-      },
-      {
-        code: `const Foo = () => <div css={css({ color: 'hotpink' })} />`,
-        options: ['object']
-      }
-    ],
+ruleTester.run('syntax-preference (object)', rule, {
+  valid: [
+    // give me some code that won't trigger a warning
+    {
+      code: "const H1 = styled.h1({ color: 'red' })",
+      options: ['object']
+    },
+    {
+      code: "const H1 = styled('h1')({ color: 'red' })",
+      options: ['object']
+    },
+    {
+      code: 'const query = gql` { user(id: 5) { firstName, lastName } }`',
+      options: ['object']
+    },
+    {
+      code: `const Foo = () => <div css={{ color: 'hotpink' }} />`,
+      options: ['object']
+    },
+    {
+      code: `const Foo = () => <div css={css({ color: 'hotpink' })} />`,
+      options: ['object']
+    }
+  ],
 
-    invalid: [
-      {
-        code: 'const H1 = styled.h1` color: red; `',
-        options: ['object'],
-        errors: [
-          {
-            messageId: 'preferObjectStyle',
-            type: AST_NODE_TYPES.TaggedTemplateExpression
-          }
-        ]
-      },
-      {
-        code: "const H1 = styled('h1')` color: red; `",
-        options: ['object'],
-        errors: [
-          {
-            messageId: 'preferObjectStyle',
-            type: AST_NODE_TYPES.TaggedTemplateExpression
-          }
-        ]
-      },
-      {
-        code: `const Foo = () => <div css={css\`color: hotpink;\`} />`,
-        options: ['object'],
-        errors: [
-          {
-            messageId: 'preferObjectStyle',
-            type: AST_NODE_TYPES.TaggedTemplateExpression
-          }
-        ]
-      },
-      {
-        code: `const Foo = () => <div css={'color: hotpink;'} />`,
-        options: ['object'],
-        errors: [
-          {
-            messageId: 'preferObjectStyle',
-            type: AST_NODE_TYPES.Literal
-          }
-        ]
-      },
-      {
-        code: `const Foo = () => <div css="color: hotpink;" />`,
-        options: ['object'],
-        errors: [
-          {
-            messageId: 'preferObjectStyle',
-            type: AST_NODE_TYPES.Literal
-          }
-        ]
-      },
-      {
-        code: `const Foo = () => <div css={['background-color: green;', css\`color: hotpink;\`]} />`,
-        options: ['object'],
-        errors: [
-          {
-            messageId: 'preferObjectStyle',
-            type: AST_NODE_TYPES.Literal
-          },
-          {
-            messageId: 'preferObjectStyle',
-            type: AST_NODE_TYPES.TaggedTemplateExpression
-          }
-        ]
-      },
-      {
-        code: `const Foo = () => <div css={css(['background-color: green;', css\`color: hotpink;\`])} />`,
-        options: ['object'],
-        errors: [
-          {
-            messageId: 'preferObjectStyle',
-            type: AST_NODE_TYPES.Literal
-          },
-          {
-            messageId: 'preferObjectStyle',
-            type: AST_NODE_TYPES.TaggedTemplateExpression
-          }
-        ]
-      },
-      {
-        code: `const Foo = () => <div css />`,
-        options: ['object'],
-        errors: [
-          {
-            messageId: 'emptyCssProp',
-            type: AST_NODE_TYPES.JSXAttribute
-          }
-        ]
-      }
-    ]
-  }
-)
+  invalid: [
+    {
+      code: 'const H1 = styled.h1` color: red; `',
+      options: ['object'],
+      errors: [
+        {
+          messageId: 'preferObjectStyle',
+          type: AST_NODE_TYPES.TaggedTemplateExpression
+        }
+      ]
+    },
+    {
+      code: "const H1 = styled('h1')` color: red; `",
+      options: ['object'],
+      errors: [
+        {
+          messageId: 'preferObjectStyle',
+          type: AST_NODE_TYPES.TaggedTemplateExpression
+        }
+      ]
+    },
+    {
+      code: `const Foo = () => <div css={css\`color: hotpink;\`} />`,
+      options: ['object'],
+      errors: [
+        {
+          messageId: 'preferObjectStyle',
+          type: AST_NODE_TYPES.TaggedTemplateExpression
+        }
+      ]
+    },
+    {
+      code: `const Foo = () => <div css={'color: hotpink;'} />`,
+      options: ['object'],
+      errors: [
+        {
+          messageId: 'preferObjectStyle',
+          type: AST_NODE_TYPES.Literal
+        }
+      ]
+    },
+    {
+      code: `const Foo = () => <div css="color: hotpink;" />`,
+      options: ['object'],
+      errors: [
+        {
+          messageId: 'preferObjectStyle',
+          type: AST_NODE_TYPES.Literal
+        }
+      ]
+    },
+    {
+      code: `const Foo = () => <div css={['background-color: green;', css\`color: hotpink;\`]} />`,
+      options: ['object'],
+      errors: [
+        {
+          messageId: 'preferObjectStyle',
+          type: AST_NODE_TYPES.Literal
+        },
+        {
+          messageId: 'preferObjectStyle',
+          type: AST_NODE_TYPES.TaggedTemplateExpression
+        }
+      ]
+    },
+    {
+      code: `const Foo = () => <div css={css(['background-color: green;', css\`color: hotpink;\`])} />`,
+      options: ['object'],
+      errors: [
+        {
+          messageId: 'preferObjectStyle',
+          type: AST_NODE_TYPES.Literal
+        },
+        {
+          messageId: 'preferObjectStyle',
+          type: AST_NODE_TYPES.TaggedTemplateExpression
+        }
+      ]
+    },
+    {
+      code: `const Foo = () => <div css />`,
+      options: ['object'],
+      errors: [
+        {
+          messageId: 'emptyCssProp',
+          type: AST_NODE_TYPES.JSXAttribute
+        }
+      ]
+    }
+  ]
+})
 
-ruleTester.run(
-  'syntax-preference (undefined)',
-  rule as unknown as RuleModuleForTesting,
-  {
-    valid: [
-      // give me some code that won't trigger a warning
-      {
-        code: 'const H1 = styled.h1` color: red; `'
-      },
-      {
-        code: "const H1 = styled('h1')` color: red; `"
-      },
-      {
-        code: "const H1 = styled.h1({ color: 'red' })"
-      },
-      {
-        code: "const H1 = styled('h1')({ color: 'red' })"
-      },
-      {
-        code: 'const query = gql` { user(id: 5) { firstName, lastName } }`'
-      }
-    ],
+ruleTester.run('syntax-preference (undefined)', rule, {
+  valid: [
+    // give me some code that won't trigger a warning
+    {
+      code: 'const H1 = styled.h1` color: red; `'
+    },
+    {
+      code: "const H1 = styled('h1')` color: red; `"
+    },
+    {
+      code: "const H1 = styled.h1({ color: 'red' })"
+    },
+    {
+      code: "const H1 = styled('h1')({ color: 'red' })"
+    },
+    {
+      code: 'const query = gql` { user(id: 5) { firstName, lastName } }`'
+    }
+  ],
 
-    invalid: []
-  }
-)
+  invalid: []
+})

--- a/packages/eslint-plugin/test/rules/syntax-preference.test.ts
+++ b/packages/eslint-plugin/test/rules/syntax-preference.test.ts
@@ -10,7 +10,7 @@
 
 import { AST_NODE_TYPES, TSESLint } from '@typescript-eslint/experimental-utils'
 import rule from '../../src/rules/syntax-preference'
-import { espreeParser } from '../test-utils'
+import { RuleModuleForTesting, espreeParser } from '../test-utils'
 
 const ruleTester = new TSESLint.RuleTester({
   parser: espreeParser,
@@ -27,263 +27,275 @@ const ruleTester = new TSESLint.RuleTester({
 // Tests
 // ------------------------------------------------------------------------------
 
-ruleTester.run('syntax-preference (string)', rule, {
-  valid: [
-    // give me some code that won't trigger a warning
-    {
-      code: 'const H1 = styled.h1` color: red; `',
-      options: ['string']
-    },
-    {
-      code: "const H1 = styled('h1')` color: red; `",
-      options: ['string']
-    },
-    {
-      code: 'const query = gql` { user(id: 5) { firstName, lastName } }`',
-      options: ['string']
-    },
-    {
-      code: `const Foo = () => <div css={css\`color: hotpink;\`} />`,
-      options: ['string']
-    },
-    {
-      code: `const Foo = () => <div css={[styles, otherStyles]} />`,
-      options: ['string']
-    },
-    {
-      code: `css\`color: hotpink;\``,
-      options: ['string']
-    },
-    {
-      code: `css(cls, css\`color: hotpink;\`)`,
-      options: ['string']
-    }
-  ],
+ruleTester.run(
+  'syntax-preference (string)',
+  rule as unknown as RuleModuleForTesting,
+  {
+    valid: [
+      // give me some code that won't trigger a warning
+      {
+        code: 'const H1 = styled.h1` color: red; `',
+        options: ['string']
+      },
+      {
+        code: "const H1 = styled('h1')` color: red; `",
+        options: ['string']
+      },
+      {
+        code: 'const query = gql` { user(id: 5) { firstName, lastName } }`',
+        options: ['string']
+      },
+      {
+        code: `const Foo = () => <div css={css\`color: hotpink;\`} />`,
+        options: ['string']
+      },
+      {
+        code: `const Foo = () => <div css={[styles, otherStyles]} />`,
+        options: ['string']
+      },
+      {
+        code: `css\`color: hotpink;\``,
+        options: ['string']
+      },
+      {
+        code: `css(cls, css\`color: hotpink;\`)`,
+        options: ['string']
+      }
+    ],
 
-  invalid: [
-    {
-      code: "const H1 = styled.h1({ color: 'red' })",
-      options: ['string'],
-      errors: [
-        {
-          messageId: 'preferStringStyle',
-          type: AST_NODE_TYPES.ObjectExpression
-        }
-      ]
-    },
-    {
-      code: "const H1 = styled('h1')({ color: 'red' })",
-      options: ['string'],
-      errors: [
-        {
-          messageId: 'preferStringStyle',
-          type: AST_NODE_TYPES.ObjectExpression
-        }
-      ]
-    },
-    {
-      code: `const Foo = () => <div css={{ color: 'hotpink' }} />`,
-      options: ['string'],
-      errors: [
-        {
-          messageId: 'preferStringStyle',
-          type: AST_NODE_TYPES.ObjectExpression
-        }
-      ]
-    },
-    {
-      code: `const Foo = () => <div css={'color: hotpink;'} />`,
-      options: ['string'],
-      errors: [
-        {
-          messageId: 'preferWrappingWithCSS',
-          type: AST_NODE_TYPES.Literal
-        }
-      ]
-    },
-    {
-      code: `const Foo = () => <div css="'color: hotpink;'" />`,
-      options: ['string'],
-      errors: [
-        {
-          messageId: 'preferWrappingWithCSS',
-          type: AST_NODE_TYPES.Literal
-        }
-      ]
-    },
-    {
-      code: `const Foo = () => <div css={['background-color: green;', { color: 'hotpink' }]} />`,
-      options: ['string'],
-      errors: [
-        {
-          messageId: 'preferWrappingWithCSS',
-          type: AST_NODE_TYPES.Literal
-        },
-        {
-          messageId: 'preferStringStyle',
-          type: AST_NODE_TYPES.ObjectExpression
-        }
-      ]
-    },
-    {
-      code: `css(cls, { color: 'hotpink' })`,
-      options: ['string'],
-      errors: [
-        {
-          messageId: 'preferStringStyle',
-          type: AST_NODE_TYPES.ObjectExpression
-        }
-      ]
-    },
-    {
-      code: `const Foo = () => <div css />`,
-      options: ['string'],
-      errors: [
-        {
-          messageId: 'emptyCssProp',
-          type: AST_NODE_TYPES.JSXAttribute
-        }
-      ]
-    }
-  ]
-})
+    invalid: [
+      {
+        code: "const H1 = styled.h1({ color: 'red' })",
+        options: ['string'],
+        errors: [
+          {
+            messageId: 'preferStringStyle',
+            type: AST_NODE_TYPES.ObjectExpression
+          }
+        ]
+      },
+      {
+        code: "const H1 = styled('h1')({ color: 'red' })",
+        options: ['string'],
+        errors: [
+          {
+            messageId: 'preferStringStyle',
+            type: AST_NODE_TYPES.ObjectExpression
+          }
+        ]
+      },
+      {
+        code: `const Foo = () => <div css={{ color: 'hotpink' }} />`,
+        options: ['string'],
+        errors: [
+          {
+            messageId: 'preferStringStyle',
+            type: AST_NODE_TYPES.ObjectExpression
+          }
+        ]
+      },
+      {
+        code: `const Foo = () => <div css={'color: hotpink;'} />`,
+        options: ['string'],
+        errors: [
+          {
+            messageId: 'preferWrappingWithCSS',
+            type: AST_NODE_TYPES.Literal
+          }
+        ]
+      },
+      {
+        code: `const Foo = () => <div css="'color: hotpink;'" />`,
+        options: ['string'],
+        errors: [
+          {
+            messageId: 'preferWrappingWithCSS',
+            type: AST_NODE_TYPES.Literal
+          }
+        ]
+      },
+      {
+        code: `const Foo = () => <div css={['background-color: green;', { color: 'hotpink' }]} />`,
+        options: ['string'],
+        errors: [
+          {
+            messageId: 'preferWrappingWithCSS',
+            type: AST_NODE_TYPES.Literal
+          },
+          {
+            messageId: 'preferStringStyle',
+            type: AST_NODE_TYPES.ObjectExpression
+          }
+        ]
+      },
+      {
+        code: `css(cls, { color: 'hotpink' })`,
+        options: ['string'],
+        errors: [
+          {
+            messageId: 'preferStringStyle',
+            type: AST_NODE_TYPES.ObjectExpression
+          }
+        ]
+      },
+      {
+        code: `const Foo = () => <div css />`,
+        options: ['string'],
+        errors: [
+          {
+            messageId: 'emptyCssProp',
+            type: AST_NODE_TYPES.JSXAttribute
+          }
+        ]
+      }
+    ]
+  }
+)
 
-ruleTester.run('syntax-preference (object)', rule, {
-  valid: [
-    // give me some code that won't trigger a warning
-    {
-      code: "const H1 = styled.h1({ color: 'red' })",
-      options: ['object']
-    },
-    {
-      code: "const H1 = styled('h1')({ color: 'red' })",
-      options: ['object']
-    },
-    {
-      code: 'const query = gql` { user(id: 5) { firstName, lastName } }`',
-      options: ['object']
-    },
-    {
-      code: `const Foo = () => <div css={{ color: 'hotpink' }} />`,
-      options: ['object']
-    },
-    {
-      code: `const Foo = () => <div css={css({ color: 'hotpink' })} />`,
-      options: ['object']
-    }
-  ],
+ruleTester.run(
+  'syntax-preference (object)',
+  rule as unknown as RuleModuleForTesting,
+  {
+    valid: [
+      // give me some code that won't trigger a warning
+      {
+        code: "const H1 = styled.h1({ color: 'red' })",
+        options: ['object']
+      },
+      {
+        code: "const H1 = styled('h1')({ color: 'red' })",
+        options: ['object']
+      },
+      {
+        code: 'const query = gql` { user(id: 5) { firstName, lastName } }`',
+        options: ['object']
+      },
+      {
+        code: `const Foo = () => <div css={{ color: 'hotpink' }} />`,
+        options: ['object']
+      },
+      {
+        code: `const Foo = () => <div css={css({ color: 'hotpink' })} />`,
+        options: ['object']
+      }
+    ],
 
-  invalid: [
-    {
-      code: 'const H1 = styled.h1` color: red; `',
-      options: ['object'],
-      errors: [
-        {
-          messageId: 'preferObjectStyle',
-          type: AST_NODE_TYPES.TaggedTemplateExpression
-        }
-      ]
-    },
-    {
-      code: "const H1 = styled('h1')` color: red; `",
-      options: ['object'],
-      errors: [
-        {
-          messageId: 'preferObjectStyle',
-          type: AST_NODE_TYPES.TaggedTemplateExpression
-        }
-      ]
-    },
-    {
-      code: `const Foo = () => <div css={css\`color: hotpink;\`} />`,
-      options: ['object'],
-      errors: [
-        {
-          messageId: 'preferObjectStyle',
-          type: AST_NODE_TYPES.TaggedTemplateExpression
-        }
-      ]
-    },
-    {
-      code: `const Foo = () => <div css={'color: hotpink;'} />`,
-      options: ['object'],
-      errors: [
-        {
-          messageId: 'preferObjectStyle',
-          type: AST_NODE_TYPES.Literal
-        }
-      ]
-    },
-    {
-      code: `const Foo = () => <div css="color: hotpink;" />`,
-      options: ['object'],
-      errors: [
-        {
-          messageId: 'preferObjectStyle',
-          type: AST_NODE_TYPES.Literal
-        }
-      ]
-    },
-    {
-      code: `const Foo = () => <div css={['background-color: green;', css\`color: hotpink;\`]} />`,
-      options: ['object'],
-      errors: [
-        {
-          messageId: 'preferObjectStyle',
-          type: AST_NODE_TYPES.Literal
-        },
-        {
-          messageId: 'preferObjectStyle',
-          type: AST_NODE_TYPES.TaggedTemplateExpression
-        }
-      ]
-    },
-    {
-      code: `const Foo = () => <div css={css(['background-color: green;', css\`color: hotpink;\`])} />`,
-      options: ['object'],
-      errors: [
-        {
-          messageId: 'preferObjectStyle',
-          type: AST_NODE_TYPES.Literal
-        },
-        {
-          messageId: 'preferObjectStyle',
-          type: AST_NODE_TYPES.TaggedTemplateExpression
-        }
-      ]
-    },
-    {
-      code: `const Foo = () => <div css />`,
-      options: ['object'],
-      errors: [
-        {
-          messageId: 'emptyCssProp',
-          type: AST_NODE_TYPES.JSXAttribute
-        }
-      ]
-    }
-  ]
-})
+    invalid: [
+      {
+        code: 'const H1 = styled.h1` color: red; `',
+        options: ['object'],
+        errors: [
+          {
+            messageId: 'preferObjectStyle',
+            type: AST_NODE_TYPES.TaggedTemplateExpression
+          }
+        ]
+      },
+      {
+        code: "const H1 = styled('h1')` color: red; `",
+        options: ['object'],
+        errors: [
+          {
+            messageId: 'preferObjectStyle',
+            type: AST_NODE_TYPES.TaggedTemplateExpression
+          }
+        ]
+      },
+      {
+        code: `const Foo = () => <div css={css\`color: hotpink;\`} />`,
+        options: ['object'],
+        errors: [
+          {
+            messageId: 'preferObjectStyle',
+            type: AST_NODE_TYPES.TaggedTemplateExpression
+          }
+        ]
+      },
+      {
+        code: `const Foo = () => <div css={'color: hotpink;'} />`,
+        options: ['object'],
+        errors: [
+          {
+            messageId: 'preferObjectStyle',
+            type: AST_NODE_TYPES.Literal
+          }
+        ]
+      },
+      {
+        code: `const Foo = () => <div css="color: hotpink;" />`,
+        options: ['object'],
+        errors: [
+          {
+            messageId: 'preferObjectStyle',
+            type: AST_NODE_TYPES.Literal
+          }
+        ]
+      },
+      {
+        code: `const Foo = () => <div css={['background-color: green;', css\`color: hotpink;\`]} />`,
+        options: ['object'],
+        errors: [
+          {
+            messageId: 'preferObjectStyle',
+            type: AST_NODE_TYPES.Literal
+          },
+          {
+            messageId: 'preferObjectStyle',
+            type: AST_NODE_TYPES.TaggedTemplateExpression
+          }
+        ]
+      },
+      {
+        code: `const Foo = () => <div css={css(['background-color: green;', css\`color: hotpink;\`])} />`,
+        options: ['object'],
+        errors: [
+          {
+            messageId: 'preferObjectStyle',
+            type: AST_NODE_TYPES.Literal
+          },
+          {
+            messageId: 'preferObjectStyle',
+            type: AST_NODE_TYPES.TaggedTemplateExpression
+          }
+        ]
+      },
+      {
+        code: `const Foo = () => <div css />`,
+        options: ['object'],
+        errors: [
+          {
+            messageId: 'emptyCssProp',
+            type: AST_NODE_TYPES.JSXAttribute
+          }
+        ]
+      }
+    ]
+  }
+)
 
-ruleTester.run('syntax-preference (undefined)', rule, {
-  valid: [
-    // give me some code that won't trigger a warning
-    {
-      code: 'const H1 = styled.h1` color: red; `'
-    },
-    {
-      code: "const H1 = styled('h1')` color: red; `"
-    },
-    {
-      code: "const H1 = styled.h1({ color: 'red' })"
-    },
-    {
-      code: "const H1 = styled('h1')({ color: 'red' })"
-    },
-    {
-      code: 'const query = gql` { user(id: 5) { firstName, lastName } }`'
-    }
-  ],
+ruleTester.run(
+  'syntax-preference (undefined)',
+  rule as unknown as RuleModuleForTesting,
+  {
+    valid: [
+      // give me some code that won't trigger a warning
+      {
+        code: 'const H1 = styled.h1` color: red; `'
+      },
+      {
+        code: "const H1 = styled('h1')` color: red; `"
+      },
+      {
+        code: "const H1 = styled.h1({ color: 'red' })"
+      },
+      {
+        code: "const H1 = styled('h1')({ color: 'red' })"
+      },
+      {
+        code: 'const query = gql` { user(id: 5) { firstName, lastName } }`'
+      }
+    ],
 
-  invalid: []
-})
+    invalid: []
+  }
+)

--- a/packages/eslint-plugin/test/test-utils.ts
+++ b/packages/eslint-plugin/test/test-utils.ts
@@ -1,16 +1,6 @@
-import {
-  RuleListener,
-  RuleModule
-} from '@typescript-eslint/experimental-utils/dist/ts-eslint'
 import resolveFrom from 'resolve-from'
 
 export const espreeParser: string = resolveFrom(
   require.resolve('eslint'),
   'espree'
 )
-
-export type RuleModuleForTesting = RuleModule<
-  string,
-  readonly unknown[],
-  RuleListener
->

--- a/packages/eslint-plugin/test/test-utils.ts
+++ b/packages/eslint-plugin/test/test-utils.ts
@@ -1,6 +1,16 @@
+import {
+  RuleListener,
+  RuleModule
+} from '@typescript-eslint/experimental-utils/dist/ts-eslint'
 import resolveFrom from 'resolve-from'
 
 export const espreeParser: string = resolveFrom(
   require.resolve('eslint'),
   'espree'
 )
+
+export type RuleModuleForTesting = RuleModule<
+  string,
+  readonly unknown[],
+  RuleListener
+>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6029,6 +6029,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/json-schema@^7.0.9":
+  version "7.0.11"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
+  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -6391,7 +6396,7 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/experimental-utils@4.33.0", "@typescript-eslint/experimental-utils@^4.0.1", "@typescript-eslint/experimental-utils@^4.30.0":
+"@typescript-eslint/experimental-utils@4.33.0", "@typescript-eslint/experimental-utils@^4.0.1":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz#6f2a786a4209fa2222989e9380b5331b2810f7fd"
   integrity sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==
@@ -6460,6 +6465,14 @@
     "@typescript-eslint/types" "4.33.0"
     "@typescript-eslint/visitor-keys" "4.33.0"
 
+"@typescript-eslint/scope-manager@5.25.0":
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.25.0.tgz#e78f1484bca7e484c48782075219c82c6b77a09f"
+  integrity sha512-p4SKTFWj+2VpreUZ5xMQsBMDdQ9XdRvODKXN4EksyBjFp2YvQdLkyHqOffakYZPuWJUDNu3jVXtHALDyTv3cww==
+  dependencies:
+    "@typescript-eslint/types" "5.25.0"
+    "@typescript-eslint/visitor-keys" "5.25.0"
+
 "@typescript-eslint/types@3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.10.1.tgz#1d7463fa7c32d8a23ab508a803ca2fe26e758727"
@@ -6474,6 +6487,11 @@
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
   integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
+
+"@typescript-eslint/types@5.25.0":
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.25.0.tgz#dee51b1855788b24a2eceeae54e4adb89b088dd8"
+  integrity sha512-7fWqfxr0KNHj75PFqlGX24gWjdV/FDBABXL5dyvBOWHpACGyveok8Uj4ipPX/1fGU63fBkzSIycEje4XsOxUFA==
 
 "@typescript-eslint/typescript-estree@2.34.0":
   version "2.34.0"
@@ -6528,6 +6546,31 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.25.0":
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.25.0.tgz#a7ab40d32eb944e3fb5b4e3646e81b1bcdd63e00"
+  integrity sha512-MrPODKDych/oWs/71LCnuO7NyR681HuBly2uLnX3r5i4ME7q/yBqC4hW33kmxtuauLTM0OuBOhhkFaxCCOjEEw==
+  dependencies:
+    "@typescript-eslint/types" "5.25.0"
+    "@typescript-eslint/visitor-keys" "5.25.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@^5.25.0":
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.25.0.tgz#272751fd737733294b4ab95e16c7f2d4a75c2049"
+  integrity sha512-qNC9bhnz/n9Kba3yI6HQgQdBLuxDoMgdjzdhSInZh6NaDnFpTUlwNGxplUFWfY260Ya0TRPvkg9dd57qxrJI9g==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.25.0"
+    "@typescript-eslint/types" "5.25.0"
+    "@typescript-eslint/typescript-estree" "5.25.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
 "@typescript-eslint/visitor-keys@3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz#cd4274773e3eb63b2e870ac602274487ecd1e931"
@@ -6550,6 +6593,14 @@
   dependencies:
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@5.25.0":
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.25.0.tgz#33aa5fdcc5cedb9f4c8828c6a019d58548d4474b"
+  integrity sha512-yd26vFgMsC4h2dgX4+LR+GeicSKIfUvZREFLf3DDjZPtqgLx5AJZr6TetMNwFP9hcKreTTeztQYBTNbNoOycwA==
+  dependencies:
+    "@typescript-eslint/types" "5.25.0"
+    eslint-visitor-keys "^3.3.0"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -10995,6 +11046,13 @@ debug@^4.1.0:
   dependencies:
     ms "2.1.2"
 
+debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
@@ -12660,6 +12718,11 @@ eslint-visitor-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
+
+eslint-visitor-keys@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
+  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint-webpack-plugin@^2.5.2:
   version "2.5.4"
@@ -15307,7 +15370,7 @@ globby@^10.0.0, globby@^10.0.1:
     merge2 "^1.2.3"
     slash "^3.0.0"
 
-globby@^11.0.1:
+globby@^11.0.1, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -17258,6 +17321,13 @@ is-glob@^3.1.0:
   integrity sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
   dependencies:
     is-extglob "^2.1.0"
+
+is-glob@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
+  dependencies:
+    is-extglob "^2.1.1"
 
 is-hexadecimal@^1.0.0:
   version "1.0.3"
@@ -27330,6 +27400,13 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semve
   version "6.3.0"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.7:
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@~5.3.0:
   version "5.3.0"


### PR DESCRIPTION
This change was originally made [here](https://github.com/emotion-js/emotion/pull/2732/commits/b45662d92ca37a90d7feeebea154a4beaa605dfa). Its purpose is to prevent the following error from Preconstruct.

```text
🎁 error Generating TypeScript declarations for packages/eslint-plugin/src/index.ts failed:
🎁 error packages/eslint-plugin/src/index.ts:8:12 - error TS2742: The inferred type of 'rules' cannot be named without a reference to '@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/types/dist/ast-spec'. This is likely not portable. A type annotation is necessary.
🎁 error
🎁 error 8 export let rules = {
🎁 error ~~~~~
🎁 error packages/eslint-plugin/src/index.ts:8:12 - error TS4023: Exported variable 'rules' has or is using name 'JSXConfig' from external module "/home/srmagura/Documents/oss/emotion-ts/packages/eslint-plugin/src/rules/jsx-import" but cannot be named.
🎁 error
🎁 error 8 export let rules = {
🎁 error ~~~~~
🎁 error
```