### PR TITLE
Add fetchpriority to props

### DIFF
--- a/.changeset/eighty-garlics-dance.md
+++ b/.changeset/eighty-garlics-dance.md
@@ -2,4 +2,8 @@
 "@emotion/is-prop-valid": patch
 ---
 
+
+author: @codejet
+author: @DustinBrett
+
 Adds `fetchpriority` and `fetchPriority` to the list of allowed props.

--- a/.changeset/eighty-garlics-dance.md
+++ b/.changeset/eighty-garlics-dance.md
@@ -1,0 +1,5 @@
+---
+"@emotion/is-prop-valid": patch
+---
+
+Adds `fetchpriority` and `fetchPriority` to the list of allowed props.

--- a/packages/is-prop-valid/src/props.js
+++ b/packages/is-prop-valid/src/props.js
@@ -73,6 +73,7 @@ const props = {
   encType: true,
   enterKeyHint: true,
   fetchpriority: true,
+  fetchPriority: true,
   form: true,
   formAction: true,
   formEncType: true,

--- a/packages/is-prop-valid/src/props.js
+++ b/packages/is-prop-valid/src/props.js
@@ -72,6 +72,7 @@ const props = {
   draggable: true,
   encType: true,
   enterKeyHint: true,
+  fetchpriority: true,
   form: true,
   formAction: true,
   formEncType: true,


### PR DESCRIPTION
**What**:

Adding the now standardized `fetchpriority` property to the valid props list. "Fetch Priority" is now included in the [HTML living standard](https://html.spec.whatwg.org/multipage/urls-and-fetching.html#fetch-priority-attributes). It's been in Chrome since [101](https://caniuse.com/?search=fetchpriority)-[102](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority#browser_compatibility) and is now coming to [Safari 17](https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes#Web-API).

**Why**:

This is a [useful property](https://web.dev/fetch-priority/) that I use throughout my site. In some places I am passing it to a styled component and because it uses emotions is-prop-valid check, I am getting a warning. I think this property will continue to grow in adoption and should be considered valid.

![image](https://github.com/emotion-js/emotion/assets/16656318/c20f7d7a-88a0-4589-a6dc-398b69fa4079)

**How**:

Added the lowercased property name to `packages\is-prop-valid\src\props.js`. Similar to what was done in the closed PR [#2748](https://github.com/emotion-js/emotion/pull/2748).

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Code complete N/A
- [ ] Changeset N/A