### PR TITLE
downgrade csstype

### DIFF
--- a/packages/serialize/package.json
+++ b/packages/serialize/package.json
@@ -18,7 +18,7 @@
     "@emotion/memoize": "^0.8.1",
     "@emotion/unitless": "^0.8.1",
     "@emotion/utils": "^1.2.1",
-    "csstype": "^3.0.2"
+    "csstype": "3.0.2 - 3.1.2"
   },
   "devDependencies": {
     "@definitelytyped/dtslint": "0.0.112",


### PR DESCRIPTION
<!--
Downgrades **ccsstype** version in **serialize** project
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Accept a range of versions between 3.0.2 and 3.1.1

**Why**:

https://github.com/emotion-js/emotion/issues/3136

**How**:

Put version od csstype into range

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
