### PR TITLE
Add option `explicitAmpersand` on @emotion/cache to handle :is and :where, etc

### DIFF
--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -60,3 +60,37 @@ A DOM node that emotion will insert all of its style tags into. This is useful f
 `boolean`
 
 A boolean representing whether to prepend rather than append style tags into the specified container DOM node.
+
+### `explicitAmpersand`
+
+`boolean`
+
+Defaults to `false`. Opt-out of automatic pseudo class prefixing.
+
+Consider the following component:
+
+```jsx
+<article
+  css={css`
+    :where([data-theme='dark']) & {
+      /* ... */
+    }
+  `}
+/>
+```
+
+With `explicitAmpersand` set to `true`:
+
+```css
+:where([data-theme='dark']) .emotion-article {
+  /* ... */
+}
+```
+
+With `explicitAmpersand` set to `false`:
+
+```css
+.emotion-article:where([data-theme='dark']) .emotion-article {
+  /* ... */
+}
+```

--- a/packages/cache/__tests__/__snapshots__/index.js.snap
+++ b/packages/cache/__tests__/__snapshots__/index.js.snap
@@ -57,4 +57,133 @@ exports[`should accept insertionPoint option 1`] = `
 </head>
 `;
 
+exports[`should not prefix pseudo-classes automatically when using explicitAmpersand option 1`] = `
+:where([dir='rtl']) .emotion-0 {
+  color: red;
+}
+
+.emotion-0:before {
+  content: 'test';
+}
+
+<body>
+  <div
+    id="container"
+  >
+    <style
+      data-emotion="test-container"
+      data-s=""
+    >
+      
+      .emotion-0{}
+    </style>
+    <style
+      data-emotion="test-container"
+      data-s=""
+    >
+      
+      :where([dir='rtl']) .emotion-0{color:red;}
+    </style>
+    <style
+      data-emotion="test-container"
+      data-s=""
+    >
+      
+      .emotion-0:before{content:'test';}
+    </style>
+  </div>
+  <div>
+    <div
+      class="emotion-0"
+    />
+  </div>
+</body>
+`;
+
+exports[`should not prefix pseudo-classes automatically when using option 1`] = `
+:where([dir='rtl']) .emotion-0 {
+  color: red;
+}
+
+.emotion-0:before {
+  content: 'test';
+}
+
+<body>
+  <div
+    id="container"
+  >
+    <style
+      data-emotion="test-container"
+      data-s=""
+    >
+      
+      .emotion-0{}
+    </style>
+    <style
+      data-emotion="test-container"
+      data-s=""
+    >
+      
+      :where([dir='rtl']) .emotion-0{color:red;}
+    </style>
+    <style
+      data-emotion="test-container"
+      data-s=""
+    >
+      
+      .emotion-0:before{content:'test';}
+    </style>
+  </div>
+  <div>
+    <div
+      class="emotion-0"
+    />
+  </div>
+</body>
+`;
+
+exports[`should prefix pseudo-classes automatically when not using explicitAmpersand option 1`] = `
+.emotion-0:where([dir='rtl']) .emotion-0 {
+  color: red;
+}
+
+.emotion-0:before {
+  content: 'test';
+}
+
+<body>
+  <div
+    id="container"
+  >
+    <style
+      data-emotion="test-container"
+      data-s=""
+    >
+      
+      .emotion-0{}
+    </style>
+    <style
+      data-emotion="test-container"
+      data-s=""
+    >
+      
+      .emotion-0:where([dir='rtl']) .emotion-0{color:red;}
+    </style>
+    <style
+      data-emotion="test-container"
+      data-s=""
+    >
+      
+      .emotion-0:before{content:'test';}
+    </style>
+  </div>
+  <div>
+    <div
+      class="emotion-0"
+    />
+  </div>
+</body>
+`;
+
 exports[`throws correct error with invalid key 1`] = `"Emotion key must only contain lower case alphabetical characters and - but "." was passed"`;

--- a/packages/cache/__tests__/index.js
+++ b/packages/cache/__tests__/index.js
@@ -2,7 +2,7 @@
 import 'test-utils/next-env'
 import { safeQuerySelector } from 'test-utils'
 import createCache from '@emotion/cache'
