### PR TITLE
Added `edge-light` and `workerd` conditions

### DIFF
--- a/.changeset/whiny-lemons-lay.md
+++ b/.changeset/whiny-lemons-lay.md
@@ -1,0 +1,10 @@
+---
+'@emotion/use-insertion-effect-with-fallbacks': minor
+'@emotion/primitives': minor
+'@emotion/styled': minor
+'@emotion/cache': minor
+'@emotion/react': minor
+'@emotion/utils': minor
+---
+
+Added `edge-light` and `workerd` conditions to `package.json` manifest to better serve users using Vercel Edge and Cloudflare Workers.

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -11,10 +11,20 @@
         "default": "./dist/emotion-cache.cjs.js"
       },
       "development": {
+        "edge-light": {
+          "module": "./dist/emotion-cache.development.edge-light.esm.js",
+          "import": "./dist/emotion-cache.development.edge-light.cjs.mjs",
+          "default": "./dist/emotion-cache.development.edge-light.cjs.js"
+        },
         "worker": {
-          "module": "./dist/emotion-cache.development.worker.esm.js",
-          "import": "./dist/emotion-cache.development.worker.cjs.mjs",
-          "default": "./dist/emotion-cache.development.worker.cjs.js"
+          "module": "./dist/emotion-cache.development.edge-light.esm.js",
+          "import": "./dist/emotion-cache.development.edge-light.cjs.mjs",
+          "default": "./dist/emotion-cache.development.edge-light.cjs.js"
+        },
+        "workerd": {
+          "module": "./dist/emotion-cache.development.edge-light.esm.js",
+          "import": "./dist/emotion-cache.development.edge-light.cjs.mjs",
+          "default": "./dist/emotion-cache.development.edge-light.cjs.js"
         },
         "browser": {
           "module": "./dist/emotion-cache.browser.development.esm.js",
@@ -25,10 +35,20 @@
         "import": "./dist/emotion-cache.development.cjs.mjs",
         "default": "./dist/emotion-cache.development.cjs.js"
       },
+      "edge-light": {
+        "module": "./dist/emotion-cache.edge-light.esm.js",
+        "import": "./dist/emotion-cache.edge-light.cjs.mjs",
+        "default": "./dist/emotion-cache.edge-light.cjs.js"
+      },
       "worker": {
-        "module": "./dist/emotion-cache.worker.esm.js",
-        "import": "./dist/emotion-cache.worker.cjs.mjs",
-        "default": "./dist/emotion-cache.worker.cjs.js"
+        "module": "./dist/emotion-cache.edge-light.esm.js",
+        "import": "./dist/emotion-cache.edge-light.cjs.mjs",
+        "default": "./dist/emotion-cache.edge-light.cjs.js"
+      },
+      "workerd": {
+        "module": "./dist/emotion-cache.edge-light.esm.js",
+        "import": "./dist/emotion-cache.edge-light.cjs.mjs",
+        "default": "./dist/emotion-cache.edge-light.cjs.js"
       },
       "browser": {
         "module": "./dist/emotion-cache.browser.esm.js",
@@ -47,6 +67,8 @@
       "default": "./src/conditions/false.js"
     },
     "#is-browser": {
+      "edge-light": "./src/conditions/false.js",
+      "workerd": "./src/conditions/false.js",
       "worker": "./src/conditions/false.js",
       "browser": "./src/conditions/true.js",
       "default": "./src/conditions/is-browser.js"

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -53,7 +53,6 @@
     "./package.json": "./package.json",
     "./macro": "./macro.js"
   },
-  "imports": {},
   "preconstruct": {
     "exports": {
       "extra": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,10 +10,20 @@
         "default": "./dist/emotion-react.cjs.js"
       },
       "development": {
+        "edge-light": {
+          "module": "./dist/emotion-react.development.edge-light.esm.js",
+          "import": "./dist/emotion-react.development.edge-light.cjs.mjs",
+          "default": "./dist/emotion-react.development.edge-light.cjs.js"
+        },
         "worker": {
-          "module": "./dist/emotion-react.development.worker.esm.js",
-          "import": "./dist/emotion-react.development.worker.cjs.mjs",
-          "default": "./dist/emotion-react.development.worker.cjs.js"
+          "module": "./dist/emotion-react.development.edge-light.esm.js",
+          "import": "./dist/emotion-react.development.edge-light.cjs.mjs",
+          "default": "./dist/emotion-react.development.edge-light.cjs.js"
+        },
+        "workerd": {
+          "module": "./dist/emotion-react.development.edge-light.esm.js",
+          "import": "./dist/emotion-react.development.edge-light.cjs.mjs",
+          "default": "./dist/emotion-react.development.edge-light.cjs.js"
         },
         "browser": {
           "module": "./dist/emotion-react.browser.development.esm.js",
@@ -24,10 +34,20 @@
         "import": "./dist/emotion-react.development.cjs.mjs",
         "default": "./dist/emotion-react.development.cjs.js"
       },
+      "edge-light": {
+        "module": "./dist/emotion-react.edge-light.esm.js",
+        "import": "./dist/emotion-react.edge-light.cjs.mjs",
+        "default": "./dist/emotion-react.edge-light.cjs.js"
+      },
       "worker": {
-        "module": "./dist/emotion-react.worker.esm.js",
-        "import": "./dist/emotion-react.worker.cjs.mjs",
-        "default": "./dist/emotion-react.worker.cjs.js"
+        "module": "./dist/emotion-react.edge-light.esm.js",
+        "import": "./dist/emotion-react.edge-light.cjs.mjs",
+        "default": "./dist/emotion-react.edge-light.cjs.js"
+      },
+      "workerd": {
+        "module": "./dist/emotion-react.edge-light.esm.js",
+        "import": "./dist/emotion-react.edge-light.cjs.mjs",
+        "default": "./dist/emotion-react.edge-light.cjs.js"
       },
       "browser": {
         "module": "./dist/emotion-react.browser.esm.js",
@@ -44,10 +64,20 @@
         "default": "./jsx-runtime/dist/emotion-react-jsx-runtime.cjs.js"
       },
       "development": {
+        "edge-light": {
+          "module": "./jsx-runtime/dist/emotion-react-jsx-runtime.development.edge-light.esm.js",
+          "import": "./jsx-runtime/dist/emotion-react-jsx-runtime.development.edge-light.cjs.mjs",
+          "default": "./jsx-runtime/dist/emotion-react-jsx-runtime.development.edge-light.cjs.js"
+        },
         "worker": {
-          "module": "./jsx-runtime/dist/emotion-react-jsx-runtime.development.worker.esm.js",
-          "import": "./jsx-runtime/dist/emotion-react-jsx-runtime.development.worker.cjs.mjs",
-          "default": "./jsx-runtime/dist/emotion-react-jsx-runtime.development.worker.cjs.js"
+          "module": "./jsx-runtime/dist/emotion-react-jsx-runtime.development.edge-light.esm.js",
+          "import": "./jsx-runtime/dist/emotion-react-jsx-runtime.development.edge-light.cjs.mjs",
+          "default": "./jsx-runtime/dist/emotion-react-jsx-runtime.development.edge-light.cjs.js"
+        },
+        "workerd": {
+          "module": "./jsx-runtime/dist/emotion-react-jsx-runtime.development.edge-light.esm.js",
+          "import": "./jsx-runtime/dist/emotion-react-jsx-runtime.development.edge-light.cjs.mjs",
+          "default": "./jsx-runtime/dist/emotion-react-jsx-runtime.development.edge-light.cjs.js"
         },
         "browser": {
           "module": "./jsx-runtime/dist/emotion-react-jsx-runtime.browser.development.esm.js",
@@ -58,10 +88,20 @@
         "import": "./jsx-runtime/dist/emotion-react-jsx-runtime.development.cjs.mjs",
         "default": "./jsx-runtime/dist/emotion-react-jsx-runtime.development.cjs.js"
       },
+      "edge-light": {
+        "module": "./jsx-runtime/dist/emotion-react-jsx-runtime.edge-light.esm.js",
+        "import": "./jsx-runtime/dist/emotion-react-jsx-runtime.edge-light.cjs.mjs",
+        "default": "./jsx-runtime/dist/emotion-react-jsx-runtime.edge-light.cjs.js"
+      },
       "worker": {
-        "module": "./jsx-runtime/dist/emotion-react-jsx-runtime.worker.esm.js",
-        "import": "./jsx-runtime/dist/emotion-react-jsx-runtime.worker.cjs.mjs",
-        "default": "./jsx-runtime/dist/emotion-react-jsx-runtime.worker.cjs.js"
+        "module": "./jsx-runtime/dist/emotion-react-jsx-runtime.edge-light.esm.js",
+        "import": "./jsx-runtime/dist/emotion-react-jsx-runtime.edge-light.cjs.mjs",
+        "default": "./jsx-runtime/dist/emotion-react-jsx-runtime.edge-light.cjs.js"
+      },
+      "workerd": {
+        "module": "./jsx-runtime/dist/emotion-react-jsx-runtime.edge-light.esm.js",
+        "import": "./jsx-runtime/dist/emotion-react-jsx-runtime.edge-light.cjs.mjs",
+        "default": "./jsx-runtime/dist/emotion-react-jsx-runtime.edge-light.cjs.js"
       },
       "browser": {
         "module": "./jsx-runtime/dist/emotion-react-jsx-runtime.browser.esm.js",
@@ -78,10 +118,20 @@
         "default": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.cjs.js"
       },
       "development": {
+        "edge-light": {
+          "module": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.development.edge-light.esm.js",
+          "import": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.development.edge-light.cjs.mjs",
+          "default": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.development.edge-light.cjs.js"
+        },
         "worker": {
-          "module": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.development.worker.esm.js",
-          "import": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.development.worker.cjs.mjs",
-          "default": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.development.worker.cjs.js"
+          "module": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.development.edge-light.esm.js",
+          "import": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.development.edge-light.cjs.mjs",
+          "default": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.development.edge-light.cjs.js"
+        },
+        "workerd": {
+          "module": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.development.edge-light.esm.js",
+          "import": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.development.edge-light.cjs.mjs",
+          "default": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.development.edge-light.cjs.js"
         },
         "browser": {
           "module": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.browser.development.esm.js",
@@ -92,10 +142,20 @@
         "import": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.development.cjs.mjs",
         "default": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.development.cjs.js"
       },
+      "edge-light": {
+        "module": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.edge-light.esm.js",
+        "import": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.edge-light.cjs.mjs",
+        "default": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.edge-light.cjs.js"
+      },
       "worker": {
-        "module": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.worker.esm.js",
-        "import": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.worker.cjs.mjs",
-        "default": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.worker.cjs.js"
+        "module": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.edge-light.esm.js",
+        "import": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.edge-light.cjs.mjs",
+        "default": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.edge-light.cjs.js"
+      },
+      "workerd": {
+        "module": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.edge-light.esm.js",
+        "import": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.edge-light.cjs.mjs",
+        "default": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.edge-light.cjs.js"
       },
       "browser": {
         "module": "./_isolated-hnrs/dist/emotion-react-_isolated-hnrs.browser.esm.js",
@@ -112,10 +172,20 @@
         "default": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.cjs.js"
       },
       "development": {
+        "edge-light": {
+          "module": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.development.edge-light.esm.js",
+          "import": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.development.edge-light.cjs.mjs",
+          "default": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.development.edge-light.cjs.js"
+        },
         "worker": {
-          "module": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.development.worker.esm.js",
-          "import": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.development.worker.cjs.mjs",
-          "default": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.development.worker.cjs.js"
+          "module": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.development.edge-light.esm.js",
+          "import": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.development.edge-light.cjs.mjs",
+          "default": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.development.edge-light.cjs.js"
+        },
+        "workerd": {
+          "module": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.development.edge-light.esm.js",
+          "import": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.development.edge-light.cjs.mjs",
+          "default": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.development.edge-light.cjs.js"
         },
         "browser": {
           "module": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.browser.development.esm.js",
@@ -126,10 +196,20 @@
         "import": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.development.cjs.mjs",
         "default": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.development.cjs.js"
       },
+      "edge-light": {
+        "module": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.edge-light.esm.js",
+        "import": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.edge-light.cjs.mjs",
+        "default": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.edge-light.cjs.js"
+      },
       "worker": {
-        "module": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.worker.esm.js",
-        "import": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.worker.cjs.mjs",
-        "default": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.worker.cjs.js"
+        "module": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.edge-light.esm.js",
+        "import": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.edge-light.cjs.mjs",
+        "default": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.edge-light.cjs.js"
+      },
+      "workerd": {
+        "module": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.edge-light.esm.js",
+        "import": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.edge-light.cjs.mjs",
+        "default": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.edge-light.cjs.js"
       },
       "browser": {
         "module": "./jsx-dev-runtime/dist/emotion-react-jsx-dev-runtime.browser.esm.js",
@@ -156,6 +236,8 @@
       "default": "./src/conditions/false.js"
     },
     "#is-browser": {
+      "edge-light": "./src/conditions/false.js",
+      "workerd": "./src/conditions/false.js",
       "worker": "./src/conditions/false.js",
       "browser": "./src/conditions/true.js",
       "default": "./src/conditions/is-browser.js"

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -51,10 +51,20 @@
         "default": "./base/dist/emotion-styled-base.cjs.js"
       },
       "development": {
+        "edge-light": {
+          "module": "./base/dist/emotion-styled-base.development.edge-light.esm.js",
+          "import": "./base/dist/emotion-styled-base.development.edge-light.cjs.mjs",
+          "default": "./base/dist/emotion-styled-base.development.edge-light.cjs.js"
+        },
         "worker": {
-          "module": "./base/dist/emotion-styled-base.development.worker.esm.js",
-          "import": "./base/dist/emotion-styled-base.development.worker.cjs.mjs",
-          "default": "./base/dist/emotion-styled-base.development.worker.cjs.js"
+          "module": "./base/dist/emotion-styled-base.development.edge-light.esm.js",
+          "import": "./base/dist/emotion-styled-base.development.edge-light.cjs.mjs",
+          "default": "./base/dist/emotion-styled-base.development.edge-light.cjs.js"
+        },
+        "workerd": {
+          "module": "./base/dist/emotion-styled-base.development.edge-light.esm.js",
+          "import": "./base/dist/emotion-styled-base.development.edge-light.cjs.mjs",
+          "default": "./base/dist/emotion-styled-base.development.edge-light.cjs.js"
         },
         "browser": {
           "module": "./base/dist/emotion-styled-base.browser.development.esm.js",
@@ -65,10 +75,20 @@
         "import": "./base/dist/emotion-styled-base.development.cjs.mjs",
         "default": "./base/dist/emotion-styled-base.development.cjs.js"
       },
+      "edge-light": {
+        "module": "./base/dist/emotion-styled-base.edge-light.esm.js",
+        "import": "./base/dist/emotion-styled-base.edge-light.cjs.mjs",
+        "default": "./base/dist/emotion-styled-base.edge-light.cjs.js"
+      },
       "worker": {
-        "module": "./base/dist/emotion-styled-base.worker.esm.js",
-        "import": "./base/dist/emotion-styled-base.worker.cjs.mjs",
-        "default": "./base/dist/emotion-styled-base.worker.cjs.js"
+        "module": "./base/dist/emotion-styled-base.edge-light.esm.js",
+        "import": "./base/dist/emotion-styled-base.edge-light.cjs.mjs",
+        "default": "./base/dist/emotion-styled-base.edge-light.cjs.js"
+      },
+      "workerd": {
+        "module": "./base/dist/emotion-styled-base.edge-light.esm.js",
+        "import": "./base/dist/emotion-styled-base.edge-light.cjs.mjs",
+        "default": "./base/dist/emotion-styled-base.edge-light.cjs.js"
       },
       "browser": {
         "module": "./base/dist/emotion-styled-base.browser.esm.js",
@@ -85,10 +105,20 @@
         "default": "./dist/emotion-styled.cjs.js"
       },
       "development": {
+        "edge-light": {
+          "module": "./dist/emotion-styled.development.edge-light.esm.js",
+          "import": "./dist/emotion-styled.development.edge-light.cjs.mjs",
+          "default": "./dist/emotion-styled.development.edge-light.cjs.js"
+        },
         "worker": {
-          "module": "./dist/emotion-styled.development.worker.esm.js",
-          "import": "./dist/emotion-styled.development.worker.cjs.mjs",
-          "default": "./dist/emotion-styled.development.worker.cjs.js"
+          "module": "./dist/emotion-styled.development.edge-light.esm.js",
+          "import": "./dist/emotion-styled.development.edge-light.cjs.mjs",
+          "default": "./dist/emotion-styled.development.edge-light.cjs.js"
+        },
+        "workerd": {
+          "module": "./dist/emotion-styled.development.edge-light.esm.js",
+          "import": "./dist/emotion-styled.development.edge-light.cjs.mjs",
+          "default": "./dist/emotion-styled.development.edge-light.cjs.js"
         },
         "browser": {
           "module": "./dist/emotion-styled.browser.development.esm.js",
@@ -99,10 +129,20 @@
         "import": "./dist/emotion-styled.development.cjs.mjs",
         "default": "./dist/emotion-styled.development.cjs.js"
       },
+      "edge-light": {
+        "module": "./dist/emotion-styled.edge-light.esm.js",
+        "import": "./dist/emotion-styled.edge-light.cjs.mjs",
+        "default": "./dist/emotion-styled.edge-light.cjs.js"
+      },
       "worker": {
-        "module": "./dist/emotion-styled.worker.esm.js",
-        "import": "./dist/emotion-styled.worker.cjs.mjs",
-        "default": "./dist/emotion-styled.worker.cjs.js"
+        "module": "./dist/emotion-styled.edge-light.esm.js",
+        "import": "./dist/emotion-styled.edge-light.cjs.mjs",
+        "default": "./dist/emotion-styled.edge-light.cjs.js"
+      },
+      "workerd": {
+        "module": "./dist/emotion-styled.edge-light.esm.js",
+        "import": "./dist/emotion-styled.edge-light.cjs.mjs",
+        "default": "./dist/emotion-styled.edge-light.cjs.js"
       },
       "browser": {
         "module": "./dist/emotion-styled.browser.esm.js",
@@ -128,6 +168,8 @@
       "default": "./src/conditions/false.js"
     },
     "#is-browser": {
+      "edge-light": "./src/conditions/false.js",
+      "workerd": "./src/conditions/false.js",
       "worker": "./src/conditions/false.js",
       "browser": "./src/conditions/true.js",
       "default": "./src/conditions/is-browser.js"

--- a/packages/use-insertion-effect-with-fallbacks/package.json
+++ b/packages/use-insertion-effect-with-fallbacks/package.json
@@ -25,10 +25,20 @@
         "import": "./dist/emotion-use-insertion-effect-with-fallbacks.cjs.mjs",
         "default": "./dist/emotion-use-insertion-effect-with-fallbacks.cjs.js"
       },
+      "edge-light": {
+        "module": "./dist/emotion-use-insertion-effect-with-fallbacks.edge-light.esm.js",
+        "import": "./dist/emotion-use-insertion-effect-with-fallbacks.edge-light.cjs.mjs",
+        "default": "./dist/emotion-use-insertion-effect-with-fallbacks.edge-light.cjs.js"
+      },
       "worker": {
-        "module": "./dist/emotion-use-insertion-effect-with-fallbacks.worker.esm.js",
-        "import": "./dist/emotion-use-insertion-effect-with-fallbacks.worker.cjs.mjs",
-        "default": "./dist/emotion-use-insertion-effect-with-fallbacks.worker.cjs.js"
+        "module": "./dist/emotion-use-insertion-effect-with-fallbacks.edge-light.esm.js",
+        "import": "./dist/emotion-use-insertion-effect-with-fallbacks.edge-light.cjs.mjs",
+        "default": "./dist/emotion-use-insertion-effect-with-fallbacks.edge-light.cjs.js"
+      },
+      "workerd": {
+        "module": "./dist/emotion-use-insertion-effect-with-fallbacks.edge-light.esm.js",
+        "import": "./dist/emotion-use-insertion-effect-with-fallbacks.edge-light.cjs.mjs",
+        "default": "./dist/emotion-use-insertion-effect-with-fallbacks.edge-light.cjs.js"
       },
       "browser": {
         "module": "./dist/emotion-use-insertion-effect-with-fallbacks.browser.esm.js",
@@ -43,6 +53,8 @@
   },
   "imports": {
     "#is-browser": {
+      "edge-light": "./src/conditions/false.js",
+      "workerd": "./src/conditions/false.js",
       "worker": "./src/conditions/false.js",
       "browser": "./src/conditions/true.js",
       "default": "./src/conditions/is-browser.js"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -11,10 +11,20 @@
         "import": "./dist/emotion-utils.cjs.mjs",
         "default": "./dist/emotion-utils.cjs.js"
       },
+      "edge-light": {
+        "module": "./dist/emotion-utils.edge-light.esm.js",
+        "import": "./dist/emotion-utils.edge-light.cjs.mjs",
+        "default": "./dist/emotion-utils.edge-light.cjs.js"
+      },
       "worker": {
-        "module": "./dist/emotion-utils.worker.esm.js",
-        "import": "./dist/emotion-utils.worker.cjs.mjs",
-        "default": "./dist/emotion-utils.worker.cjs.js"
+        "module": "./dist/emotion-utils.edge-light.esm.js",
+        "import": "./dist/emotion-utils.edge-light.cjs.mjs",
+        "default": "./dist/emotion-utils.edge-light.cjs.js"
+      },
+      "workerd": {
+        "module": "./dist/emotion-utils.edge-light.esm.js",
+        "import": "./dist/emotion-utils.edge-light.cjs.mjs",
+        "default": "./dist/emotion-utils.edge-light.cjs.js"
       },
       "browser": {
         "module": "./dist/emotion-utils.browser.esm.js",
@@ -29,6 +39,8 @@
   },
   "imports": {
     "#is-browser": {
+      "edge-light": "./src/conditions/false.ts",
+      "workerd": "./src/conditions/false.ts",
       "worker": "./src/conditions/false.ts",
       "browser": "./src/conditions/true.ts",
       "default": "./src/conditions/is-browser.ts"


### PR DESCRIPTION
Next.js plans to migrate away from using `worker` condition because that pulls in React browser builds... so I have been asked to add their dedicated condition.