### PR TITLE
[@emotion/sheet] Prevent stale `before` element references

### DIFF
--- a/.changeset/selfish-parrots-think.md
+++ b/.changeset/selfish-parrots-think.md
@@ -1,0 +1,5 @@
+---
+'@emotion/sheet': patch
+---
+
+Prevent NotFoundError being thrown when a stale `before` element reference is set

--- a/packages/sheet/__tests__/index.js
+++ b/packages/sheet/__tests__/index.js
@@ -243,4 +243,19 @@ describe('StyleSheet', () => {
 
     expect(() => sheet.flush()).not.toThrowError()
   })
+
+  test('should not throw when `before` is stale', () => {
+    const head = safeQuerySelector('head')
+    const beforeStyle = document.createElement('style')
+    beforeStyle.setAttribute('id', 'beforeStyle')
+    head.appendChild(beforeStyle)
+
+    const sheet = new StyleSheet({ ...defaultOptions })
+    sheet.before = beforeStyle
+
+    // Simulate a stale `before` node
+    head.removeChild(sheet.before)
+
+    expect(() => sheet.insert(rule)).not.toThrow()
+  })
 })

--- a/packages/sheet/src/index.ts
+++ b/packages/sheet/src/index.ts
@@ -89,13 +89,17 @@ export class StyleSheet {
   }
 
   private _insertTag = (tag: HTMLStyleElement): void => {
-    let before
+    let before = null
     if (this.tags.length === 0) {
       if (this.insertionPoint) {
         before = this.insertionPoint.nextSibling
       } else if (this.prepend) {
         before = this.container.firstChild
-      } else {
+      } else if (this.before && this.before.parentNode === this.container) {
+        // We check whether the designated `before` node still exists
+        // and is a child of the container to avoid NotFoundError being thrown.
+        // If either is false, we let it be null and insert the `tag` node
+        // as the last child instead.
         before = this.before
       }
     } else {


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This PR fixes a bug in `@emotion/sheet` that causes a `NotFoundError` to be thrown when a stale (removed, moved, disconnected, or otherwise not a child of the `container`) element is set in the `before` property.

This can happen internally and externally. We noticed it breaking when multiple `@emotion/react`'s `<Global />` components are being reinserted into the same container, but it can be caused by anything that controls the `before` property from the outside (which is technically how that property is supposed to be used).

**Why**:

To prevent `@emotion/sheet` from crashing user applications.

**How**:

A stale element reference can happen in many ways. Since `before` is externally controllable, we have to check whether it references an expected element and is up to date. I do it by confirming it's a child of the `container` element, which should be good enough to prevent this issue.

All other conditions within `_insertTag` seem to reference the actual state of the DOM, which is safe considering its synchronous nature.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation - N/A
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->
