### PR TITLE
put csstype version in range

### DIFF
--- a/.changeset/sharp-islands-unite.md
+++ b/.changeset/sharp-islands-unite.md
@@ -1,0 +1,5 @@
+---
+'@emotion/serialize': patch
+---
+
+put csstype version in range

--- a/packages/serialize/package.json
+++ b/packages/serialize/package.json
@@ -18,7 +18,7 @@
     "@emotion/memoize": "^0.8.1",
     "@emotion/unitless": "^0.8.1",
     "@emotion/utils": "^1.2.1",
-    "csstype": "^3.0.2"
+    "csstype": ">=3.0.2 <=3.1.2"
   },
   "devDependencies": {
     "@definitelytyped/dtslint": "0.0.112",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2589,7 +2589,7 @@ __metadata:
     "@emotion/memoize": ^0.8.1
     "@emotion/unitless": ^0.8.1
     "@emotion/utils": ^1.2.1
-    csstype: ^3.0.2
+    csstype: ">=3.0.2 <=3.1.2"
     typescript: ^4.5.5
   languageName: unknown
   linkType: soft
@@ -10503,6 +10503,13 @@ __metadata:
   dependencies:
     cssom: ~0.3.6
   checksum: 5f05e6fd2e3df0b44695c2f08b9ef38b011862b274e320665176467c0725e44a53e341bc4959a41176e83b66064ab786262e7380fd1cabeae6efee0d255bb4e3
+  languageName: node
+  linkType: hard
+
+"csstype@npm:>=3.0.2 <=3.1.2":
+  version: 3.1.2
+  resolution: "csstype@npm:3.1.2"
+  checksum: e1a52e6c25c1314d6beef5168da704ab29c5186b877c07d822bd0806717d9a265e8493a2e35ca7e68d0f5d472d43fac1cdce70fd79fd0853dff81f3028d857b5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR puts csstype allowed versions in the range >=3.0.2 <=3.1.2. Fixes https://github.com/emotion-js/emotion/issues/3136

**What**:
puts csstype allowed versions in the range >=3.0.2 <=3.1.2

**Why**:
https://github.com/emotion-js/emotion/issues/3136


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

