### PR TITLE
Fixed `@emotion/babel-plugin` compatibility with Babel 8

### DIFF
--- a/.changeset/hungry-lions-brake.md
+++ b/.changeset/hungry-lions-brake.md
@@ -1,0 +1,5 @@
+---
+'@emotion/babel-plugin': patch
+---
+
+Fixed compatibility with Babel 8 by replacing the usage of the removed `path.hoist()` API.

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -1,11 +1,16 @@
 name: 'CI setup'
+inputs:
+  node-version:
+    description: 'Node.js version passed to setup-node'
+    required: false
+    default: 16.x
 runs:
   using: 'composite'
   steps:
-    - name: Setup Node.js 16.x
+    - name: Setup Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: ${{ inputs.node-version }}
         cache: yarn
 
     - name: Install Dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,19 @@ jobs:
       - name: Dist Tests
         run: yarn test:dist
 
+  test_babel8:
+    name: Test Babel 8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/ci-setup
+        with:
+          # Babel 8 requires Node.js ^22.18.0 || >=24.11.0
+          node-version: 24.x
+
+      - name: Babel 8 Tests
+        run: yarn test:babel8
+
   linting:
     name: Linting
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@
 - `yarn test` will run the tests once.
 - `yarn coverage` will run the tests and produce a coverage report in `coverage/`.
 - `yarn test:watch` will run the tests on every change.
