### PR TITLE
docs: Clarify that component selectors only work with `@emotion/styled`

### DIFF
--- a/docs/babel.mdx
+++ b/docs/babel.mdx
@@ -22,6 +22,6 @@ Uglifyjs will use the injected `/*#__PURE__*/` flag comments to mark your `css` 
 
 When enabled, navigate directly to the style declaration in your javascript file.
 
-#### Components as selectors
+#### Components as Selectors
 
-The ability to refer to another component to apply override styles depending on nesting context. Learn more in the [styled docs](/docs/styled.mdx#targeting-another-emotion-component).
+This feature allows you to refer to other Emotion components in your CSS selectors to apply override styles depending on nesting context. Learn more in the [styled docs](/docs/styled.mdx#targeting-another-emotion-component). Only components defined with `styled` can be used as component selectors.


### PR DESCRIPTION
This came about from a discussion in our Slack where component selectors were not working when the "child" component is a standard React component using the css prop. I investigated and found that component selectors only work when the child component is defined using `styled`. This updates the docs to make that a bit more clear.

For reference, [here](https://github.com/srmagura/emotion-react-macro-repro/blob/old-jsx-transform/src/App.js) is an example not using `styled`. The component selector does not work — it prints an error about function interpolations not being allowed.