### PR TITLE
Remove path-parse 1.0.6 dependency

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -22830,14 +22830,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-parse@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "path-parse@npm:1.0.6"
-  checksum: 962a85dd384d68d469ec5ba4010df8f8f9b7e936ce603bbe3211476c5615feb3c2b1ca61211a78445fadc833f0b1a86ea6484c861035ec4ac93011ba9aff9a11
-  languageName: node
-  linkType: hard
-
-"path-parse@npm:^1.0.7":
+"path-parse@npm:^1.0.6, path-parse@npm:^1.0.7":
   version: 1.0.7
   resolution: "path-parse@npm:1.0.7"
   checksum: 49abf3d81115642938a8700ec580da6e830dde670be21893c62f4e10bd7dd4c3742ddc603fe24f898cba7eb0c6bc1777f8d9ac14185d34540c6d4d80cd9cae8a


### PR DESCRIPTION
**What**:
Remove path-parse 1.0.6 dependency.

**Why**:
Addresses #3095 (CVE-2021-23343).
<!-- How were these changes implemented? -->

**How**:
`yarn up path-parse --recursive`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

Regarding changesets - this is a new process for me. Can someone provide some guidance on how I can infer which of the packages were dependent on this one? It appears it's an indirect dependency of several packages via `resolve`