### PR TITLE
jest: Allow `@types/jest` version ^28

### DIFF
--- a/.changeset/empty-terms-beam.md
+++ b/.changeset/empty-terms-beam.md
@@ -1,0 +1,5 @@
+---
+'@emotion/jest': patch
+---
+
+Fix a dependency conflict when `@emotion/jest` was installed alongside `@types/jest@^28`.

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -24,7 +24,7 @@
     "stylis": "4.0.13"
   },
   "peerDependencies": {
-    "@types/jest": ">=26.0.14",
+    "@types/jest": "^26.0.14 || ^27.0.0 || ^28.0.0",
     "enzyme-to-json": "^3.2.1"
   },
   "peerDependenciesMeta": {

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -24,7 +24,7 @@
     "stylis": "4.0.13"
   },
   "peerDependencies": {
-    "@types/jest": "^26.0.14 || ^27.0.0",
+    "@types/jest": ">=26.0.14",
     "enzyme-to-json": "^3.2.1"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Fixes #2770.

To test the compatibility with the Jest 28 types, I upgraded `@types/jest` to 28.1.0 and ran dtslint, which succeeded. This change was just for testing so I did not commit it.