+- `yarn test:babel8` will run the Babel 8 tests for `@emotion/babel-plugin` (requires Node.js `^22.18.0 || >=24.11.0`).
 
 ## Building
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,9 @@ module.exports = {
     '/node_modules/',
     '/__fixtures__/',
     '/site/',
-    '/types/'
+    '/types/',
+    // runs on node:test through `yarn test:babel8` because Babel 8 is ESM-only
+    '\\.mjs$'
   ],
   setupFilesAfterEnv: ['test-utils/testSetup.js'],
   coveragePathIgnorePatterns: [

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:ci": "jest --coverage --no-cache --ci --runInBand",
     "test:react18:ci": "yarn test:react18 --coverage --no-cache --ci --runInBand",
     "test:dist": "yarn build && jest -c jest.dist.js --no-cache --ci --runInBand",
+    "test:babel8": "node packages/babel-plugin/__tests__/babel8.mjs",
     "test:prod": "jest -c jest.prod.js --no-cache --ci --runInBand",
     "lint:check": "eslint .",
     "test:watch": "jest --watch",
@@ -155,7 +156,7 @@
     }
   ],
   "lint-staged": {
-    "*.{js,ts,tsx,md}": [
+    "*.{js,mjs,ts,tsx,md}": [
       "prettier --write",
       "git add"
     ]
@@ -196,6 +197,7 @@
     "babel-jest": "^29.7.0",
     "babel-plugin-codegen": "^4.1.5",
     "babel-plugin-jsx-pragmatic": "^1.0.2",
+    "babel8": "npm:@babel/core@^8.0.0",
     "benchmark": "^2.1.4",
     "bolt-check": "^0.3.0",
     "bundlesize": "^0.13.2",

--- a/packages/babel-plugin/__tests__/babel8.mjs
+++ b/packages/babel-plugin/__tests__/babel8.mjs
@@ -1,0 +1,141 @@
+// checks that the plugin works with Babel 8, which removed `path.hoist()`
+// (see https://github.com/emotion-js/emotion/issues/3386)
+// Babel 8 is ESM-only and can't be loaded from the CommonJS-based Jest setup,
+// so this runs on `node:test` instead (`yarn test:babel8`)
+
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const [major, minor] = process.versions.node.split('.').map(Number)
+const supportedByBabel8 =
+  (major === 22 && minor >= 18) || (major === 24 && minor >= 11) || major > 24
+if (!supportedByBabel8) {
+  console.error(
+    `Babel 8 requires Node.js ^22.18.0 || >=24.11.0, this is ${process.version}`
+  )
+  process.exit(1)
+}
+
+// `babel8` is an alias for @babel/core@^8.0.0, see the root package.json
+const { transformAsync, version } = await import('babel8')
+assert.match(version, /^8\./)
+
+const require = createRequire(import.meta.url)
+const babel7 = require('@babel/core')
+const emotionPlugin = require('@emotion/babel-plugin')
+const babelPluginMacros = require('babel-plugin-macros')
+
+const filename = fileURLToPath(new URL('babel8-test.js', import.meta.url))
+
+// Babel 7 and 8 print the same program with slightly different formatting
+// (blank lines, redundant parentheses), so outputs are compared as ASTs
+// with the formatting metadata stripped
+const toComparableAst = code =>
+  JSON.parse(
+    JSON.stringify(
+      babel7.parseSync(code, {
+        filename,
+        babelrc: false,
+        configFile: false,
+        parserOpts: { plugins: ['jsx'] }
+      }).program,
+      (key, value) =>
+        ['loc', 'start', 'end', 'extra'].includes(key) ? undefined : value
+    )
+  )
+
+async function transform(code, plugins = [[emotionPlugin, {}]]) {
+  const options = {
+    plugins,
+    parserOpts: { plugins: ['jsx'] },
+    filename,
+    envName: 'development',
+    babelrc: false,
+    configFile: false
+  }
+  const result = await transformAsync(code, options)
+  const babel7Result = babel7.transformSync(code, options)
+  assert.deepStrictEqual(
+    toComparableAst(result.code),
+    toComparableAst(babel7Result.code)
+  )
+  return result.code
+}
+
+test('hoists a css template literal used in a css prop', async () => {
+  const code = await transform(`
+    import { css } from '@emotion/react'
+    const SomeComponent = () => <div css={css\`color: hotpink;\`} />
+  `)
+  assert.match(code, /^var _ref =/m)
+  assert.match(code, /css=\{_ref\}/)
+  assert.match(code, /color:hotpink/)
+})
+
+test('hoists a css call used in Global styles', async () => {
+  const code = await transform(`
+    import { Global, css } from '@emotion/react'
+    export default () => <Global styles={css\`body { margin: 0; }\`} />
+  `)
+  assert.match(code, /^var _ref =/m)
+  assert.match(code, /styles=\{_ref\}/)
+})
+
+test('does not hoist styles that reference local bindings', async () => {
+  const code = await transform(`
+    import { css } from '@emotion/react'
+    const SomeComponent = ({ color }) => <div css={css\`color: \${color};\`} />
+  `)
+  assert.doesNotMatch(code, /var _ref =/)
+  assert.match(code, /label:SomeComponent/)
+})
+
+test('serializes a static css prop object at compile time', async () => {
+  const code = await transform(`
+    const SomeComponent = () => <div css={{ color: 'hotpink' }} />
+  `)
+  assert.match(code, /^var _ref =/m)
+  assert.match(code, /css=\{_ref\}/)
+  assert.match(code, /color:hotpink/)
+})
+
+test('adds a css import for a dynamic css prop object', async () => {
+  const code = await transform(`
+    const SomeComponent = ({ color }) => <div css={{ color }} />
+  `)
+  assert.match(code, /import \{ css as _css \} from "@emotion\/react"/)
+  assert.match(code, /_css\(\{/)
+})
+
+test('transforms styled components', async () => {
+  const code = await transform(`
+    import styled from '@emotion/styled'
+    const Button = styled.button\`color: hotpink;\`
+  `)
+  assert.match(code, /import _styled from "@emotion\/styled\/base"/)
+  assert.match(code, /target:/)
+  assert.match(code, /label: "Button"/)
+})
+
+test('transforms @emotion/css', async () => {
+  const code = await transform(`
+    import { css } from '@emotion/css'
+    const cls = css\`color: hotpink;\`
+  `)
+  assert.match(code, /label:cls/)
+})
+
+test('transforms imports from @emotion/react/macro', async () => {
+  const code = await transform(
+    `
+      import { css } from '@emotion/react/macro'
+      const SomeComponent = () => <div css={css\`color: hotpink;\`} />
+    `,
+    [babelPluginMacros]
+  )
+  assert.match(code, /import \{ css \} from ["']@emotion\/react["'];/)
+  assert.match(code, /^var _ref =/m)
+  assert.match(code, /css=\{_ref\}/)
+})

--- a/packages/babel-plugin/__tests__/path-hoister.js
+++ b/packages/babel-plugin/__tests__/path-hoister.js
@@ -1,0 +1,43 @@
+import * as babel from '@babel/core'
+import checkDuplicatedNodes from 'babel-check-duplicated-nodes'
+import { hoistPath } from '../src/utils/path-hoister'
+
+const fixtures = [
+  `hoistMe({ color: 'hotpink' })`,
+  `const make = () => hoistMe({ color: 'hotpink' })`,
+  `const make = color => hoistMe({ color })`,
+  `const make = () => hoistMe({ c }); var c = 1`,
+  `const make = () => hoistMe({ c }); var c = 1; c = 2`,
+  `let c = 'x'; function reassign() { c = 'y' } const make = () => hoistMe({ c })`,
+  `function outer(c) { const inner = () => hoistMe({ c }); return inner }`,
+  `function outer(a) { { const inner = hoistMe({ a }) } }`,
+  `class Foo { style = hoistMe({ color: 'hotpink' }) }`
+]
+
+const transformWith = hoist =>
+  fixtures.map(fixture => {
+    const { code, ast } = babel.transformSync(fixture, {
+      plugins: [
+        {
+          visitor: {
+            CallExpression(path) {
+              if (path.node.callee.name === 'hoistMe') hoist(path)
+            }
+          }
+        }
+      ],
+      ast: true,
+      babelrc: false,
+      configFile: false
+    })
+    expect(() => checkDuplicatedNodes(babel, ast)).not.toThrow()
+    return code
+  })
+
+// `hoistPath` is a copy of `path.hoist` which has been removed in Babel 8,
+// both have to produce the same output for the same input
+test('hoistPath produces the same output as path.hoist', () => {
+  expect(transformWith(path => hoistPath(path, babel.types))).toEqual(
+    transformWith(path => path.hoist())
+  )
+})

--- a/packages/babel-plugin/src/core-macro.js
+++ b/packages/babel-plugin/src/core-macro.js
@@ -2,7 +2,8 @@ import {
   transformExpressionWithStyles,
   createTransformerMacro,
   getSourceMap,
-  addImport
+  addImport,
+  hoistPath
 } from './utils'
 
 export const transformCssCallExpression = (
@@ -23,7 +24,8 @@ export const transformCssCallExpression = (
   })
   if (node) {
     path.replaceWith(node)
-    path.hoist()
+    // `path.hoist` has been removed in Babel 8
+    hoistPath(path, babel.types)
   } else if (annotateAsPure && path.isCallExpression()) {
     path.addComment('leading', '#__PURE__')
   }

--- a/packages/babel-plugin/src/utils/index.js
+++ b/packages/babel-plugin/src/utils/index.js
@@ -9,4 +9,5 @@ export {
   joinStringLiterals
 } from './strings'
 export { addImport } from './add-import'
+export { hoistPath } from './path-hoister'
 export { createTransformerMacro } from './transformer-macro'

--- a/packages/babel-plugin/src/utils/path-hoister.js
+++ b/packages/babel-plugin/src/utils/path-hoister.js
@@ -1,0 +1,254 @@
+// this is a copy of PathHoister from https://github.com/babel/babel/blob/v7.28.4/packages/babel-traverse/src/path/lib/hoister.ts
+// (Copyright (c) 2014-present Sebastian McKenzie and other contributors, MIT licensed)
+// `NodePath#hoist` has been removed in Babel 8, so we keep a copy of it here -
+// the only changes are that `@babel/types` is taken from the running Babel
+// instance (`t`) and that the class is exposed through the `hoistPath` helper
+
+const referenceVisitor = {
+  // This visitor looks for bindings to establish a topmost scope for hoisting.
+  ReferencedIdentifier(path, state) {
+    // Don't hoist regular JSX identifiers ('div', 'span', etc).
+    // We do have to consider member expressions for hoisting (e.g. `this.component`)
+    if (
+      path.isJSXIdentifier() &&
+      state.t.react.isCompatTag(path.node.name) &&
+      !path.parentPath.isJSXMemberExpression()
+    ) {
+      return
+    }
+
+    // If the identifier refers to `this`, we need to break on the closest non-arrow scope.
+    if (path.node.name === 'this') {
+      let scope = path.scope
+      do {
+        if (
+          scope.path.isFunction() &&
+          !scope.path.isArrowFunctionExpression()
+        ) {
+          break
+        }
+      } while ((scope = scope.parent))
+      if (scope) state.breakOnScopePaths.push(scope.path)
+    }
+
+    // direct references that we need to track to hoist this to the highest scope we can
+    const binding = path.scope.getBinding(path.node.name)
+    if (!binding) return
+
+    // we can handle reassignments only if they happen in the same scope as the declaration
+    for (const violation of binding.constantViolations) {
+      if (violation.scope !== binding.path.scope) {
+        state.mutableBinding = true
+        path.stop()
+        return
+      }
+    }
+
+    // this binding isn't accessible from the parent scope so we can safely ignore it
+    // eg. it's in a closure etc
+    if (binding !== state.scope.getBinding(path.node.name)) return
+
+    state.bindings[path.node.name] = binding
+  }
+}
+
+class PathHoister {
+  constructor(path, scope, t) {
+    // Storage for scopes we can't hoist above.
+    this.breakOnScopePaths = []
+    // Storage for bindings that may affect what path we can hoist to.
+    this.bindings = {}
+    // "true" if the current path contains a reference to a binding whose
+    // value can change and thus can't be safely hoisted.
+    this.mutableBinding = false
+    // Storage for eligible scopes.
+    this.scopes = []
+    // Our original scope and path.
+    this.scope = scope
+    this.path = path
+    // By default, we attach as far up as we can; but if we're trying
+    // to avoid referencing a binding, we may have to go after.
+    this.attachAfter = false
+    this.t = t
+  }
+
+  // A scope is compatible if all required bindings are reachable.
+  isCompatibleScope(scope) {
+    for (const key of Object.keys(this.bindings)) {
+      const binding = this.bindings[key]
+      if (!scope.bindingIdentifierEquals(key, binding.identifier)) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  // Look through all scopes and push compatible ones.
+  getCompatibleScopes() {
+    let scope = this.path.scope
+    do {
+      if (this.isCompatibleScope(scope)) {
+        this.scopes.push(scope)
+      } else {
+        break
+      }
+
+      // deopt: These scopes are set in the visitor on const violations
+      if (this.breakOnScopePaths.includes(scope.path)) {
+        break
+      }
+    } while ((scope = scope.parent))
+  }
+
+  getAttachmentPath() {
+    let path = this._getAttachmentPath()
+    if (!path) return
+
+    let targetScope = path.scope
+
+    // don't allow paths that have their own lexical environments to pollute
+    if (targetScope.path === path) {
+      targetScope = path.scope.parent
+    }
+
+    // avoid hoisting to a scope that contains bindings that are executed after our attachment path
+    if (targetScope.path.isProgram() || targetScope.path.isFunction()) {
+      for (const name of Object.keys(this.bindings)) {
+        // check binding is a direct child of this paths scope
+        if (!targetScope.hasOwnBinding(name)) continue
+
+        const binding = this.bindings[name]
+
+        // allow parameter references and expressions in params (like destructuring rest)
+        if (binding.kind === 'param' || binding.path.parentKey === 'params') {
+          continue
+        }
+
+        // For each binding, get its attachment parent. This gives us an idea of where we might
+        // introduce conflicts.
+        const bindingParentPath = this.getAttachmentParentForPath(binding.path)
+
+        // If the binding's attachment appears at or after our attachment point, then we move after it.
+        if (bindingParentPath.key >= path.key) {
+          this.attachAfter = true
+          path = binding.path
+
+          // We also move past any constant violations.
+          for (const violationPath of binding.constantViolations) {
+            if (this.getAttachmentParentForPath(violationPath).key > path.key) {
+              path = violationPath
+            }
+          }
+        }
+      }
+    }
+
+    return path
+  }
+
+  _getAttachmentPath() {
+    const scopes = this.scopes
+
+    const scope = scopes.pop()
+    // deopt: no compatible scopes
+    if (!scope) return
+
+    if (scope.path.isFunction()) {
+      if (this.hasOwnParamBindings(scope)) {
+        // deopt: should ignore this scope since it's ourselves
+        if (this.scope === scope) return
+
+        // needs to be attached to the body
+        const bodies = scope.path.get('body').get('body')
+        for (let i = 0; i < bodies.length; i++) {
+          // Don't attach to something that's going to get hoisted,
+          // like a default parameter
+          if (bodies[i].node._blockHoist) continue
+          return bodies[i]
+        }
+        // deopt: If here, no attachment path found
+      } else {
+        // doesn't need to be be attached to this scope
+        return this.getNextScopeAttachmentParent()
+      }
+    } else if (scope.path.isProgram()) {
+      return this.getNextScopeAttachmentParent()
+    }
+  }
+
+  getNextScopeAttachmentParent() {
+    const scope = this.scopes.pop()
+    if (scope) return this.getAttachmentParentForPath(scope.path)
+  }
+
+  // Find an attachment for this path.
+  getAttachmentParentForPath(path) {
+    do {
+      if (
+        // Beginning of the scope
+        !path.parentPath ||
+        // Has siblings and is a statement
+        (Array.isArray(path.container) && path.isStatement())
+      ) {
+        return path
+      }
+    } while ((path = path.parentPath))
+  }
+
+  // Returns true if a scope has param bindings.
+  hasOwnParamBindings(scope) {
+    for (const name of Object.keys(this.bindings)) {
+      if (!scope.hasOwnBinding(name)) continue
+
+      const binding = this.bindings[name]
+      // Ensure constant; without it we could place behind a reassignment
+      if (binding.kind === 'param' && binding.constant) return true
+    }
+    return false
+  }
+
+  run() {
+    this.path.traverse(referenceVisitor, this)
+
+    if (this.mutableBinding) return
+
+    this.getCompatibleScopes()
+
+    const attachTo = this.getAttachmentPath()
+    if (!attachTo) return
+
+    // don't bother hoisting to the same function as this will cause multiple branches to be
+    // evaluated more than once leading to a bad optimisation
+    if (attachTo.getFunctionParent() === this.path.getFunctionParent()) return
+
+    // generate declaration and insert it to our point
+    let uid = attachTo.scope.generateUidIdentifier('ref')
+
+    const declarator = this.t.variableDeclarator(uid, this.path.node)
+
+    const insertFn = this.attachAfter ? 'insertAfter' : 'insertBefore'
+    const [attached] = attachTo[insertFn]([
+      attachTo.isVariableDeclarator()
+        ? declarator
+        : this.t.variableDeclaration('var', [declarator])
+    ])
+
+    const parent = this.path.parentPath
+    if (parent.isJSXElement() && this.path.container === parent.node.children) {
+      // turning the `span` in `<div><span /></div>` to an expression so we need to wrap it with
+      // an expression container
+      uid = this.t.jsxExpressionContainer(uid)
+    }
+
+    this.path.replaceWith(this.t.cloneNode(uid))
+
+    return attached.isVariableDeclarator()
+      ? attached.get('init')
+      : attached.get('declarations.0.init')
+  }
+}
+
+export function hoistPath(path, t) {
+  return new PathHoister(path, path.scope, t).run()
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -222,6 +222,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/code-frame@npm:8.0.0"
+  dependencies:
+    "@babel/helper-validator-identifier": ^8.0.0
+    js-tokens: ^10.0.0
+  checksum: b0cab876cd938f3e5101ada3f1708b9a84c22bdcb6a9497ad4db17fc0600e1d32e0a3a159ecf53562c92720a714bc5275a171bcfeabeeb1b3247cd8afb757b9c
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.12.1, @babel/compat-data@npm:^7.17.7, @babel/compat-data@npm:^7.18.8":
   version: 7.18.8
   resolution: "@babel/compat-data@npm:7.18.8"
@@ -233,6 +243,13 @@ __metadata:
   version: 7.24.7
   resolution: "@babel/compat-data@npm:7.24.7"
   checksum: 1fc276825dd434fe044877367dfac84171328e75a8483a6976aa28bf833b32367e90ee6df25bdd97c287d1aa8019757adcccac9153de70b1932c0d243a978ae9
+  languageName: node
+  linkType: hard
+
+"@babel/compat-data@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/compat-data@npm:8.0.0"
+  checksum: 058468d5296443a59d3bef98eaaa6a80adbfbb39e42d30bcdf64463bfa23b78fb84e90c60a5a20ced746f9de4f6094a8201e894f2155b9ea52ea89714d2700b3
   languageName: node
   linkType: hard
 
@@ -329,6 +346,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/generator@npm:8.0.0"
+  dependencies:
+    "@babel/parser": ^8.0.0
+    "@babel/types": ^8.0.0
+    "@jridgewell/gen-mapping": ^0.3.12
+    "@jridgewell/trace-mapping": ^0.3.28
+    "@types/jsesc": ^2.5.0
+    jsesc: ^3.0.2
+  checksum: 9b8e5d67cf78640fa50659540646129fc980ed1d9f5f92266cec14365106508cd4595e34df261d486fdf4f55ecc4b397841fa261e727f864c80578e58aabb8aa
+  languageName: node
+  linkType: hard
+
 "@babel/helper-annotate-as-pure@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-annotate-as-pure@npm:7.18.6"
@@ -372,6 +403,19 @@ __metadata:
     lru-cache: ^5.1.1
     semver: ^6.3.1
   checksum: dfc88bc35e223ade796c7267901728217c665adc5bc2e158f7b0ae850de14f1b7941bec4fe5950ae46236023cfbdeddd9c747c276acf9b39ca31f8dd97dc6cc6
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/helper-compilation-targets@npm:8.0.0"
+  dependencies:
+    "@babel/compat-data": ^8.0.0
+    "@babel/helper-validator-option": ^8.0.0
+    browserslist: ^4.24.0
+    lru-cache: ^11.0.0
+    semver: ^7.7.3
+  checksum: 08fc8cbc00716f6688f90981492ec8255ccf51909a485b85de3839c6b578b818b4ffd7fb46b7d695ac77ed90832a9b189b4dbe35c814c1d449a211eab3134749
   languageName: node
   linkType: hard
 
@@ -462,6 +506,13 @@ __metadata:
     "@babel/template": ^7.24.7
     "@babel/types": ^7.24.7
   checksum: 142ee08922074dfdc0ff358e09ef9f07adf3671ab6eef4fca74dcf7a551f1a43717e7efa358c9e28d7eea84c28d7f177b7a58c70452fc312ae3b1893c5dab2a4
+  languageName: node
+  linkType: hard
+
+"@babel/helper-globals@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/helper-globals@npm:8.0.0"
+  checksum: c18299171739cf7ed1ce5c406d0ca2bbb34c8f580f75ccc718b1a771306d7db69182a39dc9b479c811197e0e45ae33bbc1bb0c6b352bdba857cdd68c0c2da4a8
   languageName: node
   linkType: hard
 
@@ -645,6 +696,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/helper-string-parser@npm:8.0.0"
+  checksum: 796a8b1e6c598f73c2ab98d3ea192374587cfdea6ec36e43fac428e119d9467c43eb97b48aef678994a80acccac2afac9cab32b74e774790212c9f885bc2d25f
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-validator-identifier@npm:7.18.6"
@@ -659,6 +717,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^8.0.0, @babel/helper-validator-identifier@npm:^8.0.4":
+  version: 8.0.4
+  resolution: "@babel/helper-validator-identifier@npm:8.0.4"
+  checksum: edf6433ef4e4ec936dc15c49230d4b73e2eef634e25f2e5ea008c1b807e47868952e5fe8d592b71f609e5fb8de57dd8fceb0f733767e07ffec22cd327138f2c0
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.12.1, @babel/helper-validator-option@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-validator-option@npm:7.18.6"
@@ -670,6 +735,13 @@ __metadata:
   version: 7.24.7
   resolution: "@babel/helper-validator-option@npm:7.24.7"
   checksum: 9689166bf3f777dd424c026841c8cd651e41b21242dbfd4569a53086179a3e744c8eddd56e9d10b54142270141c91581b53af0d7c00c82d552d2540e2a919f7e
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/helper-validator-option@npm:8.0.0"
+  checksum: 12c2bf5457fbe1ff0701321b4e471420d46a94a2b10858042c7a96134894212ba04224021345c8572ed3eb7b536890deb842ccd7e5f655aa56de594529ec64d0
   languageName: node
   linkType: hard
 
@@ -703,6 +775,16 @@ __metadata:
     "@babel/template": ^7.24.7
     "@babel/types": ^7.24.7
   checksum: 934da58098a3670ca7f9f42425b9c44d0ca4f8fad815c0f51d89fc7b64c5e0b4c7d5fec038599de691229ada737edeaf72fad3eba8e16dd5842e8ea447f76b66
+  languageName: node
+  linkType: hard
+
+"@babel/helpers@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/helpers@npm:8.0.0"
+  dependencies:
+    "@babel/template": ^8.0.0
+    "@babel/types": ^8.0.0
+  checksum: caf6ecd8ec34c9f5fa6ac57b92b13700726c0d2b04f77b251b64ce1e0a5bd3641bf435450116c5a607eb7fe0a3a00329a406a6ec0b725d3b3baa70205940a617
   languageName: node
   linkType: hard
 
@@ -744,6 +826,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: fc9d2c4c8712f89672edc55c0dc5cf640dcec715b56480f111f85c2bc1d507e251596e4110d65796690a96ac37a4b60432af90b3e97bb47e69d4ef83872dbbd6
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^8.0.0, @babel/parser@npm:^8.0.4":
+  version: 8.0.4
+  resolution: "@babel/parser@npm:8.0.4"
+  dependencies:
+    "@babel/types": ^8.0.4
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 256943cc4b5bfbd5d71d9fe67b61d87b5c391d4c984262ebe53468e7ff850df773ee8019d0826d17aeabbd75e81bc7b2d44c44445511286f908fd50cd6c3d6b0
   languageName: node
   linkType: hard
 
@@ -2177,6 +2270,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@babel/template@npm:8.0.0"
+  dependencies:
+    "@babel/code-frame": ^8.0.0
+    "@babel/parser": ^8.0.0
+    "@babel/types": ^8.0.0
+  checksum: a243ac9b658ffc890fd283510b03b234390237430ff9777a4f7fc9046def3e62dd83824098b9958e127e1f09d1657531b5833218c7440df188e16bf7de0736b3
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.0.0, @babel/traverse@npm:^7.1.0, @babel/traverse@npm:^7.12.1, @babel/traverse@npm:^7.18.9, @babel/traverse@npm:^7.7.0":
   version: 7.18.9
   resolution: "@babel/traverse@npm:7.18.9"
@@ -2213,6 +2317,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^8.0.0":
+  version: 8.0.4
+  resolution: "@babel/traverse@npm:8.0.4"
+  dependencies:
+    "@babel/code-frame": ^8.0.0
+    "@babel/generator": ^8.0.0
+    "@babel/helper-globals": ^8.0.0
+    "@babel/parser": ^8.0.4
+    "@babel/template": ^8.0.0
+    "@babel/types": ^8.0.4
+    obug: ^2.1.1
+  checksum: 83a4142d483bc55d1fcf4d529605e615c7e0c93e7e9add45da121f387f251072a2ef6ec95e50521a308713efac1d0b67b75a7284e5b2d1e8f37683611ac374e5
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.12.1, @babel/types@npm:^7.12.6, @babel/types@npm:^7.18.6, @babel/types@npm:^7.18.9, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.7.0, @babel/types@npm:^7.8.3":
   version: 7.18.9
   resolution: "@babel/types@npm:7.18.9"
@@ -2231,6 +2350,16 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.24.7
     to-fast-properties: ^2.0.0
   checksum: 3e4437fced97e02982972ce5bebd318c47d42c9be2152c0fd28c6f786cc74086cc0a8fb83b602b846e41df37f22c36254338eada1a47ef9d8a1ec92332ca3ea8
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^8.0.0, @babel/types@npm:^8.0.4":
+  version: 8.0.4
+  resolution: "@babel/types@npm:8.0.4"
+  dependencies:
+    "@babel/helper-string-parser": ^8.0.0
+    "@babel/helper-validator-identifier": ^8.0.4
+  checksum: 82cb72ddcc298808444e3418338eacd50b5e06aefdae76e8fdf076afa94a0bd435a7a2dc12966ad52355a1df63ad69c9e42f81baa6da6586569291d29971d2cc
   languageName: node
   linkType: hard
 
@@ -3811,6 +3940,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/gen-mapping@npm:^0.3.12":
+  version: 0.3.13
+  resolution: "@jridgewell/gen-mapping@npm:0.3.13"
+  dependencies:
+    "@jridgewell/sourcemap-codec": ^1.5.0
+    "@jridgewell/trace-mapping": ^0.3.24
+  checksum: f2105acefc433337145caa3c84bba286de954f61c0bc46279bbd85a9e6a02871089717fa060413cfb6a9d44189fe8313b2d1cabf3a2eb3284d208fd5f75c54ff
+  languageName: node
+  linkType: hard
+
 "@jridgewell/gen-mapping@npm:^0.3.2":
   version: 0.3.2
   resolution: "@jridgewell/gen-mapping@npm:0.3.2"
@@ -3885,6 +4024,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/sourcemap-codec@npm:^1.5.0":
+  version: 1.5.5
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
+  checksum: c2e36e67971f719a8a3a85ef5a5f580622437cc723c35d03ebd0c9c0b06418700ef006f58af742791f71f6a4fc68fcfaf1f6a74ec2f9a3332860e9373459dae7
+  languageName: node
+  linkType: hard
+
 "@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25":
   version: 0.3.25
   resolution: "@jridgewell/trace-mapping@npm:0.3.25"
@@ -3892,6 +4038,16 @@ __metadata:
     "@jridgewell/resolve-uri": ^3.1.0
     "@jridgewell/sourcemap-codec": ^1.4.14
   checksum: 9d3c40d225e139987b50c48988f8717a54a8c994d8a948ee42e1412e08988761d0754d7d10b803061cc3aebf35f92a5dbbab493bd0e1a9ef9e89a2130e83ba34
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.28":
+  version: 0.3.31
+  resolution: "@jridgewell/trace-mapping@npm:0.3.31"
+  dependencies:
+    "@jridgewell/resolve-uri": ^3.1.0
+    "@jridgewell/sourcemap-codec": ^1.4.14
+  checksum: af8fda2431348ad507fbddf8e25f5d08c79ecc94594061ce402cf41bc5aba1a7b3e59bf0fd70a619b35f33983a3f488ceeba8faf56bff784f98bb5394a8b7d47
   languageName: node
   linkType: hard
 
@@ -6381,6 +6537,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/gensync@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "@types/gensync@npm:1.0.5"
+  checksum: 1b417012a1249c60d2a5d3a646c208710473f31ab91ee702d4a0bf742d4d20a04c4296efcf6f42b7c1b38536ff732c3aa00dd5afc8fa138c70d1905a0521a5c3
+  languageName: node
+  linkType: hard
+
 "@types/glob@npm:^7.1.1":
   version: 7.1.1
   resolution: "@types/glob@npm:7.1.1"
@@ -6523,6 +6686,13 @@ __metadata:
     "@types/tough-cookie": "*"
     parse5: ^7.0.0
   checksum: d55402c5256ef451f93a6e3d3881f98339fe73a5ac2030588df056d6835df8367b5a857b48d27528289057e26dcdd3f502edc00cb877c79174cb3a4c7f2198c1
+  languageName: node
+  linkType: hard
+
+"@types/jsesc@npm:^2.5.0":
+  version: 2.5.1
+  resolution: "@types/jsesc@npm:2.5.1"
+  checksum: fb4303b059df0b6834f26446712d890a93fa7c446347b61505a925e07c7fab3aaab083940bca0be8d521779a2a6a5c16a75136f6de753f4a65c1f24fd7c6aee6
   languageName: node
   linkType: hard
 
@@ -9130,6 +9300,30 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"babel8@npm:@babel/core@^8.0.0":
+  version: 8.0.1
+  resolution: "@babel/core@npm:8.0.1"
+  dependencies:
+    "@babel/code-frame": ^8.0.0
+    "@babel/generator": ^8.0.0
+    "@babel/helper-compilation-targets": ^8.0.0
+    "@babel/helpers": ^8.0.0
+    "@babel/parser": ^8.0.0
+    "@babel/template": ^8.0.0
+    "@babel/traverse": ^8.0.0
+    "@babel/types": ^8.0.0
+    "@types/gensync": ^1.0.5
+    convert-source-map: ^2.0.0
+    empathic: ^2.0.1
+    gensync: ^1.0.0-beta.2
+    import-meta-resolve: ^4.2.0
+    json5: ^2.2.3
+    obug: ^2.1.1
+    semver: ^7.7.3
+  checksum: 567910df2a92707fb5c87ce424d58ab47515b75703509b6e42fff0ac443d93a16fe2472ad365aa798b88b5d82fa866348ebbfc4223bade51ba341528667b06b9
+  languageName: node
+  linkType: hard
+
 "babylon@npm:^6.18.0":
   version: 6.18.0
   resolution: "babylon@npm:6.18.0"
@@ -9195,6 +9389,15 @@ __metadata:
     mixin-deep: ^1.2.0
     pascalcase: ^0.1.1
   checksum: a4a146b912e27eea8f66d09cb0c9eab666f32ce27859a7dfd50f38cd069a2557b39f16dba1bc2aecb3b44bf096738dd207b7970d99b0318423285ab1b1994edd
+  languageName: node
+  linkType: hard
+
+"baseline-browser-mapping@npm:^2.10.44":
+  version: 2.11.7
+  resolution: "baseline-browser-mapping@npm:2.11.7"
+  bin:
+    baseline-browser-mapping: dist/cli.cjs
+  checksum: 5bbee2c7c599cdc1336c53b62f39fc1101b25cd34384534f339b204e684695eb87c33d5aae82371ee676e5b1fca0f2fb2bb554030e6d0203c28843955def3f4d
   languageName: node
   linkType: hard
 
@@ -9592,6 +9795,21 @@ __metadata:
   bin:
     browserslist: cli.js
   checksum: 06189e2d6666a203ce097cc0e713a40477d08420927b79af139211e5712f3cf676fdc4dd6af3aa493d47c09206a344b3420a8315577dbe88c58903132de9b0f5
+  languageName: node
+  linkType: hard
+
+"browserslist@npm:^4.24.0":
+  version: 4.28.7
+  resolution: "browserslist@npm:4.28.7"
+  dependencies:
+    baseline-browser-mapping: ^2.10.44
+    caniuse-lite: ^1.0.30001806
+    electron-to-chromium: ^1.5.393
+    node-releases: ^2.0.51
+    update-browserslist-db: ^1.2.3
+  bin:
+    browserslist: cli.js
+  checksum: 81093d27f0b0c9207e42af04655607ea870d6eb9c04b38106ffcf36e05f436747caf250604abd5471eab55b16eb2be305d8e5a7c61a5636df34a7b9397737756
   languageName: node
   linkType: hard
 
@@ -10001,6 +10219,13 @@ __metadata:
   version: 1.0.30001634
   resolution: "caniuse-lite@npm:1.0.30001634"
   checksum: 5ab273ec36fee64b148bee8a84e758eb22cc282cce9af41eb0d36a0cdd2b90ff96ba502be89aaf0448b3153cd100629acac94971bb5cb9016f6c5ccbeda944b2
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001806":
+  version: 1.0.30001806
+  resolution: "caniuse-lite@npm:1.0.30001806"
+  checksum: 4b4a970fbd7cb7b8ee6b5068336f7afa7d9cc65ff444080630ab363dcb44205994f68897c7685dc3de4f04dd1f65ec395e50790a594d0470db4894bedf5cb379
   languageName: node
   linkType: hard
 
@@ -12623,6 +12848,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"electron-to-chromium@npm:^1.5.393":
+  version: 1.5.398
+  resolution: "electron-to-chromium@npm:1.5.398"
+  checksum: 35f8a8b776888a56ae0627869f0d55f2fbeeb59b63600ffcb11bbfb16bc55e5e26a67d6812110b624185ee57440744caa8af565eb7b01121b560e7681511dae1
+  languageName: node
+  linkType: hard
+
 "elegant-spinner@npm:^1.0.1":
   version: 1.0.1
   resolution: "elegant-spinner@npm:1.0.1"
@@ -12723,6 +12955,7 @@ __metadata:
     babel-jest: ^29.7.0
     babel-plugin-codegen: ^4.1.5
     babel-plugin-jsx-pragmatic: ^1.0.2
+    babel8: "npm:@babel/core@^8.0.0"
     benchmark: ^2.1.4
     bolt-check: ^0.3.0
     bundlesize: ^0.13.2
@@ -12807,6 +13040,13 @@ __metadata:
     unist-util-visit: ^4.1.0
   languageName: unknown
   linkType: soft
+
+"empathic@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "empathic@npm:2.0.1"
+  checksum: c5a37b78926e722c38779e5026342350098771fa1cacb52cb808e5329896ab39abb88cd2f1374671d6e5c98aa24cba2534f00da2938d04f11de1a2d012ee75c3
+  languageName: node
+  linkType: hard
 
 "encodeurl@npm:~1.0.2":
   version: 1.0.2
@@ -13351,6 +13591,13 @@ __metadata:
   version: 3.1.2
   resolution: "escalade@npm:3.1.2"
   checksum: 1ec0977aa2772075493002bdbd549d595ff6e9393b1cb0d7d6fcaf78c750da0c158f180938365486f75cb69fba20294351caddfce1b46552a7b6c3cde52eaa02
+  languageName: node
+  linkType: hard
+
+"escalade@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "escalade@npm:3.2.0"
+  checksum: 47b029c83de01b0d17ad99ed766347b974b0d628e848de404018f3abee728e987da0d2d370ad4574aa3d5b5bfc368754fd085d69a30f8e75903486ec4b5b709e
   languageName: node
   linkType: hard
 
@@ -16854,6 +17101,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"import-meta-resolve@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "import-meta-resolve@npm:4.2.0"
+  checksum: fe5ca3258f22dc3dd4e2f2e8f6b54324c1cf0261216c7d9aae801b2eadf664bbd61e26cfb907a1238761285a3e9c8c23403321d52ca0e579c341b8d90c97fa52
+  languageName: node
+  linkType: hard
+
 "imurmurhash@npm:^0.1.4":
   version: 0.1.4
   resolution: "imurmurhash@npm:0.1.4"
@@ -19420,6 +19674,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-tokens@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "js-tokens@npm:10.0.0"
+  checksum: 1bc804299157b0a81543f9975d380aaf9e4bd57853e41623a10ebd364dad30682d2f194d1b0485832cd85a59a0bef21fbfc7a063a95575b782ddecaa804647fb
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -19619,6 +19880,15 @@ __metadata:
   bin:
     jsesc: bin/jsesc
   checksum: 4dc190771129e12023f729ce20e1e0bfceac84d73a85bc3119f7f938843fe25a4aeccb54b6494dce26fcf263d815f5f31acdefac7cc9329efb8422a4f4d9fa9d
+  languageName: node
+  linkType: hard
+
+"jsesc@npm:^3.0.2":
+  version: 3.1.0
+  resolution: "jsesc@npm:3.1.0"
+  bin:
+    jsesc: bin/jsesc
+  checksum: 19c94095ea026725540c0d29da33ab03144f6bcf2d4159e4833d534976e99e0c09c38cefa9a575279a51fc36b31166f8d6d05c9fe2645d5f15851d690b41f17f
   languageName: node
   linkType: hard
 
@@ -20562,6 +20832,13 @@ __metadata:
   version: 2.0.0
   resolution: "lowercase-keys@npm:2.0.0"
   checksum: 24d7ebd56ccdf15ff529ca9e08863f3c54b0b9d1edb97a3ae1af34940ae666c01a1e6d200707bce730a8ef76cb57cc10e65f245ecaaf7e6bc8639f2fb460ac23
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^11.0.0":
+  version: 11.5.2
+  resolution: "lru-cache@npm:11.5.2"
+  checksum: ea040bdd8255384d1965c09983e1357ef6eca044747917c2f9db610f3fc773a518ea86bbcffb3b376f793ed61729f240c69cc5593ec89062d64e31c50973f3c0
   languageName: node
   linkType: hard
 
@@ -22953,6 +23230,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-releases@npm:^2.0.51":
+  version: 2.0.51
+  resolution: "node-releases@npm:2.0.51"
+  checksum: 0d607ebc5c1aa94ef110e6ab926ec51fca55b8534a889a42ffeda1575af00b3bf2e2473898fa45213a3dfedde5f2cedfc4dee2060967e97d6b9518531e388710
+  languageName: node
+  linkType: hard
+
 "node-stream-zip@npm:^1.9.1":
   version: 1.11.3
   resolution: "node-stream-zip@npm:1.11.3"
@@ -23582,6 +23866,13 @@ __metadata:
   version: 1.1.2
   resolution: "obuf@npm:1.1.2"
   checksum: 41a2ba310e7b6f6c3b905af82c275bf8854896e2e4c5752966d64cbcd2f599cfffd5932006bcf3b8b419dfdacebb3a3912d5d94e10f1d0acab59876c8757f27f
+  languageName: node
+  linkType: hard
+
+"obug@npm:^2.1.1":
+  version: 2.1.4
+  resolution: "obug@npm:2.1.4"
+  checksum: 2a70ee823423b1092881473cf4283a503e8bcbf5e4bd4be7856949af9ec3eb75fec1033caac97578ab723546273ba66d7b2b074e75ea02c226a549f7d7bdd7e7
   languageName: node
   linkType: hard
 
@@ -24442,6 +24733,13 @@ __metadata:
   version: 1.0.1
   resolution: "picocolors@npm:1.0.1"
   checksum: fa68166d1f56009fc02a34cdfd112b0dd3cf1ef57667ac57281f714065558c01828cdf4f18600ad6851cbe0093952ed0660b1e0156bddf2184b6aaf5817553a5
+  languageName: node
+  linkType: hard
+
+"picocolors@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "picocolors@npm:1.1.1"
+  checksum: e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
   languageName: node
   linkType: hard
 
@@ -28094,6 +28392,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.7.3":
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
+  bin:
+    semver: bin/semver.js
+  checksum: 0c580f17e88e2b45806dc5cf3d824f719c946999d3554bf30307c2b68b3300ab3c8bfcd84d8f489b93b4cbb5362f5fc8de4d2858954f18d834253c4450fc9f6b
+  languageName: node
+  linkType: hard
+
 "send@npm:0.17.1":
   version: 0.17.1
   resolution: "send@npm:0.17.1"
@@ -30974,6 +31281,20 @@ __metadata:
   bin:
     update-browserslist-db: cli.js
   checksum: 51b1f7189c9ea5925c80154b0a6fd3ec36106d07858d8f69826427d8edb4735d1801512c69eade38ba0814d7407d11f400d74440bbf3da0309f3d788017f35b2
+  languageName: node
+  linkType: hard
+
+"update-browserslist-db@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "update-browserslist-db@npm:1.2.3"
+  dependencies:
+    escalade: ^3.2.0
+    picocolors: ^1.1.1
+  peerDependencies:
+    browserslist: ">= 4.21.0"
+  bin:
+    update-browserslist-db: cli.js
+  checksum: 6f209a97ae8eacdd3a1ef2eb365adf49d1e2a757e5b2dd4ac87dc8c99236cbe3e572d3e605a87dd7b538a11751b71d9f93edc47c7405262a293a493d155316cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Replaced the `path.hoist()` call in `@emotion/babel-plugin` with a copy of Babel 7's `PathHoister`, so the plugin works with both Babel 7 and Babel 8.

Fixes: https://github.com/emotion-js/emotion/issues/3386

<!-- Why are these changes necessary? -->

**Why**:

`NodePath#hoist` was removed in `@babel/traverse@8` without a replacement (https://babeljs.io/docs/v8-migration-api), so any build running this plugin with `@babel/core@8` fails with `TypeError: path.hoist is not a function`.

<!-- How were these changes implemented? -->

**How**:

- Vendored `PathHoister` from `@babel/traverse@7.28.4` into `src/utils/path-hoister.js`. The only changes are that `@babel/types` is taken from the running Babel instance and that the class is exposed through a `hoistPath` helper.
- Added a Jest test that checks `hoistPath` produces the same output as the native `path.hoist` on Babel 7.
- Added `yarn test:babel8` (and a CI job for it) which runs the plugin against `@babel/core@8` and asserts the output matches Babel 7's. It is a `node:test` script rather than a Jest test because Babel 8 is ESM-only and requires Node.js `^22.18.0 || >=24.11.0`.

Note: `@emotion/babel-preset-css-prop` still doesn't work with Babel 8 - it bundles `@babel/plugin-transform-react-jsx@^7` which refuses to load there. That seemed better left for a separate PR.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset

<!-- feel free to add additional comments -->
