### PR TITLE
Support dynamic value

### DIFF
--- a/packages/serialize/src/index.js
+++ b/packages/serialize/src/index.js
@@ -239,7 +239,7 @@ function createStringFromObject(
   } else {
     for (let key in obj) {
       let value = obj[key]
-      if (typeof value === 'function') {
+      if (typeof value === 'function' && mergedProps !== undefined) {
         value = value(mergedProps)
       }
       if (typeof value !== 'object') {

--- a/packages/serialize/src/index.js
+++ b/packages/serialize/src/index.js
@@ -239,6 +239,9 @@ function createStringFromObject(
   } else {
     for (let key in obj) {
       let value = obj[key]
+      if (typeof value === 'function') {
+        value = value(mergedProps)
+      }
       if (typeof value !== 'object') {
         if (registered != null && registered[value] !== undefined) {
           string += `${key}{${registered[value]}}`

--- a/packages/serialize/types/index.d.ts
+++ b/packages/serialize/types/index.d.ts
@@ -7,18 +7,19 @@ import * as CSS from 'csstype'
 export { RegisteredCache, SerializedStyles }
 
 export type CSSProperties = CSS.PropertiesFallback<number | string>
-export type CSSPropertiesWithMultiValues = {
+export type CSSPropertiesWithMultiValues<Props> = {
   [K in keyof CSSProperties]:
     | CSSProperties[K]
     | ReadonlyArray<Extract<CSSProperties[K], string>>
+    | ((props: Props) => number | string)
 }
 
-export type CSSPseudos = { [K in CSS.Pseudos]?: CSSObject }
+export type CSSPseudos<Props> = { [K in CSS.Pseudos]?: CSSObject<Props> }
 
-export interface ArrayCSSInterpolation
-  extends ReadonlyArray<CSSInterpolation> {}
+export interface ArrayCSSInterpolation<Props>
+  extends ReadonlyArray<CSSInterpolation<Props>> {}
 
-export type InterpolationPrimitive =
+export type InterpolationPrimitive<Props> =
   | null
   | undefined
   | boolean
@@ -27,18 +28,22 @@ export type InterpolationPrimitive =
   | ComponentSelector
   | Keyframes
   | SerializedStyles
-  | CSSObject
+  | CSSObject<Props>
 
-export type CSSInterpolation = InterpolationPrimitive | ArrayCSSInterpolation
+export type CSSInterpolation<Props> =
+  | InterpolationPrimitive<Props>
+  | ArrayCSSInterpolation<Props>
 
-export interface CSSOthersObject {
-  [propertiesName: string]: CSSInterpolation
+export interface CSSOthersObject<Props> {
+  [propertiesName: string]:
+    | CSSInterpolation<Props>
+    | ((props: Props) => string | number)
 }
 
-export interface CSSObject
-  extends CSSPropertiesWithMultiValues,
-    CSSPseudos,
-    CSSOthersObject {}
+export interface CSSObject<Props = unknown>
+  extends CSSPropertiesWithMultiValues<Props>,
+    CSSPseudos<Props>,
+    CSSOthersObject<Props> {}
 
 export interface ComponentSelector {
   __emotion_styles: any
@@ -59,7 +64,7 @@ export interface FunctionInterpolation<Props> {
 }
 
 export type Interpolation<Props> =
-  | InterpolationPrimitive
+  | InterpolationPrimitive<Props>
   | ArrayInterpolation<Props>
   | FunctionInterpolation<Props>
 

--- a/packages/serialize/types/index.d.ts
+++ b/packages/serialize/types/index.d.ts
@@ -7,19 +7,21 @@ import * as CSS from 'csstype'
 export { RegisteredCache, SerializedStyles }
 
 export type CSSProperties = CSS.PropertiesFallback<number | string>
-export type CSSPropertiesWithMultiValues<Props> = {
+export type CSSPropertiesWithMultiValues<Props = unknown> = {
   [K in keyof CSSProperties]:
     | CSSProperties[K]
     | ReadonlyArray<Extract<CSSProperties[K], string>>
     | ((props: Props) => number | string)
 }
 
-export type CSSPseudos<Props> = { [K in CSS.Pseudos]?: CSSObject<Props> }
+export type CSSPseudos<Props = unknown> = {
+  [K in CSS.Pseudos]?: CSSObject<Props>
+}
 
-export interface ArrayCSSInterpolation<Props>
+export interface ArrayCSSInterpolation<Props = unknown>
   extends ReadonlyArray<CSSInterpolation<Props>> {}
 
-export type InterpolationPrimitive<Props> =
+export type InterpolationPrimitive<Props = unknown> =
   | null
   | undefined
   | boolean
@@ -30,11 +32,11 @@ export type InterpolationPrimitive<Props> =
   | SerializedStyles
   | CSSObject<Props>
 
-export type CSSInterpolation<Props> =
+export type CSSInterpolation<Props = unknown> =
   | InterpolationPrimitive<Props>
   | ArrayCSSInterpolation<Props>
 
-export interface CSSOthersObject<Props> {
+export interface CSSOthersObject<Props = unknown> {
   [propertiesName: string]:
     | CSSInterpolation<Props>
     | ((props: Props) => string | number)

--- a/packages/serialize/types/index.d.ts
+++ b/packages/serialize/types/index.d.ts
@@ -20,8 +20,8 @@ export type CSSPseudos<Props = unknown> = {
   [K in CSS.Pseudos]?: CSSObject<Props>
 }
 
-export interface ArrayCSSInterpolation<Props = unknown>
-  extends ReadonlyArray<CSSInterpolation<Props>> {}
+export interface ArrayCSSInterpolation
+  extends ReadonlyArray<CSSInterpolation> {}
 
 export type InterpolationPrimitive<Props = unknown> =
   | null
@@ -34,14 +34,17 @@ export type InterpolationPrimitive<Props = unknown> =
   | SerializedStyles
   | CSSObject<Props>
 
-export type CSSInterpolation<Props = unknown> =
-  | InterpolationPrimitive<Props>
-  | ArrayCSSInterpolation<Props>
+export type CSSInterpolation = InterpolationPrimitive | ArrayCSSInterpolation
 
 export interface CSSOthersObject<Props = unknown> {
   [propertiesName: string]:
-    | CSSInterpolation<Props>
-    | ((props: Props) => CSSInterpolation<Props>)
+    | InterpolationPrimitive<Props>
+    | ReadonlyArray<InterpolationPrimitive<Props>>
+    | ((
+        props: Props
+      ) =>
+        | InterpolationPrimitive<Props>
+        | ReadonlyArray<InterpolationPrimitive<Props>>)
 }
 
 export interface CSSObject<Props = unknown>

--- a/packages/serialize/types/index.d.ts
+++ b/packages/serialize/types/index.d.ts
@@ -39,7 +39,7 @@ export type CSSInterpolation<Props = unknown> =
 export interface CSSOthersObject<Props = unknown> {
   [propertiesName: string]:
     | CSSInterpolation<Props>
-    | ((props: Props) => string | number)
+    | ((props: Props) => number | string)
 }
 
 export interface CSSObject<Props = unknown>

--- a/packages/serialize/types/index.d.ts
+++ b/packages/serialize/types/index.d.ts
@@ -10,10 +10,8 @@ export type CSSProperties = CSS.PropertiesFallback<number | string>
 export type CSSPropertiesWithMultiValues<Props = unknown> = {
   [K in keyof CSSProperties]:
     | CSSProperties[K]
-    | ReadonlyArray<Extract<CSSProperties[K], string>>
-    | ((
-        props: Props
-      ) => CSSProperties[K] | ReadonlyArray<Extract<CSSProperties[K], string>>)
+    | ReadonlyArray<CSSProperties[K]>
+    | ((props: Props) => CSSProperties[K] | ReadonlyArray<CSSProperties[K]>)
 }
 
 export type CSSPseudos<Props = unknown> = {

--- a/packages/serialize/types/index.d.ts
+++ b/packages/serialize/types/index.d.ts
@@ -10,8 +10,10 @@ export type CSSProperties = CSS.PropertiesFallback<number | string>
 export type CSSPropertiesWithMultiValues<Props = unknown> = {
   [K in keyof CSSProperties]:
     | CSSProperties[K]
-    | ReadonlyArray<CSSProperties[K]>
-    | ((props: Props) => CSSProperties[K] | ReadonlyArray<CSSProperties[K]>)
+    | ReadonlyArray<CSSProperties[K] & string>
+    | ((
+        props: Props
+      ) => CSSProperties[K] | ReadonlyArray<CSSProperties[K] & string>)
 }
 
 export type CSSPseudos<Props = unknown> = {

--- a/packages/serialize/types/index.d.ts
+++ b/packages/serialize/types/index.d.ts
@@ -11,7 +11,9 @@ export type CSSPropertiesWithMultiValues<Props = unknown> = {
   [K in keyof CSSProperties]:
     | CSSProperties[K]
     | ReadonlyArray<Extract<CSSProperties[K], string>>
-    | ((props: Props) => number | string)
+    | ((
+        props: Props
+      ) => CSSProperties[K] | ReadonlyArray<Extract<CSSProperties[K], string>>)
 }
 
 export type CSSPseudos<Props = unknown> = {
@@ -39,7 +41,7 @@ export type CSSInterpolation<Props = unknown> =
 export interface CSSOthersObject<Props = unknown> {
   [propertiesName: string]:
     | CSSInterpolation<Props>
-    | ((props: Props) => number | string)
+    | ((props: Props) => CSSInterpolation<Props>)
 }
 
 export interface CSSObject<Props = unknown>

--- a/packages/serialize/types/tests.ts
+++ b/packages/serialize/types/tests.ts
@@ -37,6 +37,17 @@ serializeStyles(
   {}
 )
 // $ExpectType SerializedStyles
+serializeStyles<{ vars: { background: string; foreground: string } }>([
+  {
+    backgroundColor: ({ vars }) => vars.background,
+    color: ({ vars }) => vars.foreground,
+    '&:hover': {
+      backgroundColor: ({ vars }) => vars.foreground,
+      color: ({ vars }) => vars.background
+    }
+  }
+])
+// $ExpectType SerializedStyles
 serializeStyles([testTemplateStringsArray, 5, '4px'], {}, {})
 
 // $ExpectError

--- a/packages/serialize/types/tests.ts
+++ b/packages/serialize/types/tests.ts
@@ -39,9 +39,11 @@ serializeStyles(
 // $ExpectType SerializedStyles
 serializeStyles<{ vars: { background: string; foreground: string } }>([
   {
+    display: () => ['-webkit-flex', 'flex'],
     backgroundColor: ({ vars }) => vars.background,
     color: ({ vars }) => vars.foreground,
     lineHeight: ({ vars }) => 1.2,
+    '--css-var': ({ vars }) => vars.foreground,
     '&:hover': {
       backgroundColor: ({ vars }) => vars.foreground,
       color: ({ vars }) => vars.background

--- a/packages/serialize/types/tests.ts
+++ b/packages/serialize/types/tests.ts
@@ -37,13 +37,16 @@ serializeStyles(
   {}
 )
 // $ExpectType SerializedStyles
-serializeStyles<{ vars: { background: string; foreground: string } }>([
+serializeStyles<{
+  vars: { background: string; foreground: string; step: number }
+}>([
   {
     display: () => ['-webkit-flex', 'flex'],
     backgroundColor: ({ vars }) => vars.background,
     color: ({ vars }) => vars.foreground,
     lineHeight: ({ vars }) => 1.2,
-    '--css-var': ({ vars }) => vars.foreground,
+    '--spacing': () => 1,
+    '--step': ({ vars }) => `calc(${vars.step} * var(--spacing))`,
     '&:hover': {
       backgroundColor: ({ vars }) => vars.foreground,
       color: ({ vars }) => vars.background
@@ -57,6 +60,8 @@ serializeStyles([testTemplateStringsArray, 5, '4px'], {}, {})
 serializeStyles()
 // $ExpectError
 serializeStyles({})
+// $ExpectError
+serializeStyles([{ borderCollapse: () => 'unknown' }])
 // $ExpectError
 serializeStyles({}, {})
 

--- a/packages/serialize/types/tests.ts
+++ b/packages/serialize/types/tests.ts
@@ -41,6 +41,7 @@ serializeStyles<{ vars: { background: string; foreground: string } }>([
   {
     backgroundColor: ({ vars }) => vars.background,
     color: ({ vars }) => vars.foreground,
+    lineHeight: ({ vars }) => 1.2,
     '&:hover': {
       backgroundColor: ({ vars }) => vars.foreground,
       color: ({ vars }) => vars.background

--- a/packages/styled/__tests__/__snapshots__/styled.js.snap
+++ b/packages/styled/__tests__/__snapshots__/styled.js.snap
@@ -483,6 +483,18 @@ exports[`styled objects 1`] = `
 </h1>
 `;
 
+exports[`styled objects with dynamic value 1`] = `
+.emotion-0 {
+  padding: 0.5rem;
+}
+
+<h1
+  className="emotion-0"
+>
+  hello world
+</h1>
+`;
+
 exports[`styled objects with spread properties 1`] = `
 .emotion-0 {
   font-size: 20px;

--- a/packages/styled/__tests__/styled.js
+++ b/packages/styled/__tests__/styled.js
@@ -437,6 +437,13 @@ describe('styled', () => {
     expect(tree).toMatchSnapshot()
   })
 
+  test('objects with dynamic value', () => {
+    const H1 = styled('h1')({ padding: props => props.padding || '1rem' })
+    const tree = renderer.create(<H1 padding="0.5rem">hello world</H1>).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
   test('composing components', () => {
     const Button = styled.button`
       color: green;


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Add callback support for the value when serializing styles. For example:

```js
styled('div')({
  background: (props) => props.color || '#fff',
  '&:hover': {
    background: (props) => props.color || 'red',
  }
})
```

**Why**:

1. We ([MUI](https://github.com/mui/material-ui)) need emotion to have a consistent API with our new static CSS-in-JS library to let developers switch between engines.
2. styled-components already support the callback for the values so it's not new.

**How**:

The change is mainly in emotion's `serialize` function. When the value is a function, just call it with the props and continue serializing the result the same as before.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
