### PR TITLE
Fix: Account for !important tag when checking for content text being quoted properly

### DIFF
--- a/packages/serialize/src/index.ts
+++ b/packages/serialize/src/index.ts
@@ -136,12 +136,28 @@ if (isDevelopment) {
 
   processStyleValue = (key: string, value: string | number) => {
     if (key === 'content') {
+      let isProperlyQuoted = false
+      if (typeof value === 'string') {
+        const first = value.charAt(0)
+        if ((first === '"' || first === "'") && value.length > 1) {
+          const closingIndex = value.lastIndexOf(first)
+          if (closingIndex > 0) {
+            const remainder = value.slice(closingIndex + 1).trim()
+            if (
+              closingIndex === value.length - 1 ||
+              remainder === '' ||
+              remainder === '!important'
+            ) {
+              isProperlyQuoted = true
+            }
+          }
+        }
+      }
       if (
         typeof value !== 'string' ||
         (contentValues.indexOf(value) === -1 &&
           !contentValuePattern.test(value) &&
-          (value.charAt(0) !== value.charAt(value.length - 1) ||
-            (value.charAt(0) !== '"' && value.charAt(0) !== "'")))
+          !isProperlyQuoted)
       ) {
         throw new Error(
           `You seem to be using a value for 'content' without quotes, try replacing it with \`content: '"${value}"'\``


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Currently, CSS that uses content with quoted text followed by an !important tag breaks in development mode:
e.g `css={{ content: "'•' !important" }}` as mentioned in #3183.

**Why**:

This is because we currently check for quoted content by matching the starting character and ending character of the content, however with an !important tag added it will no longer match correctly.

**How**:

We now identify the first quote character, find its last occurrence and then check if the remainder after last occurrence is !important, if it is we no longer error incorrectly.
