### PR TITLE
Support typings for Jest v29

### DIFF
--- a/.changeset/brave-scissors-smile.md
+++ b/.changeset/brave-scissors-smile.md
@@ -1,5 +1,5 @@
 ---
-'@emotion/jest': minor
+'@emotion/jest': patch
 ---
 
-Support typings for Jest v29
+Fix a dependency conflict when `@emotion/jest` was installed alongside `@types/jest@^29`.

--- a/.changeset/brave-scissors-smile.md
+++ b/.changeset/brave-scissors-smile.md
@@ -1,0 +1,5 @@
+---
+'@emotion/jest': minor
+---
+
+Support typings for Jest v29

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -43,7 +43,7 @@
     "stylis": "4.0.13"
   },
   "peerDependencies": {
-    "@types/jest": "^26.0.14 || ^27.0.0 || ^28.0.0",
+    "@types/jest": "^26.0.14 || ^27.0.0 || ^28.0.0 || ^29.0.0",
     "enzyme-to-json": "^3.2.1"
   },
   "peerDependenciesMeta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2482,7 +2482,7 @@ __metadata:
     stylis: 4.0.13
     typescript: ^4.5.5
   peerDependencies:
-    "@types/jest": ^26.0.14 || ^27.0.0 || ^28.0.0
+    "@types/jest": ^26.0.14 || ^27.0.0 || ^28.0.0 || ^29.0.0
     enzyme-to-json: ^3.2.1
   peerDependenciesMeta:
     "@types/jest":


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Similar to https://github.com/emotion-js/emotion/pull/2456 and https://github.com/emotion-js/emotion/pull/2771. Allows `@emotion/jest` to be compatible with the typings for Jest v29.

**Why**:

See https://jestjs.io/blog/2022/08/25/jest-29. No relevant breaking changes, so it should be fine to permit the additional typing peer dep.

**How**:

Expanded the peer dep range.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
