### PR TITLE
feat: update @emotion/server types to support all exported members

### DIFF
--- a/.changeset/silent-baboons-press.md
+++ b/.changeset/silent-baboons-press.md
@@ -1,0 +1,5 @@
+---
+'@emotion/server': patch
+---
+
+Update emotion server types to support all exported members

--- a/.changeset/silent-baboons-press.md
+++ b/.changeset/silent-baboons-press.md
@@ -2,4 +2,4 @@
 '@emotion/server': patch
 ---
 
-Update emotion server types to support all exported members
+Added missing TypeScript declarations for `extractCriticalToChunks` and `constructStyleTagsFromChunks` exports.

--- a/packages/server/types/index.d.ts
+++ b/packages/server/types/index.d.ts
@@ -3,6 +3,8 @@
 
 import { EmotionServer } from '@emotion/server/create-instance'
 
+export const extractCritical: EmotionServer['extractCritical']
+export const extractCriticalToChunks: EmotionServer['extractCriticalToChunks']
 export const renderStylesToString: EmotionServer['renderStylesToString']
 export const renderStylesToNodeStream: EmotionServer['renderStylesToNodeStream']
-export const extractCritical: EmotionServer['extractCritical']
+export const constructStyleTagsFromChunks: EmotionServer['constructStyleTagsFromChunks']


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

Looking at the index.js file within emotion/server it does export extractCriticalToChunks however they are not added to the exported types. Is this intentional as we should not use it or can we update the types to support them?

**What**:
Update types for @emotion/server 

**Why**:

To prevent typescript from complaining when I try to use `import { extractCriticalToChunks } from '@emotion/server';` 
![image](https://user-images.githubusercontent.com/13072566/180425536-0dda9885-c22f-4301-9bf1-4ee59bd2427f.png)

**How**:

Followed the same approach as the other exported types. 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
