### PR TITLE
Check vitest global for @emotion/react loaded twice warning

### DIFF
--- a/.changeset/loud-dancers-return.md
+++ b/.changeset/loud-dancers-return.md
@@ -1,0 +1,5 @@
+---
+'@emotion/react': patch
+---
+
+Include vitest global check when omitting the warning about duplicate instantiation in mocked modules. Will only capture vitest global `vi` if globals are configured.

--- a/.changeset/loud-dancers-return.md
+++ b/.changeset/loud-dancers-return.md
@@ -2,4 +2,4 @@
 '@emotion/react': patch
 ---
 
-Include vitest global check when omitting the warning about duplicate instantiation in mocked modules. Will only capture vitest global `vi` if globals are configured.
+Do not warn about `@emotion/react` being loaded twice in Vitest as that might easily happen with mocked modules.

--- a/flow-typed/npm/vitest_vx.x.x.js
+++ b/flow-typed/npm/vitest_vx.x.x.js
@@ -1,0 +1,1 @@
+declare var vi: {}

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -17,9 +17,9 @@ export { default as css } from './css'
 if (process.env.NODE_ENV !== 'production') {
   const isBrowser = typeof document !== 'undefined'
   // #1727 for some reason Jest evaluates modules twice if some consuming module gets mocked with jest.mock
-  const isJest = typeof jest !== 'undefined'
+  const isTestEnv = typeof jest !== 'undefined' || typeof vi !== 'undefined'
 
-  if (isBrowser && !isJest) {
+  if (isBrowser && !isTestEnv) {
     // globalThis has wide browser support - https://caniuse.com/?search=globalThis, Node.js 12 and later
     const globalContext =
       // $FlowIgnore

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -16,7 +16,7 @@ export { default as css } from './css'
 
 if (process.env.NODE_ENV !== 'production') {
   const isBrowser = typeof document !== 'undefined'
-  // #1727 for some reason Jest evaluates modules twice if some consuming module gets mocked with jest.mock
+  // #1727, #2905 for some reason Jest and Vitest evaluate modules twice if some consuming module gets mocked
   const isTestEnv = typeof jest !== 'undefined' || typeof vi !== 'undefined'
 
   if (isBrowser && !isTestEnv) {


### PR DESCRIPTION
**What**:
`vitest` shows the same symptoms with the duplicate loading when mocking out modules that include `@emotion/react`.

**Why**:
Stop logging warnings during test runs.

**How**:
Include check for the `vi` global as well as `jest`. I had to add a flow type for `vi` but this is not something I'm familiar with so happy to do that properly with guidance.

**Checklist**:
- [x] Documentation (N/A)
- [x] Tests (N/A)
- [x] Code complete (N/A)
- [x] Changeset 