### PR TITLE
Fix compat with @types/react@18.2.8

### DIFF
--- a/packages/react/types/index.d.ts
+++ b/packages/react/types/index.d.ts
@@ -96,6 +96,7 @@ export function ClassNames(props: ClassNamesProps): ReactElement
 export const jsx: typeof createElement
 export namespace jsx {
   namespace JSX {
+    type ElementType = EmotionJSX.ElementType
     interface Element extends EmotionJSX.Element {}
     interface ElementClass extends EmotionJSX.ElementClass {}
     interface ElementAttributesProperty

--- a/packages/react/types/jsx-namespace.d.ts
+++ b/packages/react/types/jsx-namespace.d.ts
@@ -20,7 +20,7 @@ type ReactJSXIntrinsicClassAttributes<T> = JSX.IntrinsicClassAttributes<T>
 type ReactJSXIntrinsicElements = JSX.IntrinsicElements
 
 export namespace EmotionJSX {
-  type ElementType = ReactJSXElementType;
+  type ElementType = ReactJSXElementType
   interface Element extends ReactJSXElement {}
   interface ElementClass extends ReactJSXElementClass {}
   interface ElementAttributesProperty

--- a/packages/react/types/jsx-namespace.d.ts
+++ b/packages/react/types/jsx-namespace.d.ts
@@ -9,6 +9,7 @@ type WithConditionalCSSProp<P> = 'className' extends keyof P
   : {}
 
 // unpack all here to avoid infinite self-referencing when defining our own JSX namespace
+type ReactJSXElementType = JSX.ElementType
 type ReactJSXElement = JSX.Element
 type ReactJSXElementClass = JSX.ElementClass
 type ReactJSXElementAttributesProperty = JSX.ElementAttributesProperty
@@ -19,6 +20,7 @@ type ReactJSXIntrinsicClassAttributes<T> = JSX.IntrinsicClassAttributes<T>
 type ReactJSXIntrinsicElements = JSX.IntrinsicElements
 
 export namespace EmotionJSX {
+  type ElementType = ReactJSXElementType;
   interface Element extends ReactJSXElement {}
   interface ElementClass extends ReactJSXElementClass {}
   interface ElementAttributesProperty


### PR DESCRIPTION
Closes #3049

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What** and **Why**: See #3049

<!-- Why are these changes necessary? -->

**How**:

<!-- Have you done all of these things?  -->

Copies the `ElementType` type from `React.JSX` to the Emotion types in the JSX runtime

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
