### PR TITLE
Rename default export for @emotion/styled so it shows up as a suggestion for an auto-import

### DIFF
--- a/.changeset/wild-pumas-smash.md
+++ b/.changeset/wild-pumas-smash.md
@@ -2,4 +2,4 @@
 '@emotion/styled': patch
 ---
 
-Renamed default export variable for `@emotion/styled` to aid inferred names in auto-import completions in IDEs
+Renamed default-exported variable in `@emotion/styled` to aid inferred import names in auto-import completions in IDEs

--- a/.changeset/wild-pumas-smash.md
+++ b/.changeset/wild-pumas-smash.md
@@ -1,0 +1,5 @@
+---
+'@emotion/styled': patch
+---
+
+Renamed default export variable for @emotion/styled so it shows up as an automatic import for editors

--- a/.changeset/wild-pumas-smash.md
+++ b/.changeset/wild-pumas-smash.md
@@ -2,4 +2,4 @@
 '@emotion/styled': patch
 ---
 
-Renamed default export variable for @emotion/styled so it shows up as an automatic import for editors
+Renamed default export variable for `@emotion/styled` to aid inferred names in auto-import completions in IDEs

--- a/packages/styled/src/index.ts
+++ b/packages/styled/src/index.ts
@@ -1,5 +1,5 @@
 import { Theme } from '@emotion/react'
-import styled from './base'
+import oldStyled from './base'
 import { ReactJSXIntrinsicElements } from './jsx-namespace'
 import { tags } from './tags'
 import {
@@ -33,10 +33,10 @@ export type StyledTags = {
 export interface CreateStyled extends BaseCreateStyled, StyledTags {}
 
 // bind it to avoid mutating the original function
-const newStyled = styled.bind(null) as CreateStyled
+const styled = oldStyled.bind(null) as CreateStyled
 
 tags.forEach(tagName => {
-  ;(newStyled as any)[tagName] = newStyled(tagName as keyof typeof newStyled)
+  ;(styled as any)[tagName] = styled(tagName as keyof typeof styled)
 })
 
-export default newStyled
+export default styled

--- a/packages/styled/src/index.ts
+++ b/packages/styled/src/index.ts
@@ -1,5 +1,5 @@
 import { Theme } from '@emotion/react'
-import oldStyled from './base'
+import baseStyled from './base'
 import { ReactJSXIntrinsicElements } from './jsx-namespace'
 import { tags } from './tags'
 import {
@@ -33,7 +33,7 @@ export type StyledTags = {
 export interface CreateStyled extends BaseCreateStyled, StyledTags {}
 
 // bind it to avoid mutating the original function
-const styled = oldStyled.bind(null) as CreateStyled
+const styled = baseStyled.bind(null) as CreateStyled
 
 tags.forEach(tagName => {
   ;(styled as any)[tagName] = styled(tagName as keyof typeof styled)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Updated a variable name cause it influences auto-import behavior in editors.

<!-- Why are these changes necessary? -->

**Why**: Because I no longer desire to type the import manually.

<!-- How were these changes implemented? -->

**How**: I renamed a variable.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
