### PR TITLE
Migration docs change: import { css } from '@emotion/core'

### DIFF
--- a/docs/migrating-to-emotion-10.mdx
+++ b/docs/migrating-to-emotion-10.mdx
@@ -71,7 +71,7 @@ import styled, { css } from 'react-emotion'
 // ↓ ↓ ↓ ↓ ↓ ↓
 
 import styled from '@emotion/styled'
-import { css } from 'emotion'
+import { css } from '@emotion/core'
 ```
 
 - Add a `css` call to the `css` prop when a template literal is used.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
A one-line change in the migration documentation:

```diff
- import { css } from 'emotion'
+ import { css } from '@emotion/core'
```


<!-- Why are these changes necessary? -->

**Why**:

I was migrating an older emotion project to version 11 and was running into an error with my `css` calls. Looks like a typo in the docs — once I imported from `@emotion/core` everything was 👍.

<!-- How were these changes implemented? -->

**How**:

Quick PR directly on GitHub.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset --> N/A

<!-- feel free to add additional comments -->
