### PR TITLE
docs: fix unnecessary closing bracket in style tag example in composition docs

### DIFF
--- a/docs/composition.mdx
+++ b/docs/composition.mdx
@@ -42,7 +42,6 @@ render(
           color: turquoise;
         }
       `}
-      >
     </style>
     <p className="base danger">What color will this be?</p>
   </div>


### PR DESCRIPTION
**What**:
- Remove an unnecessary closing bracket `>` from the `<style>` tag in a JSX code example in the composition documentation.


**Why**:
- The extra `>` in the JSX caused invalid syntax and may confuse readers.
- Fixing this improves code example correctness and readability.


**How**:
- Edited the JSX snippet by deleting the stray closing bracket after the template string inside the `<style>` tag.

**Checklist**:

- [x] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

