### PR TITLE
Fix TypeScript error with function interpolations

### DIFF
--- a/.changeset/thin-bears-talk.md
+++ b/.changeset/thin-bears-talk.md
@@ -1,0 +1,5 @@
+---
+'@emotion/styled': patch
+---
+
+Fix incorrectly inferred types when using function interpolations

--- a/packages/styled/types/base.d.ts
+++ b/packages/styled/types/base.d.ts
@@ -63,6 +63,16 @@ export interface CreateStyledComponent<
   SpecificComponentProps extends {} = {},
   JSXProps extends {} = {}
 > {
+  // This signature is actually never taken (due to `marker: never`); it's here to guide type inference.
+  // See https://github.com/emotion-js/emotion/issues/3174 for context.
+  (
+    ...styles: Array<
+      Interpolation<
+        ComponentProps & SpecificComponentProps & { theme: Theme }
+      > & { marker: never }
+    >
+  ): StyledComponent<ComponentProps, SpecificComponentProps, JSXProps>
+
   (
     template: TemplateStringsArray,
     ...styles: Array<

--- a/packages/styled/types/tests.tsx
+++ b/packages/styled/types/tests.tsx
@@ -301,3 +301,32 @@ const Input5 = styled.input`
   // $ExpectError
   styled('div', { shouldForwardProp: (prop: 'foo') => true })({})
 }
+
+{
+  // Different ways to provide props to styled components
+
+  styled.div`
+    textAlign: ${'center'},
+    position: ${'relative'},
+  `
+
+  styled.div({
+    textAlign: `center`,
+    position: `relative`
+  })
+
+  styled.div(() => ({
+    textAlign: `center`,
+    position: `relative`
+  }))
+
+  styled('div')({
+    textAlign: `center`,
+    position: `relative`
+  })
+
+  styled('div')(() => ({
+    textAlign: `center`,
+    position: `relative`
+  }))
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

After recent change to CSSTypes (#3141, #3164), some uses of styled components, namely the ones which provided a function interpolation, started to fail to typecheck. This adds a couple of tests for these use-cases and a corresponding fix.

<!-- Why are these changes necessary? -->

**Why**:

This fixes #3174.

<!-- How were these changes implemented? -->

**How**:

As hinted on by @Andarist, the reason for the bug is that TypeScript caches the inference data from the failed overloads, even if this forces otherwise-matching ones to fail too. Therefore, the fix is to add "dummy" overload, never taken due to having a `never`-typed field in it, to guide type inference correctly.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation (N/A)
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
