### PR TITLE
Add helious/emotion-mirror link to Libraries

### DIFF
--- a/docs/community.mdx
+++ b/docs/community.mdx
@@ -23,6 +23,7 @@ title: 'Community'
 - [styled-conditions](https://github.com/karolisgrinkevicius/styled-conditions) - Ultra-lightweight flag utility to conditionally apply css depending on React props
 - [manipulative](https://github.com/paulshen/manipulative) - React devtool to style emotion components from the browser
 - [emotion-tailwind-preflight](https://github.com/flogy/emotion-tailwind-preflight) - Merge the shiny TailwindCSS base styles into your CSS-in-JS project
+- [emotion-mirror](https://github.com/helious/emotion-mirror) - A wrapper of styled that lints Stylelint rules against CSS-in-JS at runtime
 
 ## Component Libraries
 


### PR DESCRIPTION
**What**:
I felt like I made a thing that is worth sharing to the Emotion community! I'd like to add https://github.com/helious/emotion-mirror to the Libraries links so others can get runtime linting via https://stylelint.io/ for their CSS-in-JS components. It's nice to get warnings when you have malformed CSS or want to set up a way to enforce some CSS standards for a repo.

**Why**:
The team I currently worked on were talking about leveraging template strings or opting for object syntax when using `styled`; we like how the template strings feel like writing CSS, but we also liked that security that we were setting valid CSS props with the object syntax. Alas, I saw that both approaches really miss out on validating the styles that are actually generated when using CSS-in-JS, leading to potential bugs from malformed CSS.

**How**:
So I set out on a journey to implement some sort of linting on CSS-in-JS's generated CSS. Opted to make this a plugin that could treeshake out and only run while code is in development. Wrapped `styled` with `stylelint`'s bundled version so it could run in the browser. Grabs the output and runs it through `stylelint` when a styled component renders and present any warnings in the browser's console.   

**Checklist**:
- [x] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A
- [ ] Changeset N/A

Would love anyone to test this out besides myself! Would love to see others gain value out of this. :)