### PR TITLE
Add -ms-expand and -ms-reveal to ignored prefixes

### DIFF
--- a/.changeset/olive-ladybugs-fry.md
+++ b/.changeset/olive-ladybugs-fry.md
@@ -2,4 +2,4 @@
 '@emotion/sheet': patch
 ---
 
-Add -ms-expand and -ms-reveal to ignored prefixes
+Do not log failed rule insertions in the speedy mode for even more vendor-prefixed pseudo-elements/classes like `:-ms-expand` and `:-ms-reveal`.

--- a/.changeset/olive-ladybugs-fry.md
+++ b/.changeset/olive-ladybugs-fry.md
@@ -1,0 +1,5 @@
+---
+'@emotion/sheet': patch
+---
+
+Add -ms-expand and -ms-reveal to ignored prefixes

--- a/packages/sheet/src/index.js
+++ b/packages/sheet/src/index.js
@@ -147,7 +147,7 @@ export class StyleSheet {
       } catch (e) {
         if (
           process.env.NODE_ENV !== 'production' &&
-          !/:(-moz-placeholder|-moz-focus-inner|-moz-focusring|-ms-input-placeholder|-moz-read-write|-moz-read-only|-ms-clear){/.test(
+          !/:(-moz-placeholder|-moz-focus-inner|-moz-focusring|-ms-input-placeholder|-moz-read-write|-moz-read-only|-ms-clear|-ms-expand|-ms-reveal){/.test(
             rule
           )
         ) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: adds the `-ms-expand` and `-ms-reveal` to ignored vendor prefixes; similar to #2393.

<!-- Why are these changes necessary? -->

**Why**: browsers that do not support these vendor prefixes (i.e. Chrome and Firefox) will cause error messages to be displayed in the console. The prefixes themselves are fairly common:

- `-ms-expand` is used to hide the browser's dropdown arrow when styling `select` elements, in Internet Explorer, Edge (both old and Chromium-based). This pseudo element is also used in [MUI Core](https://github.com/mui/material-ui/blob/f27694b0ec007c879f8c89eba73bd627ea5c7af0/packages/mui-material/src/NativeSelect/NativeSelectInput.js#L36).
- `-ms-reveal` is often used to hide the password reveal button, in password inputs. This pseudo-element selector works in IE10+ and in Edge browsers as well.

<!-- How were these changes implemented? -->

**How**: the pseudo-elements were added to the the regex of selectors for which no error is emitted.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation (N/A ; there does not seem to exist any documentation on this)
- [ ] Tests (N/A ; there seem to be no existing tests for this, and I'm not sure how to properly test this in the first place)
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
