### PR TITLE
Add scale property as unitless

### DIFF
--- a/.changeset/nasty-rice-wonder.md
+++ b/.changeset/nasty-rice-wonder.md
@@ -1,0 +1,5 @@
+---
+'@emotion/unitless': minor
+---
+
+Add `scale` property as unitless

--- a/packages/unitless/src/index.ts
+++ b/packages/unitless/src/index.ts
@@ -32,6 +32,7 @@ let unitlessKeys: Record<string, 1> = {
   opacity: 1,
   order: 1,
   orphans: 1,
+  scale: 1,
   tabSize: 1,
   widows: 1,
   zIndex: 1,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Added scale as a unitless property.

<!-- Why are these changes necessary? -->

**Why**:

Since scale is a fairly new well adopted property and does not take px value but instead will take unitless values or percentages and it strange to put: `scale: "2"`
MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/scale
W3: https://www.w3.org/TR/css-transforms-2/#propdef-scale

<!-- How were these changes implemented? -->

**How**:

These changes were implemented by modifying the unitless package

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
