### PR TITLE
fix: mark shapeImageThreshold as unitless (#3328)

### DIFF
--- a/packages/unitless/src/index.ts
+++ b/packages/unitless/src/index.ts
@@ -47,7 +47,10 @@ let unitlessKeys: Record<string, 1> = {
   strokeDashoffset: 1,
   strokeMiterlimit: 1,
   strokeOpacity: 1,
-  strokeWidth: 1
+  strokeWidth: 1,
+
+  // css properties that are unitless in some contexts  
+  shapeImageThreshold: 1 
 }
 
 export default unitlessKeys


### PR DESCRIPTION
### What this does

Adds `shapeImageThreshold` to the unitless CSS properties list.

### Why

This prevents Emotion from appending "px" to this CSS property which should always be unitless.

Fixes: #3328

---

Let me know if any changes are needed. 🙂

