### PR TITLE
fix: change the way we initialize isBrowser

### DIFF
--- a/packages/jest/src/utils.js
+++ b/packages/jest/src/utils.js
@@ -1,6 +1,6 @@
 // @flow
 
-const isBrowser = document => typeof document !== 'undefined'
+const isBrowser = () => typeof document !== 'undefined'
 
 function last(arr) {
   return arr.length > 0 ? arr[arr.length - 1] : undefined
@@ -260,7 +260,7 @@ export function getStylesFromClassNames(
 }
 
 export function getStyleElements(): Array<HTMLStyleElement> {
-  if (!isBrowser(document)) {
+  if (!isBrowser()) {
     throw new Error(
       'jest-emotion requires jsdom. See https://jestjs.io/docs/en/configuration#testenvironment-string for more information.'
     )

--- a/packages/jest/src/utils.js
+++ b/packages/jest/src/utils.js
@@ -1,6 +1,6 @@
 // @flow
 
-const isBrowser = (document) => typeof document !== 'undefined'
+const isBrowser = document => typeof document !== 'undefined'
 
 function last(arr) {
   return arr.length > 0 ? arr[arr.length - 1] : undefined

--- a/packages/jest/src/utils.js
+++ b/packages/jest/src/utils.js
@@ -1,6 +1,6 @@
 // @flow
 
-const isBrowser = typeof document !== 'undefined'
+const isBrowser = (document) => typeof document !== 'undefined'
 
 function last(arr) {
   return arr.length > 0 ? arr[arr.length - 1] : undefined
@@ -260,7 +260,7 @@ export function getStylesFromClassNames(
 }
 
 export function getStyleElements(): Array<HTMLStyleElement> {
-  if (!isBrowser) {
+  if (!isBrowser(document)) {
     throw new Error(
       'jest-emotion requires jsdom. See https://jestjs.io/docs/en/configuration#testenvironment-string for more information.'
     )


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Simple change of `isBrowser` from constant to a function that takes an input and validates it on runtime.

<!-- Why are these changes necessary? -->

**Why**:

Due to the fact that the project `jest/serializer` is checking the browser validity with `isBrowser` constant on initialization of jest doesn't give the flexibility to consumers to prepare that `document`. Therefore if we simply change the use to a function an pass `document` as a property it can verify it on runtime rather than initialization.

This is a known issue to all of the storybook community now with the new `test-runner` functionality which adds playwright under the hood

Issues:
[Storybook issue #1](https://github.com/storybookjs/test-runner/issues/281)
[Storybook issue #2](https://github.com/storybookjs/test-runner/issues/135)

<!-- How were these changes implemented? -->

**How**:

N/A

<!-- Have you done all of these things?  -->

**Checklist**:

I haven't touched the below items as the change doesn't affect any

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
