### PR TITLE
Do not use global cache for createCache() to avoid memory leaks

### DIFF
--- a/.changeset/pink-dancers-wash.md
+++ b/.changeset/pink-dancers-wash.md
@@ -1,0 +1,5 @@
+---
+'@emotion/cache': patch
+---
+
+Ensure that caches are not reused for different createCache calls

--- a/packages/cache/src/index.js
+++ b/packages/cache/src/index.js
@@ -32,18 +32,18 @@ export type Options = {
   insertionPoint?: HTMLElement
 }
 
-let getServerStylisCache = isBrowser
-  ? undefined
-  : weakMemoize(() =>
-      memoize(() => {
-        let cache = {}
-        return cache
-      })
-    )
-
 const defaultStylisPlugins = [prefixer]
 
 let createCache = (options: Options): EmotionCache => {
+  let getServerStylisCache = isBrowser
+    ? undefined
+    : weakMemoize(() =>
+        memoize(() => {
+          let cache = {}
+          return cache
+        })
+      )
+
   let key = options.key
 
   if (process.env.NODE_ENV !== 'production' && !key) {

--- a/packages/cache/src/index.js
+++ b/packages/cache/src/index.js
@@ -37,7 +37,7 @@ let getServerStylisCache = isBrowser
   : weakMemoize(() =>
       memoize(() => {
         let cache = {}
-        return name => cache[name]
+        return cache
       })
     )
 


### PR DESCRIPTION
**What**:

Currently `createCache()` seems to use a global cache that is reused even if you create multiple caches. In an SSR scenario this means that even if you [follow the recommendations to create a cache per render](https://emotion.sh/docs/ssr#extractcritical) you will end up having a shared cache. 
Also currently an [accessor function is returned from `getServerStylisCache`](https://github.com/emotion-js/emotion/blob/f3b268f7c52103979402da919c9c0dd3f9e0e189/packages/cache/src/index.js#L40)
But later it is just [used as if it would be an object](https://github.com/emotion-js/emotion/blob/f3b268f7c52103979402da919c9c0dd3f9e0e189/packages/cache/src/index.js#L199-L204)

**Why**:
I think the current approach can cause memory-leaks in bigger applications. Since we additionally just use the `serverStylisCache` as an object, I think the cached values will never be garbage collected. This causes issues in apps that have a lot of css and/or use a lot of dynamic styles.

**How**:
I want to change the return type of `getServerStylisCache` to a simple cache object. This is how it is already used. We could also try to use the `accessor` function. But I wouldn't know how to write to the cache then.

Also I want to move the call to `getServerStylisCache` inside the function body of `createCache`. This way we will get a new instance of the cache for every request.

I'm not sure how to add tests for this. And I'm also not sure if my assessment of what the current code is doing is correct. Maybe someone can help to shed some light on it.

**Checklist**:

- [x] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset
