### PR TITLE
fix: Add `jsx-runtime` exports field to `@emotion/react`

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,6 +7,50 @@
     "./dist/emotion-react.cjs.js": "./dist/emotion-react.browser.cjs.js",
     "./dist/emotion-react.esm.js": "./dist/emotion-react.browser.esm.js"
   },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./types/index.d.ts",
+        "browser": "./dist/emotion-react.browser.esm.js",
+        "default": "./dist/emotion-react.esm.js"
+      },
+      "require": {
+        "types": "./types/index.d.ts",
+        "browser": "./dist/emotion-react.browser.cjs.js",
+        "default": "./dist/emotion-react.cjs.js"
+      }
+    },
+    "./macro": {
+      "types": "./macro.d.ts",
+      "default": "./macro.js"
+    },
+    "./jsx-runtime": {
+      "import": {
+        "types": "./types/jsx-runtime.d.ts",
+        "browser": "./jsx-runtime/dist/emotion-react-jsx-runtime.browser.esm.js",
+        "default": "./jsx-runtime/dist/emotion-react-jsx-runtime.esm.js"
+      },
+      "require": {
+        "types": "./types/jsx-runtime.d.ts",
+        "browser": "./jsx-runtime/dist/emotion-react-jsx-runtime.browser.cjs.js",
+        "default": "./jsx-runtime/dist/emotion-react-jsx-runtime.cjs.js"
+      }
+    },
+    "./jsx-dev-runtime": {
+      "import": {
+        "types": "./types/jsx-dev-runtime.d.ts",
+        "browser": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.browser.esm.js",
+        "default": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.esm.js"
+      },
+      "require": {
+        "types": "./types/jsx-dev-runtime.d.ts",
+        "browser": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.browser.cjs.js",
+        "default": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.cjs.js"
+      }
+    },
+    "./dist/*": "./dist/*.js",
+    "./package.json": "./package.json"
+  },
   "types": "types/index.d.ts",
   "files": [
     "src",


### PR DESCRIPTION
Add `exports` field to `@emotion/react` in order to fix `Cannot find module 'react/jsx-runtime'` when TypeScript is pre-configured with `moduleResolution: "NodeNext"` introduced in TypeScript `v4.7`.

**Ref** https://github.com/emotion-js/emotion/issues/2742, https://github.com/microsoft/TypeScript/issues/33079

https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing
https://nodejs.org/api/packages.html#conditional-exports