### PR TITLE
[@emotion/is-prop-valid] Adds `command` and `commandForElement` to allowed props

### DIFF
--- a/.changeset/shaggy-trainers-sneeze.md
+++ b/.changeset/shaggy-trainers-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@emotion/is-prop-valid': patch
+---
+
+Adds `command` and `commandForElement` to allowed props

--- a/packages/is-prop-valid/src/props.js
+++ b/packages/is-prop-valid/src/props.js
@@ -52,6 +52,9 @@ const props = {
   className: true,
   cols: true,
   colSpan: true,
+  // https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API
+  command: true,
+  commandForElement: true,
   content: true,
   contentEditable: true,
   contextMenu: true,


### PR DESCRIPTION
* feat(is-prop-valid): add support for Invoker Commands API

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Addition of `command` and `commandForElement` to allowed props

<!-- Why are these changes necessary? -->

**Why**: Currently the package considers these two props from the [Invoker Commands API](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API)

<!-- How were these changes implemented? -->

**How**: By adding the mentioned props to `props.js`, the file that contains the list of valid props.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->