### PR TITLE
Added '@emotion/react' ESLint config

### DIFF
--- a/.changeset/sweet-forks-whisper.md
+++ b/.changeset/sweet-forks-whisper.md
@@ -1,0 +1,5 @@
+---
+'@emotion/eslint-plugin': minor
+---
+
+Added '@emotion/react' ESLint config

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -28,10 +28,20 @@ Add `@emotion` to the plugins section of your `.eslintrc` configuration file. Yo
 }
 ```
 
-Then configure the rules you want to use under the rules section.
+You can enable the rules we recommend for `react` by listing the `@emotion/react` preset under `extends`:
 
 ```json
 {
+  "extends": ["@emotion/react"],
+  "plugins": ["@emotion"]
+}
+```
+
+Alternately, you configure specifically rules you want to use under the `rules` section.
+
+```json
+{
+  "plugins": ["@emotion"],
   "rules": {
     "@emotion/jsx-import": "error"
   }
@@ -71,8 +81,10 @@ The Emotion 10 codemods are contained in this package. To use them, enable the r
 
 ## Supported Rules
 
-- [jsx-import](https://github.com/emotion-js/emotion/blob/main/packages/eslint-plugin/docs/rules/jsx-import.md)
-- [styled-import](https://github.com/emotion-js/emotion/blob/main/packages/eslint-plugin/docs/rules/styled-import.md)
-- [import-from-emotion](https://github.com/emotion-js/emotion/blob/main/packages/eslint-plugin/docs/rules/import-from-emotion.md)
-- [no-vanilla](https://github.com/emotion-js/emotion/blob/main/packages/eslint-plugin/docs/rules/no-vanilla.md)
+Rules enabled by default in the `react` config are marked with ⚛️.
+
+- ⚛️ [import-from-emotion](https://github.com/emotion-js/emotion/blob/main/packages/eslint-plugin/docs/rules/import-from-emotion.md)
+- ⚛️ [jsx-import](https://github.com/emotion-js/emotion/blob/main/packages/eslint-plugin/docs/rules/jsx-import.md)
+- ⚛️ [no-vanilla](https://github.com/emotion-js/emotion/blob/main/packages/eslint-plugin/docs/rules/no-vanilla.md)
+- ⚛️ [styled-import](https://github.com/emotion-js/emotion/blob/main/packages/eslint-plugin/docs/rules/styled-import.md)
 - [syntax-preference](https://github.com/emotion-js/emotion/blob/main/packages/eslint-plugin/docs/rules/syntax-preference.md)

--- a/packages/eslint-plugin/src/index.js
+++ b/packages/eslint-plugin/src/index.js
@@ -7,11 +7,20 @@ import styledImport from './rules/styled-import'
 import jsxImport from './rules/jsx-import'
 import pkgRenaming from './rules/pkg-renaming'
 
+export let configs = {
+  react: {
+    'import-from-emotion': 'error',
+    'jsx-import': 'error',
+    'no-vanilla': 'error',
+    'styled-import': 'error'
+  }
+}
+
 export let rules = {
   'import-from-emotion': importFromEmotion,
-  'no-vanilla': noVanilla,
-  'syntax-preference': syntaxPreference,
-  'styled-import': styledImport,
   'jsx-import': jsxImport,
-  'pkg-renaming': pkgRenaming
+  'no-vanilla': noVanilla,
+  'pkg-renaming': pkgRenaming,
+  'styled-import': styledImport,
+  'syntax-preference': syntaxPreference
 }


### PR DESCRIPTION
**What**:

Adds a new `@emotion/react` preset ESLint config users can extend from:


```json
{
  "extends": ["@emotion/react"],
  "plugins": ["@emotion"]
}
```

It enables the relevant ESLint rules related to React.

**Why**:

<!-- How were these changes implemented? -->

**How**:

* Adds the exported config as an object
* Updates the eslint-plugin README.md docs to mention it
* Sorts rules alphabetically wherever they're listed 😈 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [X] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

Is there a way you'd like me to include tests for this change?
