### PR TITLE
fix(@emotion/primitives-core): skip style and ref when finalTag is React.Fragment

### DIFF
--- a/packages/native/test/native-styled.test.js
+++ b/packages/native/test/native-styled.test.js
@@ -166,4 +166,36 @@ describe('Emotion native styled', () => {
 
     expect(tree).toMatchSnapshot()
   })
+
+  test('should not pass style prop to React.Fragment when used as styled component', () => {
+    const StyledFragment = styled(React.Fragment)`
+      color: red;
+    `
+    expect(() =>
+      renderer.create(
+        <StyledFragment>
+          <reactNative.Text>Hello World</reactNative.Text>
+        </StyledFragment>
+      )
+    ).not.toThrow()
+    expect(console.error).not.toBeCalledWith(
+      expect.stringContaining('React.Fragment')
+    )
+  })
+
+  test('should not pass style prop to React.Fragment when used via as prop', () => {
+    const StyledText = styled.Text`
+      color: hotpink;
+    `
+    expect(() =>
+      renderer.create(
+        <StyledText as={React.Fragment}>
+          <reactNative.Text>Hello World</reactNative.Text>
+        </StyledText>
+      )
+    ).not.toThrow()
+    expect(console.error).not.toBeCalledWith(
+      expect.stringContaining('React.Fragment')
+    )
+  })
 })

--- a/packages/primitives-core/src/styled.ts
+++ b/packages/primitives-core/src/styled.ts
@@ -77,9 +77,11 @@ export function createStyled(
             newProps[key] = props[key]
           }
         }
-        newProps.style = [css.apply(mergedProps, styles), props.style]
-        if (ref) {
-          newProps.ref = ref
+        if (finalTag !== React.Fragment) {
+          newProps.style = [css.apply(mergedProps, styles), props.style]
+          if (ref) {
+            newProps.ref = ref
+          }
         }
 
         return React.createElement(finalTag, newProps)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Prevent `style` and `ref` props from being forwarded to `React.Fragment` inside `@emotion/primitives-core`'s styled component render path.

**Why**:

`React.Fragment` only accepts `key` and `children` as props. When a styled component resolves to `React.Fragment` — either via `styled(React.Fragment)\`...\`` or the `as={React.Fragment}` shorthand — the code in `createStyled` unconditionally assigned `newProps.style = [computedStyles, props.style]` before calling `React.createElement(finalTag, newProps)`. This passed an invalid `style` prop to the Fragment.

React Native 0.81+ (and React Native 0.78+ per some reports) added strict prop validation that surfaces this as a runtime error:

> "Invalid prop `style` supplied to `React.Fragment`. React.Fragment can only have `key` and `children` props."

Fixes #3359.

**How**:

Guard the `style` and `ref` assignments with `if (finalTag !== React.Fragment)` so those props are only added when the target element is capable of accepting them.

```diff
- newProps.style = [css.apply(mergedProps, styles), props.style]
- if (ref) {
-   newProps.ref = ref
- }
+ if (finalTag !== React.Fragment) {
+   newProps.style = [css.apply(mergedProps, styles), props.style]
+   if (ref) {
+     newProps.ref = ref
+   }
+ }
```

**Checklist**:

- [x] Documentation N/A
- [x] Tests
- [x] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

🤖 Generated with [Claude Code](https://claude.com/claude-code) | Session: ffa7459a-75f5-425f-8eb4-d23918b2eaf9