### PR TITLE
Remove peer dependency on `@babel/core` from most packages

### DIFF
--- a/.changeset/healthy-squids-wait.md
+++ b/.changeset/healthy-squids-wait.md
@@ -1,0 +1,10 @@
+---
+'@emotion/babel-plugin': patch
+'@emotion/css': patch
+'@emotion/native': patch
+'@emotion/primitives': patch
+'@emotion/react': patch
+'@emotion/styled': patch
+---
+
+Remove peer dependency on `@babel/core`

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -18,7 +18,6 @@
   ],
   "dependencies": {
     "@babel/helper-module-imports": "^7.16.7",
-    "@babel/plugin-syntax-jsx": "^7.17.12",
     "@babel/runtime": "^7.18.3",
     "@emotion/hash": "^0.9.0",
     "@emotion/memoize": "^0.8.0",
@@ -29,9 +28,6 @@
     "find-root": "^1.1.0",
     "source-map": "^0.5.7",
     "stylis": "4.1.3"
-  },
-  "peerDependencies": {
-    "@babel/core": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.5",

--- a/packages/babel-plugin/src/index.js
+++ b/packages/babel-plugin/src/index.js
@@ -1,5 +1,4 @@
 // @flow
-import syntaxJsx from '@babel/plugin-syntax-jsx'
 import {
   createEmotionMacro,
   transformers as vanillaTransformers
@@ -90,7 +89,21 @@ export default function (babel: *, options: *) {
   let t = babel.types
   return {
     name: '@emotion',
-    inherits: syntaxJsx,
+    // https://github.com/babel/babel/blob/0c97749e0fe8ad845b902e0b23a24b308b0bf05d/packages/babel-plugin-syntax-jsx/src/index.ts#L9-L18
+    manipulateOptions(opts, parserOpts) {
+      const { plugins } = parserOpts
+
+      if (
+        plugins.some(p => {
+          const plugin = Array.isArray(p) ? p[0] : p
+          return plugin === 'typescript' || plugin === 'jsx'
+        })
+      ) {
+        return
+      }
+
+      plugins.push('jsx')
+    },
     visitor: {
       ImportDeclaration(path: *, state: *) {
         const macro = state.pluginMacros[path.node.source.value]

--- a/packages/babel-plugin/src/index.js
+++ b/packages/babel-plugin/src/index.js
@@ -90,7 +90,7 @@ export default function (babel: *, options: *) {
   return {
     name: '@emotion',
     // https://github.com/babel/babel/blob/0c97749e0fe8ad845b902e0b23a24b308b0bf05d/packages/babel-plugin-syntax-jsx/src/index.ts#L9-L18
-    manipulateOptions(opts, parserOpts) {
+    manipulateOptions(opts: *, parserOpts: *) {
       const { plugins } = parserOpts
 
       if (

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -24,16 +24,7 @@
     "@emotion/sheet": "^1.2.1",
     "@emotion/utils": "^1.2.0"
   },
-  "peerDependencies": {
-    "@babel/core": "^7.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@babel/core": {
-      "optional": true
-    }
-  },
   "devDependencies": {
-    "@babel/core": "^7.18.5",
     "@definitelytyped/dtslint": "0.0.112",
     "typescript": "^4.5.5"
   },

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -23,7 +23,6 @@
   ],
   "types": "types/index.d.ts",
   "devDependencies": {
-    "@babel/core": "^7.18.5",
     "@definitelytyped/dtslint": "0.0.112",
     "@types/react-native": "^0.63.2",
     "react": "16.14.0",
@@ -34,13 +33,7 @@
     "@emotion/primitives-core": "^11.10.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0",
     "react-native": ">=0.14.0 <1"
-  },
-  "peerDependenciesMeta": {
-    "@babel/core": {
-      "optional": true
-    }
   },
   "homepage": "https://emotion.sh",
   "license": "MIT",

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -14,17 +14,10 @@
     "@emotion/primitives-core": "^11.10.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0",
     "react": ">=16.8.0",
     "react-primitives": "^0.8.1"
   },
-  "peerDependenciesMeta": {
-    "@babel/core": {
-      "optional": true
-    }
-  },
   "devDependencies": {
-    "@babel/core": "^7.18.5",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.5",
     "react": "16.14.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -72,19 +72,14 @@
     "hoist-non-react-statics": "^3.3.1"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0",
     "react": ">=16.8.0"
   },
   "peerDependenciesMeta": {
-    "@babel/core": {
-      "optional": true
-    },
     "@types/react": {
       "optional": true
     }
   },
   "devDependencies": {
-    "@babel/core": "^7.18.5",
     "@definitelytyped/dtslint": "0.0.112",
     "@emotion/css": "11.10.5",
     "@emotion/css-prettifier": "1.1.1",

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -19,20 +19,15 @@
     "@emotion/utils": "^1.2.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0",
     "@emotion/react": "^11.0.0-rc.0",
     "react": ">=16.8.0"
   },
   "peerDependenciesMeta": {
-    "@babel/core": {
-      "optional": true
-    },
     "@types/react": {
       "optional": true
     }
   },
   "devDependencies": {
-    "@babel/core": "^7.18.5",
     "@definitelytyped/dtslint": "0.0.112",
     "@emotion/react": "11.10.5",
     "react": "16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2350,7 +2350,6 @@ __metadata:
   dependencies:
     "@babel/core": ^7.18.5
     "@babel/helper-module-imports": ^7.16.7
-    "@babel/plugin-syntax-jsx": ^7.17.12
     "@babel/runtime": ^7.18.3
     "@emotion/hash": ^0.9.0
     "@emotion/memoize": ^0.8.0
@@ -2362,8 +2361,6 @@ __metadata:
     find-root: ^1.1.0
     source-map: ^0.5.7
     stylis: 4.1.3
-  peerDependencies:
-    "@babel/core": ^7.0.0
   languageName: unknown
   linkType: soft
 
@@ -2409,7 +2406,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@emotion/css@workspace:packages/css"
   dependencies:
-    "@babel/core": ^7.18.5
     "@definitelytyped/dtslint": 0.0.112
     "@emotion/babel-plugin": ^11.10.5
     "@emotion/cache": ^11.10.5
@@ -2417,11 +2413,6 @@ __metadata:
     "@emotion/sheet": ^1.2.1
     "@emotion/utils": ^1.2.0
     typescript: ^4.5.5
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  peerDependenciesMeta:
-    "@babel/core":
-      optional: true
   languageName: unknown
   linkType: soft
 
@@ -2519,7 +2510,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@emotion/native@workspace:packages/native"
   dependencies:
-    "@babel/core": ^7.18.5
     "@definitelytyped/dtslint": 0.0.112
     "@emotion/primitives-core": ^11.10.0
     "@types/react-native": ^0.63.2
@@ -2527,11 +2517,7 @@ __metadata:
     react-native: ^0.63.2
     typescript: ^4.5.5
   peerDependencies:
-    "@babel/core": ^7.0.0
     react-native: ">=0.14.0 <1"
-  peerDependenciesMeta:
-    "@babel/core":
-      optional: true
   languageName: unknown
   linkType: soft
 
@@ -2552,7 +2538,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@emotion/primitives@workspace:packages/primitives"
   dependencies:
-    "@babel/core": ^7.18.5
     "@emotion/babel-plugin": ^11.10.0
     "@emotion/is-prop-valid": ^1.2.0
     "@emotion/primitives-core": ^11.10.0
@@ -2561,12 +2546,8 @@ __metadata:
     react: 16.14.0
     react-primitives: ^0.8.1
   peerDependencies:
-    "@babel/core": ^7.0.0
     react: ">=16.8.0"
     react-primitives: ^0.8.1
-  peerDependenciesMeta:
-    "@babel/core":
-      optional: true
   languageName: unknown
   linkType: soft
 
@@ -2574,7 +2555,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@emotion/react@workspace:packages/react"
   dependencies:
-    "@babel/core": ^7.18.5
     "@babel/runtime": ^7.18.3
     "@definitelytyped/dtslint": 0.0.112
     "@emotion/babel-plugin": ^11.10.5
@@ -2593,11 +2573,8 @@ __metadata:
     svg-tag-names: ^1.1.1
     typescript: ^4.5.5
   peerDependencies:
-    "@babel/core": ^7.0.0
     react: ">=16.8.0"
   peerDependenciesMeta:
-    "@babel/core":
-      optional: true
     "@types/react":
       optional: true
   languageName: unknown
@@ -2652,7 +2629,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@emotion/styled@workspace:packages/styled"
   dependencies:
-    "@babel/core": ^7.18.5
     "@babel/runtime": ^7.18.3
     "@definitelytyped/dtslint": 0.0.112
     "@emotion/babel-plugin": ^11.10.5
@@ -2664,12 +2640,9 @@ __metadata:
     react: 16.14.0
     typescript: ^4.5.5
   peerDependencies:
-    "@babel/core": ^7.0.0
     "@emotion/react": ^11.0.0-rc.0
     react: ">=16.8.0"
   peerDependenciesMeta:
-    "@babel/core":
-      optional: true
     "@types/react":
       optional: true
   languageName: unknown


### PR DESCRIPTION
Closes #2921
Closes #2660

So the only reason there is a peer dependency on `@babel/core` is because of `@babel/plugin-syntax-jsx`. I don't really think doing we even need to make `@emotion/babel-plugin` inherit `@babel/plugin-syntax-jsx` tbh since the only case it would matter is if people were running `@emotion/babel-plugin` without a JSX transform but just to not change the behaviour, I've inlined `@babel/plugin-syntax-jsx`. I think the cost of inlining it is more than worth it for getting rid of a peer dependency warning for most users. 