### PR TITLE
Add example with type-safe destructuring

### DIFF
--- a/docs/typescript.mdx
+++ b/docs/typescript.mdx
@@ -220,6 +220,26 @@ const StyledOriginal = styled(Original, {
 ;<StyledOriginal prop1="1" prop2={2} />
 ```
 
+Alternatively, you can destructure and split custom props from intrinsic props:
+
+```ts
+import { ComponentProps } from 'react';
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+
+type InputWrapperProps = ComponentProps<'div'> & { disabled?: boolean };
+
+const InputWrapper = styled(
+  ({ disabled, ...rest }: InputWrapperProps) => <div role="group" {...rest} />
+)`
+  ${({ disabled }) => css`
+    input {
+      background: ${disabled ? 'red' : 'white'};
+    }
+  `}
+`;
+```
+
 ### Passing props when styling a React component
 
 ```tsx


### PR DESCRIPTION
**What**:

This adds an example of extending and styling an intrinsic element with type-safety.

**Why**:

The examples in the docs only show how to style intrinsic elements with no callback for the actual tag - this is [clearly](https://stackoverflow.com/questions/40731352/extending-html-elements-in-react-and-typescript-while-preserving-props) something React devs struggle with in TypeScript, and it's made more difficult by also needing the `styled` call.

I spent almost a day before landing on a reasonably simple and satisfying approach, so I figured this can help others. :-)

I honestly feel like you should promote this pattern as the first-and-foremost option. Many of the other options will simply have you run into a wall, having to refactor to this pattern anyway. For example, `styled.div` doesn't give you any real control of anything - you'll need a custom prop, which you will then learn how to filter out using `shouldForwardProp`. Then you'll need a custom attribute, or you'll need a default value for a prop, really anything besides just forwarding, and you will need this pattern anyway. To be honest, I don't think all these "shortcuts" or "workarounds" should even exist, or at least I don't think they should be promoted - they are incomplete abstractions, so when things change, you'll need to refactor anyway. Just show me one approach first that always works - leave those shorthand options a secondary choices for people who insist on brevity over ease of change.

Just my opinion! so I'm going to leave that for your consideration. :-)