### PR TITLE
add createCache test

### DIFF
--- a/packages/cache/__tests__/__snapshots__/index.js.snap
+++ b/packages/cache/__tests__/__snapshots__/index.js.snap
@@ -57,4 +57,9 @@ exports[`should accept insertionPoint option 1`] = `
 </head>
 `;
 
+exports[`throws an error when cache is created with an empty key 1`] = `
+"You have to configure \`key\` for your cache. Please make sure it's unique (and not equal to 'css') as it's used for linking styles to your cache.
+If multiple caches share the same key they might "fight" for each other's style elements."
+`;
+
 exports[`throws correct error with invalid key 1`] = `"Emotion key must only contain lower case alphabetical characters and - but "." was passed"`;

--- a/packages/cache/__tests__/index.js
+++ b/packages/cache/__tests__/index.js
@@ -11,6 +11,12 @@ test('throws correct error with invalid key', () => {
   }).toThrowErrorMatchingSnapshot()
 })
 
+test('throws an error when cache is created with an empty key', () => {
+  expect(() => {
+    createCache({ key: '' })
+  }).toThrowErrorMatchingSnapshot()
+})
+
 test('should accept insertionPoint option', () => {
   const head = safeQuerySelector('head')
 


### PR DESCRIPTION
**What**:

I have written a test to verify that createCache throws an error when the key property is provided with a falsy value.

**Why**:

To ensure that the createCache function behaves correctly when invalid key values are passed, ensuring the stability and reliability of the code.

**How**:

The test is implemented to check if the createCache function throws an error when the key property is an empty string or any other falsy value. This is validated using toThrowErrorMatchingSnapshot to confirm that the correct error message is thrown.

**Checklist**:

- [ ] Documentation
- [x] Tests
- [ ] Code complete
- [ ] Changeset
