### PR TITLE
Docs typo: incorrect backtick in jsx-import.md

### DIFF
--- a/packages/eslint-plugin/docs/rules/jsx-import.md
+++ b/packages/eslint-plugin/docs/rules/jsx-import.md
@@ -2,7 +2,7 @@
 
 ## Rule Details
 
-This rule ensures that `jsx` from `@emotion/react is imported`. This rule can usually be auto-fixed so you should not usually have to do anything yourself.
+This rule ensures that `jsx` from `@emotion/react` is imported. This rule can usually be auto-fixed so you should not usually have to do anything yourself.
 
 Examples of **incorrect** code for this rule.
 


### PR DESCRIPTION
Formatting was a little wonky 🙂

Please forgive my not adhering to the PR template for this teeny docs typo fix.