-import { jsx, CacheProvider } from '@emotion/react'
+import { jsx, CacheProvider, css } from '@emotion/react'
 import { render } from '@testing-library/react'
 
 test('throws correct error with invalid key', () => {
@@ -49,6 +49,63 @@ it('should accept container option', () => {
   render(
     <CacheProvider value={cache}>
       <div css={{ display: 'flex', color: 'blue' }} />
+    </CacheProvider>
+  )
+
+  expect(document.body).toMatchSnapshot()
+})
+
+it('should not prefix pseudo-classes automatically when using explicitAmpersand option', () => {
+  const body = safeQuerySelector('body')
+  body.innerHTML = `<div id="container" />`
+
+  const cache = createCache({
+    key: 'test-container',
+    container: safeQuerySelector('#container'),
+    explicitAmpersand: true
+  })
+
+  render(
+    <CacheProvider value={cache}>
+      <div
+        css={css`
+          :where([dir='rtl']) & {
+            color: red;
+          }
+
+          &:before {
+            content: 'test';
+          }
+        `}
+      />
+    </CacheProvider>
+  )
+
+  expect(document.body).toMatchSnapshot()
+})
+
+it('should prefix pseudo-classes automatically when not using explicitAmpersand option', () => {
+  const body = safeQuerySelector('body')
+  body.innerHTML = `<div id="container" />`
+
+  const cache = createCache({
+    key: 'test-container',
+    container: safeQuerySelector('#container')
+  })
+
+  render(
+    <CacheProvider value={cache}>
+      <div
+        css={css`
+          :where([dir='rtl']) & {
+            color: red;
+          }
+
+          &:before {
+            content: 'test';
+          }
+        `}
+      />
     </CacheProvider>
   )
 

--- a/packages/cache/src/index.js
+++ b/packages/cache/src/index.js
@@ -29,6 +29,7 @@ export type Options = {
   container?: HTMLElement,
   speedy?: boolean,
   prepend?: boolean,
+  explicitAmpersand?: boolean,
   insertionPoint?: HTMLElement
 }
 */
@@ -115,7 +116,7 @@ let createCache = (options /*: Options */) /*: EmotionCache */ => {
     sheet: StyleSheet,
     shouldCache: boolean
   ) => string | void */
-  const omnipresentPlugins = [compat, removeLabel]
+  const omnipresentPlugins = [compat(options), removeLabel]
 
   if (process.env.NODE_ENV !== 'production') {
     omnipresentPlugins.push(

--- a/packages/cache/src/stylis-plugins.js
+++ b/packages/cache/src/stylis-plugins.js
@@ -38,7 +38,8 @@ const identifierWithPointTracking = (begin, points, index) => {
   return slice(begin, position)
 }
 
-const toRules = (parsed, points) => {
+const toRules = (parsed, points, options) => {
+  const { explicitAmpersand = false } = options || {}
   // pretend we've started with a comma
   let index = -1
   let character = 44
@@ -65,7 +66,7 @@ const toRules = (parsed, points) => {
         break
       case 4:
         // comma
-        if (character === 44) {
+        if (character === 44 && !explicitAmpersand) {
           // colon
           parsed[++index] = peek() === 58 ? '&\f' : ''
           points[index] = parsed[index].length
@@ -80,12 +81,13 @@ const toRules = (parsed, points) => {
   return parsed
 }
 
-const getRules = (value, points) => dealloc(toRules(alloc(value), points))
+const getRules = (value, points, options) =>
+  dealloc(toRules(alloc(value), points, options))
 
 // WeakSet would be more appropriate, but only WeakMap is supported in IE11
 const fixedElements = /* #__PURE__ */ new WeakMap()
 
-export let compat = element => {
+export let compat = options => element => {
   if (
     element.type !== 'rule' ||
     !element.parent ||
@@ -123,7 +125,7 @@ export let compat = element => {
   fixedElements.set(element, true)
 
   const points = []
-  const rules = getRules(value, points)
+  const rules = getRules(value, points, options)
   const parentRules = parent.props
 
   for (let i = 0, k = 0; i < rules.length; i++) {


### PR DESCRIPTION
Based on the following issue: https://github.com/emotion-js/emotion/issues/2836
This adds an opt-in option on `@emotion/cache` `explicitAmpersand` (unsure about name) that *disables* the automatic prefixing of pseudo classes in the CSS.

**What**:

I identified an issue in my own CSS with newer pseudo classes like :where and :is, where Emotion automatically prefixed those classes with the current class name. This was not the expected behavior, and there was no way for me to opt-out of this behavior. 

Consider:

```jsx
<article
  css={css`
    color: black;

    :is(p, ul, ol) + :is(p, ul, ol) {
      margin-top: 1em;
    }

    :where([data-theme="dark"]) & {
      color: white;
    }
  `}
/>;
```

where the output with the `explicitAmpersand` set to `false` (the current behavior) will output:

```css
.emotion-article:is(p, ul, ol)+:is(p, ul, ol) {}
.emotion-article:where([data-theme="dark"]) & {}
```

But with `explicitAmpersand` set to `true` (new behavior):

```css
.emotion-article :is(p, ul, ol)+:is(p, ul, ol) {}
:where([data-theme="dark"]) & {}
```

**Why**:

The current behavior of automatic prefixing of the parent class name is confusing and breaks the behavior of new psuedo classes.

**How**:

Added an opt-in option on `@emotion/cache` `explicitAmpersand`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
