### PR TITLE
fix: Add missing `@emotion/react` peer dependency to native and primitives packages(#3351)

### DIFF
--- a/.changeset/fix-peer-dependencies.md
+++ b/.changeset/fix-peer-dependencies.md
@@ -1,0 +1,8 @@
+---
+'@emotion/native': patch
+'@emotion/primitives': patch
+---
+
+Add missing `@emotion/react` peer dependency
+
+Both `@emotion/native` and `@emotion/primitives` depend on `@emotion/primitives-core`, which requires `@emotion/react` as a peer dependency. This change adds the missing peer dependency declarations to ensure proper dependency resolution.

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -44,6 +44,8 @@
     "@emotion/primitives-core": "^11.11.0"
   },
   "peerDependencies": {
+    "@emotion/react": "^11.0.0-rc.0",
+    "react": ">=16.8.0",
     "react-native": ">=0.14.0 <1"
   },
   "homepage": "https://emotion.sh",

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -35,6 +35,7 @@
   "types": "types/index.d.ts",
   "devDependencies": {
     "@definitelytyped/dtslint": "0.0.112",
+    "@emotion/react": "11.14.0",
     "@types/react-native": "^0.63.2",
     "react": "16.14.0",
     "react-native": "^0.63.2",

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -14,6 +14,7 @@
     "@emotion/primitives-core": "^11.13.0"
   },
   "peerDependencies": {
+    "@emotion/react": "^11.0.0-rc.0",
     "react": ">=16.8.0",
     "react-primitives": "^0.8.1"
   },

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -19,6 +19,7 @@
     "react-primitives": "^0.8.1"
   },
   "devDependencies": {
+    "@emotion/react": "11.14.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.5",
     "react": "16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2848,6 +2848,8 @@ __metadata:
     react-native: ^0.63.2
     typescript: ^5.4.5
   peerDependencies:
+    "@emotion/react": ^11.0.0-rc.0
+    react: ">=16.8.0"
     react-native: ">=0.14.0 <1"
   languageName: unknown
   linkType: soft
@@ -2878,6 +2880,7 @@ __metadata:
     react: 16.14.0
     react-primitives: ^0.8.1
   peerDependencies:
+    "@emotion/react": ^11.0.0-rc.0
     react: ">=16.8.0"
     react-primitives: ^0.8.1
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -2843,6 +2843,7 @@ __metadata:
   dependencies:
     "@definitelytyped/dtslint": 0.0.112
     "@emotion/primitives-core": ^11.11.0
+    "@emotion/react": 11.14.0
     "@types/react-native": ^0.63.2
     react: 16.14.0
     react-native: ^0.63.2
@@ -2875,6 +2876,7 @@ __metadata:
     "@emotion/babel-plugin": ^11.11.0
     "@emotion/is-prop-valid": ^1.2.1
     "@emotion/primitives-core": ^11.13.0
+    "@emotion/react": 11.14.0
     enzyme: ^3.11.0
     enzyme-adapter-react-16: ^1.15.5
     react: 16.14.0


### PR DESCRIPTION
**What**:

Add `@emotion/react` as a peer dependency to `@emotion/native` and `@emotion/primitives` packages.

**Why**:

Fixes #3351

Both `@emotion/native` and `@emotion/primitives` depend on `@emotion/primitives-core`, which requires `@emotion/react` as a peer dependency (it imports `ThemeContext` from `@emotion/react`). However, neither package declared this transitive peer dependency, causing npm/yarn to not warn users when `@emotion/react` is missing.

**How**:

- Added `@emotion/react: ^11.0.0-rc.0` to `peerDependencies` in `packages/native/package.json`
- Added `react: >=16.8.0` to `peerDependencies` in `packages/native/package.json` (was also missing)
- Added `@emotion/react: ^11.0.0-rc.0` to `peerDependencies` in `packages/primitives/package.json`

These version ranges match the peer dependency declarations in `@emotion/primitives-core` and `@emotion/styled`.

**Checklist**:

- [x] Documentation N/A
- [x] Tests N/A
- [x] Code complete
- [x] Changeset