### PR TITLE
Fix broken browser file reference in primitives-core/package.json

### DIFF
--- a/.changeset/empty-sloths-flow.md
+++ b/.changeset/empty-sloths-flow.md
@@ -1,0 +1,5 @@
+---
+"@emotion/primitives-core": patch
+---
+
+Remove incorrect `browser` field from `package.json`

--- a/packages/primitives-core/package.json
+++ b/packages/primitives-core/package.json
@@ -39,9 +39,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "browser": {
-    "./dist/emotion-primitives-core.esm.js": "./dist/emotion-primitives-core.browser.esm.js"
-  },
   "exports": {
     ".": {
       "types": {


### PR DESCRIPTION
remove non-existing ref to file

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

I'm running into below, missing file reference error, when using expo and react-native when targeting web.

```
Starting Metro Bundler
Web ./index.js ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ 100.0% (2071/2071)Error: While trying to resolve module `@emotion/primitives-core` from file `/Users/me/super-duper-project/node_modules/@emotion/native/dist/emotion-native.esm.js`, the package `/Users/me/super-duper-project/node_modules/@emotion/primitives-core/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`/Users/me/super-duper-project/node_modules/@emotion/primitives-core/dist/emotion-primitives-core.browser.esm.js`. Indeed, none of these files exist:

  * /Users/me/super-duper-project/node_modules/@emotion/primitives-core/dist/emotion-primitives-core.browser.esm.js(.web.ts|.ts|.web.tsx|.tsx|.web.mjs|.mjs|.web.js|.js|.web.jsx|.jsx|.web.json|.json|.web.cjs|.cjs|.web.scss|.scss|.web.sass|.sass|.web.css|.css)
  * /Users/me/super-duper-project/node_modules/@emotion/primitives-core/dist/emotion-primitives-core.browser.esm.js/index(.web.ts|.ts|.web.tsx|.tsx|.web.mjs|.mjs|.web.js|.js|.web.jsx|.jsx|.web.json|.json|.web.cjs|.cjs|.web.scss|.scss|.web.sass|.sass|.web.css|.css)
Error: While trying to resolve module `@emotion/primitives-core` from file `/Users/me/super-duper-project/node_modules/@emotion/native/dist/emotion-native.esm.js`, the package `/Users/me/super-duper-project/node_modules/@emotion/primitives-core/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`/Users/me/super-duper-project/node_modules/@emotion/primitives-core/dist/emotion-primitives-core.browser.esm.js`. Indeed, none of these files exist:

  * /Users/me/super-duper-project/node_modules/@emotion/primitives-core/dist/emotion-primitives-core.browser.esm.js(.web.ts|.ts|.web.tsx|.tsx|.web.mjs|.mjs|.web.js|.js|.web.jsx|.jsx|.web.json|.json|.web.cjs|.cjs|.web.scss|.scss|.web.sass|.sass|.web.css|.css)
  * /Users/me/super-duper-project/node_modules/@emotion/primitives-core/dist/emotion-primitives-core.browser.esm.js/index(.web.ts|.ts|.web.tsx|.tsx|.web.mjs|.mjs|.web.js|.js|.web.jsx|.jsx|.web.json|.json|.web.cjs|.cjs|.web.scss|.scss|.web.sass|.sass|.web.css|.css)
    at DependencyGraph.resolveDependency (/Users/me/super-duper-project/node_modules/metro/src/node-haste/DependencyGraph.js:243:17)
    at /Users/me/super-duper-project/node_modules/metro/src/lib/transformHelpers.js:156:21
    at resolveDependencies (/Users/me/super-duper-project/node_modules/metro/src/DeltaBundler/buildSubgraph.js:42:25)
    at visit (/Users/me/super-duper-project/node_modules/metro/src/DeltaBundler/buildSubgraph.js:83:30)
    at async Promise.all (index 11)
    at visit (/Users/me/super-duper-project/node_modules/metro/src/DeltaBundler/buildSubgraph.js:92:5)
    at async Promise.all (index 2)
    at visit (/Users/me/super-duper-project/node_modules/metro/src/DeltaBundler/buildSubgraph.js:92:5)
    at async Promise.all (index 0)
    at buildSubgraph (/Users/me/super-duper-project/node_modules/metro/src/DeltaBundler/buildSubgraph.js:103:3)
```


**Why**:

Since the target file doesn't exist, I tested without this ref altogether and everything works fine.

**How**:

Removing the ref in the package.json solves the problem.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
