### PR TITLE
Fix dtslint CI failures caused by the typescript@next dist-tag now resolving to TypeScript 7

### DIFF
--- a/.yarn/patches/@definitelytyped-utils-npm-0.0.112-5e73d8f58c.patch
+++ b/.yarn/patches/@definitelytyped-utils-npm-0.0.112-5e73d8f58c.patch
@@ -1,0 +1,15 @@
+diff --git a/dist/typescript-installer.js b/dist/typescript-installer.js
+index 53875d93f80d796e6237996a47dc5d9e4d374f1d..577c523c376526ade92fcdb46f4eb26557688f6b 100644
+--- a/dist/typescript-installer.js
++++ b/dist/typescript-installer.js
+@@ -35,7 +35,9 @@ async function installAllTypeScriptVersions() {
+ }
+ exports.installAllTypeScriptVersions = installAllTypeScriptVersions;
+ async function installTypeScriptNext() {
+-    await install("next");
++    // the `next` dist-tag no longer points to a 4.7-dev build, so install
++    // the stable release of the latest supported version instead
++    await install(typescript_versions_1.TypeScriptVersion.latest);
+ }
+ exports.installTypeScriptNext = installTypeScriptNext;
+ async function install(version) {

--- a/package.json
+++ b/package.json
@@ -245,6 +245,7 @@
   },
   "packageManager": "yarn@3.2.3",
   "resolutions": {
-    "@definitelytyped/dtslint@0.0.112": "patch:@definitelytyped/dtslint@npm%3A0.0.112#./.yarn/patches/@definitelytyped-dtslint-npm-0.0.112-1e6b842976.patch"
+    "@definitelytyped/dtslint@0.0.112": "patch:@definitelytyped/dtslint@npm%3A0.0.112#./.yarn/patches/@definitelytyped-dtslint-npm-0.0.112-1e6b842976.patch",
+    "@definitelytyped/utils@^0.0.112": "patch:@definitelytyped/utils@npm%3A0.0.112#./.yarn/patches/@definitelytyped-utils-npm-0.0.112-5e73d8f58c.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2619,7 +2619,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@definitelytyped/utils@npm:^0.0.112":
+"@definitelytyped/utils@npm:0.0.112":
   version: 0.0.112
   resolution: "@definitelytyped/utils@npm:0.0.112"
   dependencies:
@@ -2632,6 +2632,22 @@ __metadata:
     tar: ^2.2.2
     tar-stream: ^2.1.4
   checksum: ff3542f40753421ea2c07373c6ed0bce17cd02d77fa2dd6ca00ee36e1aedfdf3990328c536a95f709a34d92591adb0af2cb8e99c91fe7763127de750f6a72b59
+  languageName: node
+  linkType: hard
+
+"@definitelytyped/utils@patch:@definitelytyped/utils@npm%3A0.0.112#./.yarn/patches/@definitelytyped-utils-npm-0.0.112-5e73d8f58c.patch::locator=emotion-monorepo%40workspace%3A.":
+  version: 0.0.112
+  resolution: "@definitelytyped/utils@patch:@definitelytyped/utils@npm%3A0.0.112#./.yarn/patches/@definitelytyped-utils-npm-0.0.112-5e73d8f58c.patch::version=0.0.112&hash=ca299c&locator=emotion-monorepo%40workspace%3A."
+  dependencies:
+    "@definitelytyped/typescript-versions": ^0.0.112
+    "@qiwi/npm-registry-client": ^8.9.1
+    "@types/node": ^14.14.35
+    charm: ^1.0.2
+    fs-extra: ^8.1.0
+    fstream: ^1.0.12
+    tar: ^2.2.2
+    tar-stream: ^2.1.4
+  checksum: a9b3f739a050fad2f0baead3e94a8bbc49abc50fc92bc03bed88df3e0f9beea195ae20f28804a9333bedc0c31530a89e5be7f368cd6236a6512c42c5e0c3e100
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

- Fix the `dtslint` CI job, which currently fails on `main` for every package with:
  `Error: Cannot find module '/home/runner/.dts/typescript-installs/4.7/node_modules/typescript'`

<!-- Why are these changes necessary? -->

**Why**:

- `@definitelytyped/dtslint@0.0.112` tests each package up to the newest TypeScript version it knows about (4.7). Since 4.7 was unreleased when that version of dtslint shipped, its installer provisions that slot with `npm install typescript@next`.
- The `next` dist-tag no longer points to a 4.7-dev build — it now resolves to the TypeScript 7 native preview (currently `7.1.0-dev.*`), which is an ESM-only package without a `main` field, so dtslint's `require()` of the install path throws. This broke CI independently of any changes in this repo.

<!-- How were these changes implemented? -->

**How**:

- Added a `yarn patch` for `@definitelytyped/utils@0.0.112` (mirroring the existing patch we carry for dtslint itself) that changes `installTypeScriptNext()` to install the stable release of the latest supported version (`typescript@4.7`, resolving to 4.7.4) instead of the moving `next` dist-tag.
- Same install directory and lint behavior as before — if anything, the job now tests against the released 4.7.4 rather than a 2022 nightly.
- Verified locally with a clean `~/.dts` cache: `yarn build && yarn test:typescript` passes for all workspaces.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation N/A
- [x] Tests N/A (CI tooling fix — verified by the dtslint job itself)
- [x] Code complete
- [x] Changeset N/A (no package is released by this change)
