### PR TITLE
Added shadow-opacity to the unitless keys list 

### DIFF
--- a/.changeset/stupid-owls-confess.md
+++ b/.changeset/stupid-owls-confess.md
@@ -1,0 +1,5 @@
+---
+"@emotion/unitless": patch
+---
+
+Add shadow-opacity as a unitless property

--- a/packages/unitless/src/index.js
+++ b/packages/unitless/src/index.js
@@ -38,8 +38,10 @@ let unitlessKeys: { [key: string]: 1 } = {
   zIndex: 1,
   zoom: 1,
   WebkitLineClamp: 1,
+  
 
   // SVG-related properties
+  shadowOpacity: 1 , 
   fillOpacity: 1,
   floodOpacity: 1,
   stopOpacity: 1,

--- a/packages/unitless/src/index.js
+++ b/packages/unitless/src/index.js
@@ -39,7 +39,7 @@ let unitlessKeys: { [key: string]: 1 } = {
   zoom: 1,
   WebkitLineClamp: 1,
   // SVG-related properties
-  shadowOpacity: 1, 
+  shadowOpacity: 1,
   fillOpacity: 1,
   floodOpacity: 1,
   stopOpacity: 1,

--- a/packages/unitless/src/index.js
+++ b/packages/unitless/src/index.js
@@ -38,10 +38,8 @@ let unitlessKeys: { [key: string]: 1 } = {
   zIndex: 1,
   zoom: 1,
   WebkitLineClamp: 1,
-  
-
   // SVG-related properties
-  shadowOpacity: 1 , 
+  shadowOpacity: 1, 
   fillOpacity: 1,
   floodOpacity: 1,
   stopOpacity: 1,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**This adds the key shadow-opacity to the unitless keys list , previously it was not there and whenever the @emotion/unitless is used it shows a warning expecting some unit like px etc .**

<!-- Why are these changes necessary? -->



<!-- How were these changes implemented? -->


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Code complete
- [N/A] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
