### PR TITLE
Fix typos in the css-prop.mdx

### DIFF
--- a/docs/css-prop.mdx
+++ b/docs/css-prop.mdx
@@ -241,8 +241,8 @@ The styles are concatenated together and inserted via `insertRule`.
 
 ```css
 .css-2 {
-  font-size: 14px,
-  font-family: Georgia, serif,
+  font-size: 14px;
+  font-family: Georgia, serif;
   color: darkgray;
 }
 ```
@@ -264,8 +264,8 @@ The styles are concatenated together and inserted via `insertRule`.
 + line-height: 1.5;
 - font-family: 'sans-serif';
 - color: black;
-- font-size: 14px,
-+ font-family: Georgia, serif,
+- font-size: 14px;
++ font-family: Georgia, serif;
 + color: darkgray;
 + font-size: 10px;
 }


### PR DESCRIPTION
I was going through the official documentation and found some small typos in the `css-prop.mdx` file.

**What**: Fix small typos in the `css-prop.mdx`

<!-- Why are these changes necessary? -->

**Why**: The typos are small and easy to fix.

<!-- How were these changes implemented? -->

**How**: Fixing the typos in the `css-prop.mdx` file.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->
