### PR TITLE
Use NODE_ENV to detect Jest or Vitest

### DIFF
--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -17,7 +17,10 @@ export { default as css } from './css'
 if (process.env.NODE_ENV !== 'production') {
   const isBrowser = typeof document !== 'undefined'
   // #1727, #2905 for some reason Jest and Vitest evaluate modules twice if some consuming module gets mocked
-  const isTestEnv = typeof jest !== 'undefined' || typeof vi !== 'undefined'
+  // Both Jest as well as Vitest set `process.env.NODE_ENV` to `'test'`, according to their docs.
+  // https://jestjs.io/docs/environment-variables#node_env
+  // https://vitest.dev/guide/migration.html#envs
+  const isTestEnv = process.env.NODE_ENV === 'test'
 
   if (isBrowser && !isTestEnv) {
     // globalThis has wide browser support - https://caniuse.com/?search=globalThis, Node.js 12 and later


### PR DESCRIPTION
**What**:

Currently, when `@emotion/react` is used in a Vitest environment that has `globals: false` (which is Vitest’s default), it emits the following warning when included more than once:

```
You are loading @emotion/react when it is already loaded. Running multiple instances may cause problems. This can happen if multiple versions are used, or if multiple builds of the same version are used.
```

This warning is suppressed in Jest environments and in Vitest environments that have `globals: true` by [checking for the presence of a global `jest` or `vi`, respectively][check-for-globals]. This test does not work, though, when `globals: false` because in that case, there is no global `vi`. (This was also [documented in the PR][diff-that-mentions-globals-in-vitest] that extended the check to also take `vi` into account, but the comment was modified for the final version of the PR that got merged.)

**Why**:

If I understand the existing code correctly, the warning is supposed to be suppressed irregardless of whether `globals: true` or `globals: false`.

**How**:

This PR changes the test to check for `process.env.NODE_ENV === 'test'` instead. According to the docs, this is a reliable way to detect both [Jest][jest-node-env] and [Vitest][vitest-node-env].

[The PR for Jest that introduced the check in its first form][pr-for-jest] has a [comment][comment-for-process-env-and-webpack] that voices concerns about accessing `process.env` when using Webpack as a bundler. Since the code surrounding the check uses `process.env.NODE_ENV !== 'production'` anyway, I felt it’s safe to use `NODE_ENV` when checking for a test environment.

**Checklist**:

I’m not entirely sure which of the checklist’s items apply to this PR and would greatly appreciate any guidance! I ticked off “Documentation” as I added a comment to the line I changed, but I don’t know whether that is sufficient.

- [x] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset

[check-for-globals]: https://github.com/emotion-js/emotion/blob/1c60314df1e53e6306f45439f0d19c793a8c1a5a/packages/react/src/index.js#L20

[jest-node-env]: https://jestjs.io/docs/environment-variables#node_env
[vitest-node-env]: https://vitest.dev/guide/migration.html#envs

[issue-for-jest]: https://github.com/emotion-js/emotion/issues/1727
[pr-for-jest]: https://github.com/emotion-js/emotion/pull/1806
[comment-for-process-env-and-webpack]: https://github.com/emotion-js/emotion/pull/1806#discussion_r392634058

[pr-for-vitest]: https://github.com/emotion-js/emotion/pull/2905
[diff-that-mentions-globals-in-vitest]: https://github.com/emotion-js/emotion/pull/2905/files/84ccf43f0ba1bc9c5d26082777b844a7afbe88d2#diff-7ada84ba8df639bded4a5f9f5d1c11a5d425609d6f54ded66262420853f0b0bc
