### PR TITLE
Fix toHaveStyleRule matching for direct child targets

### DIFF
--- a/.changeset/witty-apples-rest.md
+++ b/.changeset/witty-apples-rest.md
@@ -1,0 +1,5 @@
+---
+'@emotion/jest': patch
+---
+
+Fix `toHaveStyleRule` matching for nested direct child targets.

--- a/packages/cache/types/tsconfig.json
+++ b/packages/cache/types/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "jsx": "react",
     "lib": ["es6", "dom"],
     "module": "commonjs",

--- a/packages/css/types/tsconfig.json
+++ b/packages/css/types/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "jsx": "react",
     "lib": ["es6", "dom"],
     "module": "commonjs",

--- a/packages/hash/types/tsconfig.json
+++ b/packages/hash/types/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "lib": ["es6", "dom"],
     "module": "commonjs",
     "noEmit": true,

--- a/packages/is-prop-valid/types/tsconfig.json
+++ b/packages/is-prop-valid/types/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "lib": ["es6", "dom"],
     "module": "commonjs",
     "noEmit": true,

--- a/packages/jest/src/utils.js
+++ b/packages/jest/src/utils.js
@@ -297,6 +297,9 @@ export function getStyleElements() /*: Array<HTMLStyleElement> */ {
 
 const unique = arr => Array.from(new Set(arr))
 
+const normalizeCombinatorSpacing = selector =>
+  selector.replace(/\s*([>+~])\s*/g, '$1')
+
 export function getKeys(elements /*: Array<HTMLStyleElement> */) {
   const keys = unique(
     elements.map(element => element.getAttribute('data-emotion'))
@@ -324,7 +327,10 @@ export function hasClassNames(
     // check if selector (className) of specific css rule match target
     return target instanceof RegExp
       ? target.test(selector)
-      : selector.includes(target)
+      : selector.includes(target) ||
+          normalizeCombinatorSpacing(selector).includes(
+            normalizeCombinatorSpacing(target)
+          )
   })
 }
 

--- a/packages/jest/test/matchers.test.js
+++ b/packages/jest/test/matchers.test.js
@@ -134,6 +134,26 @@ describe('toHaveStyleRule', () => {
     expect(tree).toHaveStyleRule('fill', 'green', { target: `${Svg}` })
   })
 
+  test('matches styles on a nested direct child target', () => {
+    const tree = renderer
+      .create(
+        <div
+          css={css`
+            > div {
+              background-color: hotpink;
+            }
+          `}
+        >
+          <div />
+        </div>
+      )
+      .toJSON()
+
+    expect(tree).toHaveStyleRule('background-color', 'hotpink', {
+      target: '> div'
+    })
+  })
+
   test('matches target styles by regex', () => {
     const localDivStyle = css`
       a {

--- a/packages/jest/types/tsconfig.json
+++ b/packages/jest/types/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "jsx": "react",
     "lib": ["es6", "dom"],
     "module": "commonjs",

--- a/packages/memoize/types/tsconfig.json
+++ b/packages/memoize/types/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "lib": ["es6", "dom"],
     "module": "commonjs",
     "noEmit": true,

--- a/packages/native/types/tsconfig.json
+++ b/packages/native/types/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "jsx": "react",
     "lib": ["es6", "dom"],
     "module": "commonjs",

--- a/packages/react/types/tsconfig.json
+++ b/packages/react/types/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "jsx": "react",
     "lib": ["es6", "dom"],
     "module": "commonjs",

--- a/packages/serialize/types/tsconfig.json
+++ b/packages/serialize/types/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "jsx": "react",
     "lib": ["es6", "dom"],
     "module": "commonjs",

--- a/packages/server/types/tsconfig.json
+++ b/packages/server/types/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "jsx": "react",
     "lib": [
       "es6",

--- a/packages/sheet/types/tsconfig.json
+++ b/packages/sheet/types/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "jsx": "react",
     "lib": ["es6", "dom"],
     "module": "commonjs",

--- a/packages/styled/types/tsconfig.json
+++ b/packages/styled/types/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "isolatedModules": true,
     "jsx": "react",
     "lib": ["es6", "dom"],

--- a/packages/utils/types/tsconfig.json
+++ b/packages/utils/types/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "jsx": "react",
     "lib": ["es6", "dom"],
     "module": "commonjs",

--- a/packages/weak-memoize/types/tsconfig.json
+++ b/packages/weak-memoize/types/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": "../",
     "forceConsistentCasingInFileNames": true,
+    "ignoreDeprecations": "6.0",
     "lib": ["es6", "dom"],
     "module": "commonjs",
     "noEmit": true,


### PR DESCRIPTION
## Summary
- Normalize selector combinator spacing when matching string target selectors.
- Add regression coverage for nested direct child style rules with `target: '> div'`.
- Add a patch changeset for `@emotion/jest`.

Fixes #3000

## Tests
- `yarn jest packages/jest/test/matchers.test.js -t "nested direct child" --runInBand`
- `yarn jest packages/jest/test/matchers.test.js --runInBand`
- `yarn jest packages/jest/test --runInBand`
- `yarn prettier --check packages/jest/src/utils.js packages/jest/test/matchers.test.js .changeset/witty-apples-rest.md`
- `yarn eslint packages/jest/src/utils.js packages/jest/test/matchers.test.js`
- `git diff --check`