### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -14,6 +14,12 @@ or if you prefer npm
 npm install --save @emotion/react
 ```
 
+or if you prefer Deno
+
+```bash
+deno install @emotion/react
+```
+
 To use it, import what you need, for example use [the css prop](/docs/css-prop.mdx) to create class names with styles.
 
 ```jsx


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install instructions list yarn and npm, but not Deno. Since Deno is a drop-in replacement for npm these days, I'd like to add a Deno line so Deno users have a copy-pasteable command, in parity with the others:

```sh
deno install @emotion/react
```

(As of Deno 2.8 there's no `npm:` prefix needed, it's the same command shape as `npm install @emotion/react`.)

Totally fine to close this if you'd rather keep the list short, no hard feelings. Happy to adjust wording, placement, or move it elsewhere.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._

---

**What**: Adds a `deno install @emotion/react` line to the install docs, next to the existing yarn and npm commands.

**Why**: Deno users currently have to translate the npm command themselves; this gives parity with the package managers already listed.

**How**: Added one bash snippet in `docs/install.mdx` matching the existing style.

**Checklist**:

- [x] Documentation
- [ ] Tests — N/A
- [x] Code complete
- [ ] Changeset — N/A (docs only, no package release)
