### PR TITLE
[perf] Remove `Insertion` wrapper

### DIFF
--- a/packages/styled/src/base.js
+++ b/packages/styled/src/base.js
@@ -25,33 +25,6 @@ Because you write your CSS inside a JavaScript string you actually have to do do
 You can read more about this here:
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#ES2018_revision_of_illegal_escape_sequences`
 
-const Insertion = ({ cache, serialized, isStringTag }) => {
-  registerStyles(cache, serialized, isStringTag)
-
-  const rules = useInsertionEffectAlwaysWithSyncFallback(() =>
-    insertStyles(cache, serialized, isStringTag)
-  )
-
-  if (!isBrowser && rules !== undefined) {
-    let serializedNames = serialized.name
-    let next = serialized.next
-    while (next !== undefined) {
-      serializedNames += ' ' + next.name
-      next = next.next
-    }
-    return (
-      <style
-        {...{
-          [`data-emotion`]: `${cache.key} ${serializedNames}`,
-          dangerouslySetInnerHTML: { __html: rules },
-          nonce: cache.sheet.nonce
-        }}
-      />
-    )
-  }
-  return null
-}
-
 let createStyled /*: CreateStyled */ = (
   tag /*: any */,
   options /* ?: StyledOptions */
@@ -160,15 +133,37 @@ let createStyled /*: CreateStyled */ = (
           newProps.ref = ref
         }
 
+        const isStringTag = typeof FinalTag === 'string'
+
+        registerStyles(cache, serialized, isStringTag)
+
+        const rules = useInsertionEffectAlwaysWithSyncFallback(() =>
+          insertStyles(cache, serialized, isStringTag)
+        )
+
+        if (!isBrowser && rules !== undefined) {
+          let serializedNames = serialized.name
+          let next = serialized.next
+          while (next !== undefined) {
+            serializedNames += ' ' + next.name
+            next = next.next
+          }
+          return (
+            <>
+              <style
+                {...{
+                  [`data-emotion`]: `${cache.key} ${serializedNames}`,
+                  dangerouslySetInnerHTML: { __html: rules },
+                  nonce: cache.sheet.nonce
+                }}
+              />
+              <FinalTag {...newProps} />
+            </>
+          )
+        }
+
         return (
-          <>
-            <Insertion
-              cache={cache}
-              serialized={serialized}
-              isStringTag={typeof FinalTag === 'string'}
-            />
-            <FinalTag {...newProps} />
-          </>
+          <FinalTag {...newProps} />
         )
       }
     )


### PR DESCRIPTION
I'm not sure if there is a good reason to keep the `Insertion` wrapper that is created by the styled function. It creates additional object allocations (JSX & props) and creates more work for React (more vdom diffing).

I've removed it in this PR and benchmarked again with the same [test case](https://gist.github.com/romgrk/129623975dee66e90a9d2373a33eef7a) I've been using, here are the results:

```
Before: 104.2ms	+- 7.0
After:  99.6	+- 6.7

N = 20
```