### PR TITLE
Add `focusgroup` attribute as valid prop

### DIFF
--- a/packages/is-prop-valid/src/props.js
+++ b/packages/is-prop-valid/src/props.js
@@ -74,6 +74,7 @@ const props = {
   enterKeyHint: true,
   fetchpriority: true,
   fetchPriority: true,
+  focusgroup: true,
   form: true,
   formAction: true,
   formEncType: true,


### PR DESCRIPTION
**What**:

Adding `focusgroup` to the list of valid props

**Why**:

[`focusgroup`](https://microsoftedge.github.io/Demos/focusgroup/) is an upcoming attribute for HTML elements.

Currently, we are unable to test & use this attribute as it fails the is-valid-prop check in Linaria

**How**:

Simply adding to the allow-list. No logic changes.

**Checklist**:

- [ ] Documentation - N/A
- [ ] Tests - N/A
- [ ] Code complete - N/A
- [ ] Changeset  - N/A

