### PR TITLE
docs: fix circuit-ui Storybook welcome link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Look here 👉 _[emotion babel plugin feature table and documentation](https://g
 - [emotion website](site) [[Demo Here](https://emotion.sh)]
 - [next-hnpwa-guide-kit](https://github.com/tkh44/next-hnpwa-guide-kit) [[Demo Here](https://hnpwa.life)]
 - [reactivesearch](https://github.com/appbaseio/reactivesearch), a react UI library for Elasticsearch [[Website](https://opensource.appbase.io/reactivesearch/)]
-- [circuit-ui](https://github.com/sumup-oss/circuit-ui), a react component library built at SumUp [[Storybook](https://circuit.sumup.com/?path=/story/introduction-welcome--page)]
+- [circuit-ui](https://github.com/sumup-oss/circuit-ui), a react component library built at SumUp [[Storybook](https://circuit.sumup.com/?path=/docs/introduction-welcome--docs)]
 - **open a PR and add yours!**
 
 ### Ecosystem

--- a/docs/community.mdx
+++ b/docs/community.mdx
@@ -28,7 +28,7 @@ title: 'Community'
 
 - [react-select](https://github.com/JedWatson/react-select) ([Website](http://jedwatson.github.io/react-select/))
 - [reactivesearch](https://github.com/appbaseio/reactivesearch) ([Website](https://opensource.appbase.io/reactivesearch/))
-- [circuit-ui](https://github.com/sumup/circuit-ui) ([Storybook](https://sumup.github.io/circuit-ui/))
+- [circuit-ui](https://github.com/sumup/circuit-ui) ([Storybook](https://circuit.sumup.com/?path=/docs/introduction-welcome--docs))
 - [govuk-react](https://github.com/govuk-react/govuk-react) ([Storybook](https://govuk-react.github.io/govuk-react/))
 - [smooth-ui](https://github.com/smooth-code/smooth-ui) ([Website](https://smooth-ui.smooth-code.com/))
 - [material-ui](https://github.com/mui-org/material-ui) ([Website](https://mui.com/))


### PR DESCRIPTION
## Summary
- Updates the circuit-ui Storybook link in the README and community docs to the current welcome docs path (`introduction-welcome--docs`).
- The previous deep link pointed at a removed story id and showed "Couldn't find story matching...".

Fixes #3382

## Test plan
- [x] Confirmed `introduction-welcome--docs` exists in https://circuit.sumup.com/index.json
- [ ] Open the updated Storybook URL and confirm the welcome docs page loads