### PR TITLE
fix(site): update broken v10 Docs header link

### DIFF
--- a/site/components/site-header.tsx
+++ b/site/components/site-header.tsx
@@ -196,7 +196,7 @@ export function SiteHeader() {
                 </HeaderLink>
               </li>
               <li>
-                <HeaderLink href="https://5faaafd0bd0f3f0008469537--emotion.netlify.app">
+                <HeaderLink href="https://v10--emotion.netlify.app">
                   v10 Docs
                 </HeaderLink>
               </li>


### PR DESCRIPTION
## Summary
- The site header "v10 Docs" link pointed at an old Netlify deploy-preview URL that now returns 404.
- Point it at the stable `v10` branch deploy (`https://v10--emotion.netlify.app`), which serves the v10 docs.

Fixes #3040

## Test plan
- [x] Confirmed `https://5faaafd0bd0f3f0008469537--emotion.netlify.app` returns 404
- [x] Confirmed `https://v10--emotion.netlify.app` and `/docs/introduction` return 200
- [ ] After deploy, check the header "v10 Docs" link on emotion.sh opens the v10 docs