### PR TITLE
Add a extend-expect to globally require matchers

### DIFF
--- a/.changeset/giant-coats-confess.md
+++ b/.changeset/giant-coats-confess.md
@@ -1,0 +1,5 @@
+---
+'@emotion/jest': minor
+---
+
+Add a `@emotion/jest/extend-expect` module to simplify adding matchers

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -215,6 +215,10 @@ test('renders with correct link styles', () => {
 })
 ```
 
+### Include custom matchers globally
+
+You can add the custom matchers globally by adding a `import '@emotion/jest/extend-expect` to a setupFilesAfterEnv script.
+
 ## Thanks
 
 Thanks to [Kent C. Dodds](https://twitter.com/kentcdodds) who wrote [jest-glamor-react](https://github.com/kentcdodds/jest-glamor-react) which this library is largely based on. ❤️

--- a/packages/jest/extend-expect/package.json
+++ b/packages/jest/extend-expect/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "dist/emotion-jest-extend-expect.cjs.js",
+  "module": "dist/emotion-jest-extend-expect.esm.js",
+  "types": "../types/index.d.ts"
+}

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -17,6 +17,10 @@
       "module": "./serializer/dist/emotion-jest-serializer.esm.js",
       "default": "./serializer/dist/emotion-jest-serializer.cjs.js"
     },
+    "./extend-expect": {
+      "module": "./extend-expect/dist/emotion-jest-extend-expect.esm.js",
+      "default": "./extend-expect/dist/emotion-jest-extend-expect.cjs.js"
+    },
     "./enzyme-serializer": {
       "module": "./enzyme-serializer/dist/emotion-jest-enzyme-serializer.esm.js",
       "default": "./enzyme-serializer/dist/emotion-jest-enzyme-serializer.cjs.js"
@@ -30,7 +34,8 @@
     "types/*.d.ts",
     "serializer",
     "enzyme",
-    "enzyme-serializer"
+    "enzyme-serializer",
+    "extend-expect"
   ],
   "scripts": {
     "test:typescript": "dtslint types"
@@ -86,7 +91,8 @@
       "./index.js",
       "./serializer.js",
       "./enzyme.js",
-      "./enzyme-serializer.js"
+      "./enzyme-serializer.js",
+      "./extend-expect.js"
     ]
   }
 }

--- a/packages/jest/src/extend-expect.d.ts
+++ b/packages/jest/src/extend-expect.d.ts
@@ -1,0 +1,1 @@
+import '../types'

--- a/packages/jest/src/extend-expect.js
+++ b/packages/jest/src/extend-expect.js
@@ -1,0 +1,4 @@
+import { matchers } from './matchers'
+
+// eslint-disable-next-line no-undef
+expect.extend(matchers)


### PR DESCRIPTION
…t-dom pattern

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Add a `@emotion/jest/extend-expect` import to follow pattern set up in [@testing-libary/jest-dom.](https://github.com/testing-library/jest-dom/blob/main/src/extend-expect.js)

<!-- Why are these changes necessary? -->

**Why**:
It makes it easier to import the matchers in a single line of code, follows patterns set up by other libraries. 

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ X ] Documentation
- [ ] Tests N/A
- [ X ] Code complete
- [ X ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
