### PR TITLE
Let `css` prop attachment be distributed over union types.

### DIFF
--- a/.changeset/heavy-pets-rule.md
+++ b/.changeset/heavy-pets-rule.md
@@ -2,4 +2,4 @@
 '@emotion/react': patch
 ---
 
-Let 'css' prop attachment be distributed over union types.
+Distribute `css` prop attachment over props that are union types

--- a/.changeset/heavy-pets-rule.md
+++ b/.changeset/heavy-pets-rule.md
@@ -1,0 +1,5 @@
+---
+'@emotion/react': patch
+---
+
+Let 'css' prop attachment be distributed over union types.

--- a/packages/react/types/jsx-namespace.d.ts
+++ b/packages/react/types/jsx-namespace.d.ts
@@ -86,8 +86,9 @@ export namespace EmotionJSX {
     extends ReactJSXElementAttributesProperty {}
   interface ElementChildrenAttribute extends ReactJSXElementChildrenAttribute {}
 
-  type LibraryManagedAttributes<C, P> = WithConditionalCSSProp<P> &
-    ReactJSXLibraryManagedAttributes<C, P>
+  type LibraryManagedAttributes<C, P> = P extends unknown
+    ? WithConditionalCSSProp<P> & ReactJSXLibraryManagedAttributes<C, P>
+    : never
 
   interface IntrinsicAttributes extends ReactJSXIntrinsicAttributes {}
   interface IntrinsicClassAttributes<T>

--- a/packages/react/types/tests.tsx
+++ b/packages/react/types/tests.tsx
@@ -240,6 +240,12 @@ const anim1 = keyframes`
     }
   >['css']
 
+  // $ExpectType { foo: number; className: string; css?: Interpolation<Theme> } | { foo: string }
+  type _HasCssPropAsIntended7 = EmotionJSX.LibraryManagedAttributes<
+    {},
+    { foo: number; className: string } | { foo: string }
+  >
+
   // $ExpectType false
   type _NoCssPropAsIntended1 =
     'css' extends keyof EmotionJSX.LibraryManagedAttributes<

--- a/packages/react/types/tests.tsx
+++ b/packages/react/types/tests.tsx
@@ -6,9 +6,7 @@ import {
   css,
   jsx,
   keyframes,
-  withEmotionCache,
-  Interpolation,
-  Theme
+  withEmotionCache
 } from '@emotion/react'
 import { JSX as EmotionJSX } from '@emotion/react/jsx-runtime'
 import { CSSInterpolation } from '@emotion/serialize'

--- a/packages/react/types/tests.tsx
+++ b/packages/react/types/tests.tsx
@@ -6,7 +6,9 @@ import {
   css,
   jsx,
   keyframes,
-  withEmotionCache
+  withEmotionCache,
+  Interpolation,
+  Theme
 } from '@emotion/react'
 import { JSX as EmotionJSX } from '@emotion/react/jsx-runtime'
 import { CSSInterpolation } from '@emotion/serialize'
@@ -240,11 +242,17 @@ const anim1 = keyframes`
     }
   >['css']
 
-  // $ExpectType { foo: number; className: string; css?: Interpolation<Theme> } | { foo: string }
-  type _HasCssPropAsIntended7 = EmotionJSX.LibraryManagedAttributes<
-    {},
-    { foo: number; className: string } | { foo: string }
-  >
+  /*
+     Additional brackets here prevent type reference('EmotionJSX.LibraryManagedAttributes<...>') from being resolved to type alias name('_HasCssPropAsIntended7').
+     Without them, dtslint will compare the expected type to the type name.
+  */
+  type _HasCssPropAsIntended7 = [
+    // $ExpectType { foo: boolean; } | ({ css?: Interpolation<Theme>; } & { foo: number; className: string; })
+    EmotionJSX.LibraryManagedAttributes<
+      {},
+      { foo: number; className: string } | { foo: boolean }
+    >
+  ]
 
   // $ExpectType false
   type _NoCssPropAsIntended1 =

--- a/packages/react/types/tests.tsx
+++ b/packages/react/types/tests.tsx
@@ -183,6 +183,23 @@ const anim1 = keyframes`
 }
 
 {
+  const CompWithConditionalClassNameSupport = (
+    _props: { foo: true; className?: string } | { foo: false }
+  ) => {
+    return null
+  }
+  ;<CompWithConditionalClassNameSupport
+    foo={true}
+    css={{ backgroundColor: 'hotpink' }}
+  />
+  ;<CompWithConditionalClassNameSupport
+    foo={false}
+    // $ExpectError
+    css={{ backgroundColor: 'hotpink' }}
+  />
+}
+
+{
   // based on the code from @types/react@17.x
   // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/98fa4486aefd5a1916aa385402467a7157e3c73f/types/react/v17/index.d.ts#L540-L548
   type OldFC<P = {}> = OldFunctionComponent<P>
@@ -239,18 +256,6 @@ const anim1 = keyframes`
       className?: string | Array<string>
     }
   >['css']
-
-  /*
-     Additional brackets here prevent type reference('EmotionJSX.LibraryManagedAttributes<...>') from being resolved to type alias name('_HasCssPropAsIntended7').
-     Without them, dtslint will compare the expected type to the type name.
-  */
-  type _HasCssPropAsIntended7 = [
-    // $ExpectType { foo: boolean; } | ({ css?: Interpolation<Theme>; } & { foo: number; className: string; })
-    EmotionJSX.LibraryManagedAttributes<
-      {},
-      { foo: number; className: string } | { foo: boolean }
-    >
-  ]
 
   // $ExpectType false
   type _NoCssPropAsIntended1 =


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Let `css` prop attachment be distributed over union types. So that branches with `className` prop are extended with `css` prop.

<!-- Why are these changes necessary? -->

**Why**: Some components may accept `className` prop conditionally. For example, [`Link` of wouter does.](https://github.com/molefrog/wouter/blob/f953ae6811c4e49201e11844038b71e531ab76d2/packages/wouter/types/index.d.ts#L129) Emotion skips these cases, however, and does not add `css` prop in anywhere. As far as I know, there is no runtime or compilation-time problem stopping us from supporting these kind of components. Thus I propose this change to enhance expressiveness of the library.

fixes #3185

<!-- How were these changes implemented? -->

**How**: Made `LibraryManagedAttributes` be distributed over a prop type in cases it is a union.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation "N/A"
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->

Should I add test cases for this change? Please let me know if you need.