### PR TITLE
Make classNames's cx support obj.toString()

### DIFF
--- a/packages/react/__tests__/__snapshots__/class-names.js.snap
+++ b/packages/react/__tests__/__snapshots__/class-names.js.snap
@@ -30,3 +30,14 @@ exports[`should get the theme 1`] = `
   className="emotion-0"
 />
 `;
+
+exports[`should use toString() of object 1`] = `
+.emotion-0 {
+  color: hotpink;
+  color: green;
+}
+
+<div
+  className="some-other-class emotion-0"
+/>
+`;

--- a/packages/react/__tests__/class-names.js
+++ b/packages/react/__tests__/class-names.js
@@ -64,6 +64,33 @@ test('cx', () => {
   expect(tree.toJSON()).toMatchSnapshot()
 })
 
+test('should use toString() of object', () => {
+  const tree = renderer.create(
+    <ClassNames>
+      {({ css, cx }) => {
+        let secondClassButItsInsertedFirst = css`
+          color: green;
+        `
+        let firstClassButItsInsertedSecond = css`
+          color: hotpink;
+        `
+
+        return (
+          <div
+            className={cx(
+              firstClassButItsInsertedSecond,
+              { toString: () => 'some-other-class' },
+              secondClassButItsInsertedFirst
+            )}
+          />
+        )
+      }}
+    </ClassNames>
+  )
+
+  expect(tree.toJSON()).toMatchSnapshot()
+})
+
 test('css and cx throws when used after render', () => {
   let cx, css
   renderer.create(

--- a/packages/react/src/class-names.js
+++ b/packages/react/src/class-names.js
@@ -14,7 +14,7 @@ import { isBrowser } from './utils'
 type ClassNameArg =
   | string
   | boolean
-  | { [key: string]: boolean }
+  | { [key: string]: boolean | (() => string) }
   | Array<ClassNameArg>
   | null
   | void
@@ -46,10 +46,18 @@ let classnames = (args: Array<ClassNameArg>): string => {
             )
           }
           toAdd = ''
-          for (const k in arg) {
-            if (arg[k] && k) {
-              toAdd && (toAdd += ' ')
-              toAdd += k
+
+          if (
+            arg.toString !== Object.prototype.toString &&
+            !arg.toString.toString().includes('[native code]')
+          ) {
+            toAdd += arg.toString()
+          } else {
+            for (const k in arg) {
+              if (arg[k] && k) {
+                toAdd && (toAdd += ' ')
+                toAdd += k
+              }
             }
           }
         }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

The PR updates classNames' cx function to make it accept `object.toString()`.

<!-- Why are these changes necessary? -->

**Why**:

Example:
```
const obj = {
  toString: function () {
    return 'css-class';
  },
};

<ClassNames>
  {({ css, cx }) => {
    return (
      <div
        className={cx(
          css`
            color: green;
          `,
          obj
        )}
      />
    )
  }}
</ClassNames>
```

The rendered html of above component is expected to be `<div class="css-class emotion-0" />`. It is currently `<div class="emotion-0" />` on `main` branch.

<!-- How were these changes implemented? -->

**How**:

This PR adds additional check to see if obj.toString exists. The code is mostly copied from [classnames](https://github.com/JedWatson/classnames/blob/main/index.js#L32), which is widely used to join class names.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
