### PR TITLE
Fix mismatch between CSSInterpolation and Interpolation<Props>

### DIFF
--- a/.changeset/curly-planets-search.md
+++ b/.changeset/curly-planets-search.md
@@ -1,7 +1,5 @@
 ---
-'@emotion/react': patch
 '@emotion/serialize': patch
-'@emotion/styled': patch
 ---
 
-Fix types mismatch between CSS interpolations and styled component creator functions
+Make `ArrayInterpolation` to extend `ReadonlyArray` to match a similar recent change to `ArrayCSSInterpolation`. It fixes some compatibility issues when those 2 get mixed together.

--- a/.changeset/curly-planets-search.md
+++ b/.changeset/curly-planets-search.md
@@ -1,0 +1,7 @@
+---
+'@emotion/react': patch
+'@emotion/serialize': patch
+'@emotion/styled': patch
+---
+
+Fix types mismatch between CSS interpolations and styled component creator functions

--- a/.changeset/tiny-snails-watch.md
+++ b/.changeset/tiny-snails-watch.md
@@ -1,0 +1,5 @@
+---
+"@emotion/styled": patch
+---
+
+Reordered `styled` overloads to accommodate the recent change in `@emotion/serialize`'s types.

--- a/packages/react/types/tests.tsx
+++ b/packages/react/types/tests.tsx
@@ -9,6 +9,7 @@ import {
   withEmotionCache
 } from '@emotion/react'
 import { JSX as EmotionJSX } from '@emotion/react/jsx-runtime'
+import { CSSInterpolation } from '@emotion/serialize'
 
 declare module '@emotion/react' {
   // tslint:disable-next-line: strict-export-declare-modifiers
@@ -22,6 +23,9 @@ declare module '@emotion/react' {
 
 ;<Global styles={[]} />
 ;<Global styles={theme => [theme.primaryColor]} />
+
+declare const getStyles: () => CSSInterpolation
+;<Global styles={getStyles()} />
 
 declare const getRandomColor: () => string
 

--- a/packages/serialize/types/index.d.ts
+++ b/packages/serialize/types/index.d.ts
@@ -52,7 +52,7 @@ export type Keyframes = {
 } & string
 
 export interface ArrayInterpolation<Props>
-  extends Array<Interpolation<Props>> {}
+  extends ReadonlyArray<Interpolation<Props>> {}
 
 export interface FunctionInterpolation<Props> {
   (props: Props): Interpolation<Props>

--- a/packages/styled/types/base.d.ts
+++ b/packages/styled/types/base.d.ts
@@ -63,10 +63,18 @@ export interface CreateStyledComponent<
   SpecificComponentProps extends {} = {},
   JSXProps extends {} = {}
 > {
+  (
+    template: TemplateStringsArray,
+    ...styles: Array<
+      Interpolation<ComponentProps & SpecificComponentProps & { theme: Theme }>
+    >
+  ): StyledComponent<ComponentProps, SpecificComponentProps, JSXProps>
+
   /**
    * @typeparam AdditionalProps  Additional props to add to your styled component
    */
-  <AdditionalProps extends {} = {}>(
+  <AdditionalProps extends {}>(
+    template: TemplateStringsArray,
     ...styles: Array<
       Interpolation<
         ComponentProps &
@@ -80,18 +88,10 @@ export interface CreateStyledComponent<
     JSXProps
   >
 
-  (
-    template: TemplateStringsArray,
-    ...styles: Array<
-      Interpolation<ComponentProps & SpecificComponentProps & { theme: Theme }>
-    >
-  ): StyledComponent<ComponentProps, SpecificComponentProps, JSXProps>
-
   /**
    * @typeparam AdditionalProps  Additional props to add to your styled component
    */
-  <AdditionalProps extends {}>(
-    template: TemplateStringsArray,
+  <AdditionalProps extends {} = {}>(
     ...styles: Array<
       Interpolation<
         ComponentProps &


### PR DESCRIPTION
**What**:

Eliminated types mismatch between `CSSInterpolation` (related to `csstypes`) and `Interpolation<Props>` (related to `emotion`'s own styled components machinery), which prevented the former from being used as the latter.

**Why**:

This fixes #3145.

**How**:

This required two different changes:
* Change type of `ArrayInterpolation`. Since it's expected that every interpolated value is treated by `emotion` as immutable, this change is correct, and it fixes the mismatch. At the same time, it breaks type inference on styled component creator functions, which required a second change.
* Change order of overloads for `styled.X` functions. The idea is that we want to use "template string tag" overload wherever possible and fall back to another one only for the explicit function calls. Previously, these two overloads were independent and the order didn't matter, but now, as every valid `TemplateStringsArray` is also a valid `ArrayInterpolation`, we need to explicitly prioritize the "template string tag" case.

**Checklist**:

- [ ] Documentation (N/A)
- [x] Tests
- [x] Code complete
- [x] Changeset