### PR TITLE
Support JSX.ElementType

### DIFF
--- a/.changeset/wicked-boxes-lick.md
+++ b/.changeset/wicked-boxes-lick.md
@@ -1,0 +1,5 @@
+---
+"@emotion/react": patch
+---
+
+Added `ElementType` to the Emotion's `JSX` namespace. It's defined in the same way as the one in `@types/react` and should make it possible to use components that return `string`s, `Promise`s and other types that are valid in React.

--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -96,6 +96,7 @@ export function ClassNames(props: ClassNamesProps): ReactElement
 export const jsx: typeof createElement
 export namespace jsx {
   namespace JSX {
+    type ElementType = EmotionJSX.ElementType
     interface Element extends EmotionJSX.Element {}
     interface ElementClass extends EmotionJSX.ElementClass {}
     interface ElementAttributesProperty

--- a/packages/react/types/jsx-namespace.d.ts
+++ b/packages/react/types/jsx-namespace.d.ts
@@ -18,7 +18,12 @@ type ReactJSXIntrinsicAttributes = JSX.IntrinsicAttributes
 type ReactJSXIntrinsicClassAttributes<T> = JSX.IntrinsicClassAttributes<T>
 type ReactJSXIntrinsicElements = JSX.IntrinsicElements
 
+// based on the code from @types/react@18.2.8
+// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3197efc097d522c4bf02b94e1a0766d007d6cdeb/types/react/index.d.ts#LL3204C13-L3204C13
+type ReactJSXElementType = string | React.JSXElementConstructor<any>
+
 export namespace EmotionJSX {
+  type ElementType = ReactJSXElementType
   interface Element extends ReactJSXElement {}
   interface ElementClass extends ReactJSXElementClass {}
   interface ElementAttributesProperty

--- a/packages/react/types/tests.tsx
+++ b/packages/react/types/tests.tsx
@@ -245,19 +245,3 @@ const anim1 = keyframes`
       ? true
       : false
 }
-
-// RMWC-like component test
-declare const OtherComponent: {
-  <Tag extends React.ElementType>(
-    props:
-      | React.AllHTMLAttributes<HTMLInputElement>
-      | React.ComponentPropsWithRef<Tag>,
-    ref: any
-  ): JSX.Element
-  displayName?: string
-}
-;<OtherComponent
-  onChange={ev => {
-    console.log(ev.currentTarget.value)
-  }}
-/>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Support for JSX.ElementType that introduced in [TypeScript 5.1](https://devblogs.microsoft.com/typescript/announcing-typescript-5-1/#decoupled-type-checking-between-jsx-elements-and-jsx-tag-types)

**Why**:

<!-- How were these changes implemented? -->
Until now, JSX type checking was provided by checking as JSX.Element.
From TypeScript 5.1 onward, by declaring JSX.ElementType, it will be possible to more flexibly check elements that can be handled on the jsx runtime side.

In React, this allows ReactNode to be used directly in the return value of function components. We would like to do the same for `@emotion/react/jsx-runtime`.

**How**:

In `@types/react`, JSX.ElementType has been declared since [18.2.8](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135), and I have copied the definition from the 18.2.8. because I don't know how to handle the `@types/react` version in emotion.  
If you don't mind updating `@types/react`, I can change it to use `React.JSX.ElementType` directly after updating!

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->

closes https://github.com/emotion-js/emotion/issues/3049