### PR TITLE
 Add -webkit-scrollbar pseudo-elements to ignored prefixes

### DIFF
--- a/.changeset/lovely-drinks-sort.md
+++ b/.changeset/lovely-drinks-sort.md
@@ -1,0 +1,5 @@
+---
+'@emotion/sheet': patch
+---
+
+Do not log failed rule insertions in the speedy mode for even more vendor-prefixed pseudo-elements/classes like `-webkit-scrollbar-button`, `-webkit-scrollbar-thumb` and `-webkit-scrollbar-track`.

--- a/packages/sheet/src/index.js
+++ b/packages/sheet/src/index.js
@@ -147,7 +147,7 @@ export class StyleSheet {
       } catch (e) {
         if (
           process.env.NODE_ENV !== 'production' &&
-          !/:(-moz-placeholder|-moz-focus-inner|-moz-focusring|-ms-input-placeholder|-moz-read-write|-moz-read-only|-ms-clear|-ms-expand|-ms-reveal){/.test(
+          !/:(-moz-placeholder|-moz-focus-inner|-moz-focusring|-ms-input-placeholder|-moz-read-write|-moz-read-only|-ms-clear|-ms-expand|-ms-reveal|-webkit-scrollbar-button:.*|-webkit-scrollbar-thumb:.*|-webkit-scrollbar-track:.*){/.test(
             rule
           )
         ) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Adds `-webkit-scrollbar-button`, `-webkit-scrollbar-thumb` and `webkit-scrollbar-track` to ignored vendor prefixes, similar to https://github.com/emotion-js/emotion/pull/2920, https://github.com/emotion-js/emotion/pull/2393 and https://github.com/emotion-js/emotion/pull/2149. Fixes https://github.com/emotion-js/emotion/issues/3111.

<!-- Why are these changes necessary? -->

**Why**:

These errors appear in non-webkit-browsers (Firefox) when using these webkit specific pseudo-elements. 

These are only the ones we specifically use, I don't know if we want to add a more comprehensive list, or perhaps do a filter like `:(-webkit-:.*|-moz-.*|-ms-.*){` (though that may risk introducing false positives?)?

<!-- How were these changes implemented? -->

**How**:

The existing regex was extended.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation (N/A ; there does not seem to exist any documentation on this)
- [ ] Tests (N/A ; there seem to be no existing tests for this, and I'm not sure how to properly test this in the first place. I've manually tested this in Firefox)
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
