### PR TITLE
Upgrade to `@definitelytyped/dtslint` (attempt 2)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,27 +175,8 @@ jobs:
         run: yarn lint:check
 
   typescript:
-    name: DTSLint
+    name: dtslint
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        package:
-          - cache
-          - css
-          - hash
-          - is-prop-valid
-          - jest
-          - memoize
-          - native
-          - react
-          - serialize
-          - server
-          - sheet
-          - styled
-          - utils
-          - weak-memoize
-
     steps:
       - uses: actions/checkout@main
 
@@ -221,7 +202,5 @@ jobs:
       - name: Install Dependencies
         run: yarn
 
-      - name: ESLint
-        run: yarn lint:check
-      - name: TypeScript
-        run: cd packages/${{ matrix.package }} && yarn test:typescript
+      - name: dtslint
+        run: yarn test:typescript

--- a/package.json
+++ b/package.json
@@ -125,9 +125,6 @@
       "site",
       "scripts/*",
       "playgrounds/*"
-    ],
-    "nohoist": [
-      "**/dtslint"
     ]
   },
   "preconstruct": {
@@ -209,7 +206,6 @@
     "bundlesize": "^0.13.2",
     "codecov": "^2.3.1",
     "cssjanus": "^1.2.0",
-    "dtslint": "^4.2.1",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.5",
     "enzyme-to-json": "^3.6.1",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -22,8 +22,8 @@
     "stylis": "4.0.13"
   },
   "devDependencies": {
+    "@definitelytyped/dtslint": "0.0.112",
     "@emotion/hash": "*",
-    "dtslint": "^4.2.1",
     "typescript": "^4.5.5"
   },
   "publishConfig": {

--- a/packages/cache/types/tslint.json
+++ b/packages/cache/types/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "dtslint/dtslint.json",
+  "extends": "@definitelytyped/dtslint/dtslint.json",
   "rules": {
     "array-type": [true, "generic"],
     "semicolon": false

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.13.10",
-    "dtslint": "^4.2.1",
+    "@definitelytyped/dtslint": "0.0.112",
     "typescript": "^4.5.5"
   },
   "author": "Kye Hohenberger",

--- a/packages/css/types/tslint.json
+++ b/packages/css/types/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "dtslint/dtslint.json",
+  "extends": "@definitelytyped/dtslint/dtslint.json",
   "rules": {
     "array-type": [true, "generic"],
     "import-spacing": false,

--- a/packages/hash/package.json
+++ b/packages/hash/package.json
@@ -19,7 +19,7 @@
     "test:typescript": "dtslint types"
   },
   "devDependencies": {
-    "dtslint": "^4.2.1",
+    "@definitelytyped/dtslint": "0.0.112",
     "typescript": "^4.5.5"
   },
   "browser": {

--- a/packages/hash/types/tslint.json
+++ b/packages/hash/types/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "dtslint/dtslint.json",
+  "extends": "@definitelytyped/dtslint/dtslint.json",
   "rules": {
     "array-type": [true, "generic"],
     "import-spacing": false,

--- a/packages/is-prop-valid/package.json
+++ b/packages/is-prop-valid/package.json
@@ -17,7 +17,7 @@
     "@emotion/memoize": "^0.7.4"
   },
   "devDependencies": {
-    "dtslint": "^4.2.1",
+    "@definitelytyped/dtslint": "0.0.112",
     "typescript": "^4.5.5"
   },
   "files": [

--- a/packages/is-prop-valid/types/tslint.json
+++ b/packages/is-prop-valid/types/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "dtslint/dtslint.json",
+  "extends": "@definitelytyped/dtslint/dtslint.json",
   "rules": {
     "array-type": [true, "generic"],
     "import-spacing": false,

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -36,10 +36,10 @@
     }
   },
   "devDependencies": {
+    "@definitelytyped/dtslint": "0.0.112",
     "@emotion/css": "11.9.0",
     "@emotion/react": "11.9.0",
     "@types/jest": "^27.0.3",
-    "dtslint": "^4.2.1",
     "enzyme-to-json": "^3.6.1",
     "preact": "^8.2.9",
     "preact-render-to-json": "^3.6.6",

--- a/packages/jest/types/tslint.json
+++ b/packages/jest/types/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "dtslint/dtslint.json",
+  "extends": "@definitelytyped/dtslint/dtslint.json",
   "rules": {
     "array-type": [true, "generic"],
     "semicolon": false,

--- a/packages/memoize/package.json
+++ b/packages/memoize/package.json
@@ -14,7 +14,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "dtslint": "^4.2.1",
+    "@definitelytyped/dtslint": "0.0.112",
     "typescript": "^4.5.5"
   },
   "files": [

--- a/packages/memoize/types/tslint.json
+++ b/packages/memoize/types/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "dtslint/dtslint.json",
+  "extends": "@definitelytyped/dtslint/dtslint.json",
   "rules": {
     "array-type": [true, "generic"],
     "import-spacing": false,

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -16,8 +16,8 @@
   "types": "types/index.d.ts",
   "devDependencies": {
     "@babel/core": "^7.13.10",
+    "@definitelytyped/dtslint": "0.0.112",
     "@types/react-native": "^0.63.2",
-    "dtslint": "^4.2.1",
     "react": "16.14.0",
     "react-native": "^0.63.2",
     "typescript": "^4.5.5"

--- a/packages/native/types/tslint.json
+++ b/packages/native/types/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "dtslint/dtslint.json",
+  "extends": "@definitelytyped/dtslint/dtslint.json",
   "rules": {
     "array-type": [true, "generic"],
     "callable-types": false,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -48,11 +48,11 @@
   },
   "devDependencies": {
     "@babel/core": "^7.13.10",
+    "@definitelytyped/dtslint": "0.0.112",
     "@emotion/css": "11.9.0",
     "@emotion/css-prettifier": "1.0.1",
     "@emotion/server": "11.4.0",
     "@emotion/styled": "11.8.1",
-    "dtslint": "^4.2.1",
     "html-tag-names": "^1.1.2",
     "react": "16.14.0",
     "svg-tag-names": "^1.1.1",

--- a/packages/react/types/tslint.json
+++ b/packages/react/types/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "dtslint/dtslint.json",
+  "extends": "@definitelytyped/dtslint/dtslint.json",
   "rules": {
     "array-type": [true, "generic"],
     "callable-types": false,

--- a/packages/serialize/package.json
+++ b/packages/serialize/package.json
@@ -21,7 +21,7 @@
     "csstype": "^3.0.2"
   },
   "devDependencies": {
-    "dtslint": "^4.2.1",
+    "@definitelytyped/dtslint": "0.0.112",
     "typescript": "^4.5.5"
   },
   "files": [

--- a/packages/serialize/types/tslint.json
+++ b/packages/serialize/types/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "dtslint/dtslint.json",
+  "extends": "@definitelytyped/dtslint/dtslint.json",
   "rules": {
     "array-type": [true, "generic"],
     "semicolon": false,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,11 +28,11 @@
     }
   },
   "devDependencies": {
+    "@definitelytyped/dtslint": "0.0.112",
     "@emotion/babel-plugin": "11.9.2",
     "@emotion/css": "11.9.0",
     "@emotion/css-prettifier": "1.0.1",
     "@types/node": "^10.11.4",
-    "dtslint": "^4.2.1",
     "typescript": "^4.5.5"
   },
   "author": "Kye Hohenberger",

--- a/packages/server/types/tslint.json
+++ b/packages/server/types/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "dtslint/dtslint.json",
+  "extends": "@definitelytyped/dtslint/dtslint.json",
   "rules": {
     "array-type": [true, "generic"],
     "semicolon": false,

--- a/packages/sheet/package.json
+++ b/packages/sheet/package.json
@@ -23,7 +23,7 @@
     "types/*.d.ts"
   ],
   "devDependencies": {
-    "dtslint": "^4.2.1",
+    "@definitelytyped/dtslint": "0.0.112",
     "typescript": "^4.5.5"
   }
 }

--- a/packages/sheet/types/tslint.json
+++ b/packages/sheet/types/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "dtslint/dtslint.json",
+  "extends": "@definitelytyped/dtslint/dtslint.json",
   "rules": {
     "array-type": [true, "generic"],
     "semicolon": false

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -32,8 +32,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.13.10",
+    "@definitelytyped/dtslint": "0.0.112",
     "@emotion/react": "11.9.0",
-    "dtslint": "^4.2.1",
     "react": "16.14.0",
     "typescript": "^4.5.5"
   },

--- a/packages/styled/types/tslint.json
+++ b/packages/styled/types/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "dtslint/dtslint.json",
+  "extends": "@definitelytyped/dtslint/dtslint.json",
   "rules": {
     "array-type": [true, "generic"],
     "file-name-casing": false,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -23,7 +23,7 @@
     "types/*.d.ts"
   ],
   "devDependencies": {
-    "dtslint": "^4.2.1",
+    "@definitelytyped/dtslint": "0.0.112",
     "typescript": "^4.5.5"
   }
 }

--- a/packages/utils/types/tslint.json
+++ b/packages/utils/types/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "dtslint/dtslint.json",
+  "extends": "@definitelytyped/dtslint/dtslint.json",
   "rules": {
     "array-type": [true, "generic"],
     "semicolon": false

--- a/packages/weak-memoize/package.json
+++ b/packages/weak-memoize/package.json
@@ -14,7 +14,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "dtslint": "^4.2.1",
+    "@definitelytyped/dtslint": "0.0.112",
     "typescript": "^4.5.5"
   },
   "files": [

--- a/packages/weak-memoize/types/tslint.json
+++ b/packages/weak-memoize/types/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "dtslint/dtslint.json",
+  "extends": "@definitelytyped/dtslint/dtslint.json",
   "rules": {
     "array-type": [true, "generic"],
     "import-spacing": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2801,26 +2801,53 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@definitelytyped/header-parser@latest":
-  version "0.0.110"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/header-parser/-/header-parser-0.0.110.tgz#8938f46d65fd9c876fc9f539ccd83bded069553c"
-  integrity sha512-aWtibC7WEFFpeY1dfgyDgBYCFPLfDcXJiMQf5hjHkOx0/XWGz5rNzzZYsN/U2lepIYyuIwuRWHvgaIErSEiOZw==
+"@definitelytyped/dts-critic@^0.0.112":
+  version "0.0.112"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/dts-critic/-/dts-critic-0.0.112.tgz#8879bec56aae04118ebed14a49737cf5ef194cae"
+  integrity sha512-KyzmcxI8yLdesJYLdskbzyEumPI/mUjHo+3ozowUmK34B1Fdr5LB7tDAdAVcZMVYCJ2lic1Z5sAku4VOcRi5lg==
   dependencies:
-    "@definitelytyped/typescript-versions" "^0.0.110"
+    "@definitelytyped/header-parser" "^0.0.112"
+    command-exists "^1.2.8"
+    rimraf "^3.0.2"
+    semver "^6.2.0"
+    tmp "^0.2.1"
+    yargs "^15.3.1"
+
+"@definitelytyped/dtslint@0.0.112":
+  version "0.0.112"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/dtslint/-/dtslint-0.0.112.tgz#1e06ce68e907d74c79a597a00d21d2057793e7b6"
+  integrity sha512-81mMCo7npo/jJeH8elqkwVLDVRE6ZKvJWV28RukEgtA7gAQ7flQMPxCDBu37kBkY241e7YwpfBK/vQrNp+8ObQ==
+  dependencies:
+    "@definitelytyped/dts-critic" "^0.0.112"
+    "@definitelytyped/header-parser" "^0.0.112"
+    "@definitelytyped/typescript-versions" "^0.0.112"
+    "@definitelytyped/utils" "^0.0.112"
+    fs-extra "^6.0.1"
+    json-stable-stringify "^1.0.1"
+    strip-json-comments "^2.0.1"
+    tslint "5.14.0"
+    yargs "^15.1.0"
+
+"@definitelytyped/header-parser@^0.0.112":
+  version "0.0.112"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/header-parser/-/header-parser-0.0.112.tgz#9091f8125f59e61fd0431d36d8580f20d7217d9a"
+  integrity sha512-R5LmrCk7gsRxcmD4iwfWtEtqleuREHCeeUjjWiymPUULguUTwCXumwjkfOFehbtSvpcDEQN16gxkcyV7TP5kmg==
+  dependencies:
+    "@definitelytyped/typescript-versions" "^0.0.112"
     "@types/parsimmon" "^1.10.1"
     parsimmon "^1.13.0"
 
-"@definitelytyped/typescript-versions@^0.0.110", "@definitelytyped/typescript-versions@latest":
-  version "0.0.110"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.110.tgz#9f68de6909492a3406fad84a14078e4ec1be1c39"
-  integrity sha512-OS6SOGbf0Qy+qd67GNMnQs8g/VWhrtjDS4SusylLsBRmeAw9rnKFfwrhrxLFXDHATCGpgJHatHQ6ZoJPRENYvQ==
+"@definitelytyped/typescript-versions@^0.0.112":
+  version "0.0.112"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.112.tgz#be54178f01b35cd552706d41cbbebe054aa2dc8f"
+  integrity sha512-w9xr6fPnc8ax6WPyRQRpLo4pwH1oOXgW7c68Moa4Gteaq1o2N0m5wm8UspkZB7LP0MZsrF5FMZmpevSKOE+k2w==
 
-"@definitelytyped/utils@latest":
-  version "0.0.110"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/utils/-/utils-0.0.110.tgz#3176ef188d6b0e94fc9a09646c19eeec5de8cddf"
-  integrity sha512-o7TdzWwxjZ2Ze+qbQL2KTYX7RD/uUfZfo3Ro7E8wtPd6DqrQ8q1UZY+/IChPCQ/xDFXqlZlLV4Fpfb6RBzQ2Hw==
+"@definitelytyped/utils@^0.0.112":
+  version "0.0.112"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/utils/-/utils-0.0.112.tgz#e0c8e93ad36e7ef14cde43d90ddbe0a060383f13"
+  integrity sha512-f8R5yJJD9EACuHgj30GTCk7iUeme0NFKx9Pgt1J4DquIOotAf8KjqwIhN9IY0t3HpHMoNDitr5hQGC0ekvpJdA==
   dependencies:
-    "@definitelytyped/typescript-versions" "^0.0.110"
+    "@definitelytyped/typescript-versions" "^0.0.112"
     "@qiwi/npm-registry-client" "^8.9.1"
     "@types/node" "^14.14.35"
     charm "^1.0.2"
@@ -11628,34 +11655,6 @@ download@^7.1.0:
     make-dir "^1.2.0"
     p-event "^2.1.0"
     pify "^3.0.0"
-
-dts-critic@latest:
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/dts-critic/-/dts-critic-3.3.11.tgz#93b7c1ba8017b310623b7cfb72548e0e138b68c8"
-  integrity sha512-HMO2f9AO7ge44YO8OK18f+cxm/IaE1CFuyNFbfJRCEbyazWj5X5wWDF6W4CGdo5Ax0ILYVfJ7L/rOwuUN1fzWw==
-  dependencies:
-    "@definitelytyped/header-parser" latest
-    command-exists "^1.2.8"
-    rimraf "^3.0.2"
-    semver "^6.2.0"
-    tmp "^0.2.1"
-    yargs "^15.3.1"
-
-dtslint@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/dtslint/-/dtslint-4.2.1.tgz#c416db9bb7ce3face599b7097b9cd0e7f478fdf7"
-  integrity sha512-57mWY9osUEfS6k62ATS9RSgug1dZcuN4O31hO76u+iEexa6VUEbKoPGaA2mNtc0FQDcdTl0zEUtti79UQKSQyQ==
-  dependencies:
-    "@definitelytyped/header-parser" latest
-    "@definitelytyped/typescript-versions" latest
-    "@definitelytyped/utils" latest
-    dts-critic latest
-    fs-extra "^6.0.1"
-    json-stable-stringify "^1.0.1"
-    strip-json-comments "^2.0.1"
-    tslint "5.14.0"
-    tsutils "^2.29.0"
-    yargs "^15.1.0"
 
 duplexer2@^0.1.2:
   version "0.1.4"


### PR DESCRIPTION
Fixes #2735.

The first attempt at this was [here](https://github.com/emotion-js/emotion/pull/2739/files/7a3f608053a9e2be00579d8a965019fb508c08c7..3a5af86a1ec69d9d002f1a363617e0b5497ef5c4). Though, that PR was targeting `ts-migration`. This time I have decided to target `main`. I will need to make a few tweaks after I merge this into `ts-migration`.

I removed the matrix strategy from our dtslint job in GitHub Actions. Before this change, we had 14 instances of the dtslint job, which each installed dependencies (2 minutes) and ran dtslint (20 seconds). With the new design, we will only install dependencies once, so a lot of duplicate work is being removed.