### PR TITLE
Encourage creating globals outside render cycle

### DIFF
--- a/docs/globals.mdx
+++ b/docs/globals.mdx
@@ -8,22 +8,27 @@ Sometimes you might want to insert global css like resets or font faces. You can
 // @live
 import { Global, css } from '@emotion/react'
 
+// For performance, move global styles outside of the render cycle when possible
+const hotPink = css`
+  .some-class {
+    color: hotpink !important;
+  }
+`
+
+const someClass = {
+  '.some-class': {
+    fontSize: 50,
+    textAlign: 'center'
+  }
+}
+
 render(
   <div>
     <Global
-      styles={css`
-        .some-class {
-          color: hotpink !important;
-        }
-      `}
+      styles={hotPink}
     />
     <Global
-      styles={{
-        '.some-class': {
-          fontSize: 50,
-          textAlign: 'center'
-        }
-      }}
+      styles={someClass}
     />
     <div className="some-class">This is hotpink now!</div>
   </div>


### PR DESCRIPTION
**What**:

In our large app, we noticed a 50% reduction in render time when moving our tagged template literal outside of the render cycle.  
Hopefully making this change in the docs encourages others to do the same!

**Why**:

a 50% reduction in render time for large apps.
See flame chart [here](https://github.com/ParabolInc/parabol/pull/7598#issue-1501398739).

**How**:

Global styles usually live at the top of the render tree. Saving 1ms on every render can add up substantially!

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests (See flamechart) 
- [ ] Code complete N/A
- [ ] Changeset N/A

<!-- feel free to add additional comments -->
