### PR TITLE
Fix `@emotion/css/create-instance` types in TypeScript module resolution modes that support the `exports` field

### DIFF
--- a/.changeset/curly-worms-beam.md
+++ b/.changeset/curly-worms-beam.md
@@ -1,0 +1,5 @@
+---
+'@emotion/css': patch
+---
+
+Fix `@emotion/css/create-instance` types in TypeScript module resolution modes that support the `exports` field

--- a/packages/css/src/create-instance.d.ts
+++ b/packages/css/src/create-instance.d.ts
@@ -1,2 +1,2 @@
-export * from '../types'
-export { default } from '../types'
+export * from '../types/create-instance'
+export { default } from '../types/create-instance'


### PR DESCRIPTION
Closes #3056