### PR TITLE
Change `Array` to `ReadonlyArray` in CSS type declarations

### DIFF
--- a/.changeset/warm-pugs-applaud.md
+++ b/.changeset/warm-pugs-applaud.md
@@ -1,0 +1,5 @@
+---
+'@emotion/serialize': patch
+---
+
+Replace arrays with readonly arrays in CSS type definitions, following changes in `csstype`

--- a/packages/react/types/tests-css.tsx
+++ b/packages/react/types/tests-css.tsx
@@ -32,8 +32,10 @@ css`
 // $ExpectError
 css(() => 'height: 300px;')
 
-// $ExpectError
 css`
   position: relative;
-  flexgrow: ${() => 20};
+  flexgrow: ${
+    // $ExpectError
+    () => 20
+  };
 `

--- a/packages/serialize/types/index.d.ts
+++ b/packages/serialize/types/index.d.ts
@@ -10,7 +10,7 @@ export type CSSProperties = CSS.PropertiesFallback<number | string>
 export type CSSPropertiesWithMultiValues = {
   [K in keyof CSSProperties]:
     | CSSProperties[K]
-    | Array<Extract<CSSProperties[K], string>>
+    | ReadonlyArray<Extract<CSSProperties[K], string>>
 }
 
 export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject }

--- a/packages/serialize/types/index.d.ts
+++ b/packages/serialize/types/index.d.ts
@@ -15,7 +15,8 @@ export type CSSPropertiesWithMultiValues = {
 
 export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject }
 
-export interface ArrayCSSInterpolation extends Array<CSSInterpolation> {}
+export interface ArrayCSSInterpolation
+  extends ReadonlyArray<CSSInterpolation> {}
 
 export type InterpolationPrimitive =
   | null

--- a/packages/serialize/types/tests.ts
+++ b/packages/serialize/types/tests.ts
@@ -48,8 +48,12 @@ serializeStyles({}, {})
 
 let cssObject: CSSObject = {
   fontWeight: 400,
+  background: ['red'],
+  otherProp: ['some-value'],
   ':hover': {
-    fontWeight: 700
+    fontWeight: 700,
+    background: ['red'] as const,
+    otherProp: ['some-value'] as const
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

`csstype@3.1.3` changed the type of multi-valued fallback CSS properties from `array` to `readonly array` - https://github.com/frenic/csstype/commit/46694defae2cf3386218d0000490b0d0ac385aa6. This merge request follows that change, retyping `ArrayCSSInterpolation` from `Array` to `ReadonlyArray`.

**Why**:

This change is created in response to issue #3136.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation (N/A)
- [x] Tests
- [x] Code complete
- [x] Changeset
