### PR TITLE
Use locked major versions of GitHub actions

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -1,0 +1,27 @@
+name: 'CI setup'
+runs:
+  using: 'composite'
+  steps:
+    - name: Set Node.js 16.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+      shell: bash
+
+    - uses: actions/cache@v3
+      id: yarn-cache
+      with:
+        path: |
+          ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          node_modules
+        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    - name: Install Dependencies
+      run: yarn --frozen-lockfile
+      shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,31 +17,8 @@ jobs:
           - windows-latest
     runs-on: ${{matrix.platform}}
     steps:
-      - uses: actions/checkout@main
-        with:
-          fetch-depth: 0
-
-      - name: Set Node.js 12.x
-        uses: actions/setup-node@main
-        with:
-          node-version: 12.x
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install Dependencies
-        run: yarn
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/ci-setup
 
       - name: Run Tests
         run: yarn test:ci --color
@@ -54,29 +31,8 @@ jobs:
     name: Flow
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-
-      - name: Set Node.js 12.x
-        uses: actions/setup-node@main
-        with:
-          node-version: 12.x
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install Dependencies
-        run: yarn
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/ci-setup
 
       - name: Check Types
         run: yarn flow:check
@@ -85,29 +41,8 @@ jobs:
     name: Test React 18
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-
-      - name: Set Node.js 12.x
-        uses: actions/setup-node@main
-        with:
-          node-version: 12.x
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install Dependencies
-        run: yarn
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/ci-setup
 
       - name: Run Tests with React 18
         run: yarn test:react18:ci
@@ -116,29 +51,8 @@ jobs:
     name: Test Dist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-
-      - name: Set Node.js 12.x
-        uses: actions/setup-node@main
-        with:
-          node-version: 12.x
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install Dependencies
-        run: yarn
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/ci-setup
 
       - name: Dist Tests
         run: yarn test:prod
@@ -147,29 +61,8 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-
-      - name: Set Node.js 12.x
-        uses: actions/setup-node@main
-        with:
-          node-version: 12.x
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install Dependencies
-        run: yarn
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/ci-setup
 
       - name: ESLint
         run: yarn lint:check
@@ -178,29 +71,8 @@ jobs:
     name: dtslint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-
-      - name: Set Node.js 12.x
-        uses: actions/setup-node@main
-        with:
-          node-version: 12.x
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install Dependencies
-        run: yarn
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/ci-setup
 
       - name: dtslint
         run: yarn test:typescript

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,24 +13,11 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@master
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js 12.x
-        uses: actions/setup-node@master
-        with:
-          node-version: 12.x
-
-      - name: Install Yarn
-        run: npm install --global yarn
-
-      - name: Install Dependencies
-        run: yarn --frozen-lockfile
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/ci-setup
 
       - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@master
+        uses: changesets/action@v1
         with:
           publish: yarn release
         env:


### PR DESCRIPTION
1. locked versions, mostly to the latest `@v3`
2. moved shared setup to a composite action
3. upgraded Changesets action to `v1`
4. using `yarn --frozen-lockfile` consistently for all install jobs
5. bumped node version to 16.x as 12 is EOL