### PR TITLE
bug: Nested self enclosed styled component throws error with shallow render

### DIFF
--- a/packages/jest/src/create-enzyme-serializer.js
+++ b/packages/jest/src/create-enzyme-serializer.js
@@ -15,7 +15,7 @@ const enzymeToJsonSerializer = createEnzymeToJsonSerializer({
       return json
     }
     const isRealStyled = json.node.type.__emotion_real === json.node.type
-    if (isRealStyled) {
+    if (isRealStyled && json.children) {
       return {
         ...json,
         children: json.children.slice(-1)

--- a/packages/jest/test/__snapshots__/react-enzyme.test.js.snap
+++ b/packages/jest/test/__snapshots__/react-enzyme.test.js.snap
@@ -151,6 +151,20 @@ exports[`enzyme mount nested displayName 1`] = `
 </div>
 `;
 
+exports[`enzyme mount nested self-enclosed styled 1`] = `
+.emotion-0 {
+  background-color: blue;
+}
+
+<div>
+  <Greeting>
+    <div
+      className="emotion-0 emotion-1"
+    />
+  </Greeting>
+</div>
+`;
+
 exports[`enzyme mount nested styled 1`] = `
 .emotion-0 {
   background-color: red;

--- a/packages/jest/test/__snapshots__/react-enzyme.test.js.snap
+++ b/packages/jest/test/__snapshots__/react-enzyme.test.js.snap
@@ -611,6 +611,12 @@ exports[`enzyme shallow nested displayName 1`] = `
 </div>
 `;
 
+exports[`enzyme shallow nested self-enclosed styled 1`] = `
+<div>
+  <Greeting />
+</div>
+`;
+
 exports[`enzyme shallow nested styled 1`] = `
 <div>
   <Greeting>

--- a/packages/jest/test/react-enzyme.test.js
+++ b/packages/jest/test/react-enzyme.test.js
@@ -348,6 +348,18 @@ const cases = {
         </ul>
       )
     }
+  },
+  'nested self-enclosed styled': {
+    render() {
+      const Greeting = styled.div`
+        background-color: blue;
+      `
+      return (
+        <div>
+          <Greeting />
+        </div>
+      )
+    }
   }
 }
 


### PR DESCRIPTION
**What**:

We encountered an issue after upgrading to `@emotion/jest` v11.10.6. We were getting the following error:
```
Cannot read properties of null (reading 'slice')
TypeError: Cannot read properties of null (reading 'slice')
    at Object.map (.../node_modules/@emotion/jest/dist/create-enzyme-serializer-4de3b073.cjs.dev.js:17:33)
    at applyMap (.../node_modules/enzyme-to-json/utils.js:45:20)
    at internalNodeToJson (.../node_modules/enzyme-to-json/shallow.js:57:36)
```
I tried debugging the error and found that it is thrown in a very specific case when there is a self-enclosed styled component nested under another element.

**Why**:

I'm not entirely sure if this is an error related to `@emotion/jest` or `enzyme-to-json` packages but I'm providing this PR as a proof of concept and a way to recreate the bug.
I also provided a simple fix to point out where the error is thrown.

**How**:

In order to reproduce:
1. Create a component with a nested self-enclosed styled component
2. Use `shallow` from `enzyme`
3. run a snapshot test

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
