### PR TITLE
Add documentation for the `speedy` cache option

### DIFF
--- a/docs/docs.yaml
+++ b/docs/docs.yaml
@@ -22,6 +22,7 @@
     - class-names
     - cache-provider
     - performance
+    - speedy
     - for-library-authors
     - community # There is code to hide this from the menu since it has its own navbar link
 

--- a/docs/speedy.mdx
+++ b/docs/speedy.mdx
@@ -1,0 +1,50 @@
+---
+title: 'Speedy'
+---
+
+`speedy` is an option accepted by [`createCache`](/packages/cache#options) (and, at runtime, by `@emotion/css`'s `sheet`) that controls **how** emotion inserts rules into the stylesheet it manages.
+
+- When `speedy` is `false`, emotion inserts a rule by appending a text node containing the CSS to a `<style>` element. This is what you see when you inspect styles in devtools, and it's how the rules end up editable there.
+- When `speedy` is `true`, emotion instead inserts rules directly into the CSSOM using [`CSSStyleSheet.insertRule`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/insertRule). This is much faster, but the inserted rules don't show up as editable text in the `<style>` tag, so they can't be tweaked live in devtools.
+
+By default, `speedy` is **enabled in production and disabled in development**, so you get fast style insertion in production while still being able to inspect and live-edit styles while developing.
+
+## Configuring it
+
+Most apps never need to touch this option, but you can override it in two ways:
+
+**At cache creation time**, via [`createCache`](/packages/cache#options):
+
+```jsx
+import createCache from '@emotion/cache'
+
+const cache = createCache({
+  key: 'my-cache',
+  speedy: false
+})
+```
+
+**At runtime**, if you're using `@emotion/css`, via `sheet.speedy(...)`:
+
+```js
+import { sheet } from '@emotion/css'
+
+sheet.speedy(false)
+```
+
+> Note:
+>
+> `sheet.speedy(...)` must be called before any styles have been inserted — it throws in development if you call it after the first `insert`. This means it needs to run in its own module that's imported before anything else that might insert styles. See the [Puppeteer section of the SSR docs](/docs/ssr#puppeteer) for a worked example.
+
+## Known caveats
+
+`speedy`'s reliance on the CSSOM instead of plain text nodes has a few consequences worth knowing about before you rely on it (or before you disable it to work around one of them):
+
+- **Rules aren't editable in devtools.** Since the CSS text isn't present as a text node, you can't tweak declarations live in the Elements/Inspector panel the way you normally would. This is expected, not a bug.
+- **Prerendering tools that read the DOM as text won't see the rules.** Tools like Puppeteer serialize the DOM's HTML, which doesn't include rules inserted via `insertRule`. Disable `speedy` while prerendering — see the [Puppeteer section of the SSR docs](/docs/ssr#puppeteer).
+- **Styles can fail to apply reliably in Shadow DOM on Safari/WebKit-based webviews**, particularly when elements are inserted or re-rendered after the stylesheet has already been created. This shows up as styles that "stick" on first paint but don't apply to elements added later. See [#2508](https://github.com/emotion-js/emotion/issues/2508) for a reproduction and discussion. If you hit this, disabling `speedy` for the affected cache is currently the most reliable workaround.
+- **It can trigger forced synchronous reflows in some scenarios**, which can be noticeable with very large numbers of DOM nodes. See [#3109](https://github.com/emotion-js/emotion/issues/3109).
+- **It can interact unexpectedly with the `nonce` option**, especially when combined with `prepend`/`insertionPoint`. See [#2708](https://github.com/emotion-js/emotion/issues/2708) if you're using a CSP nonce and see violations.
+- **Unsupported vendor-prefixed selectors are silently dropped in production**, and log a console error in development (most visible in Firefox for engine-specific pseudo-classes/elements like `::-moz-placeholder`). See [#3111](https://github.com/emotion-js/emotion/issues/3111).
+
+If you run into one of these issues and disabling `speedy` isn't practical for your whole app, note that `speedy` is set per-cache, so you can create a separate cache with `speedy: false` for just the part of the tree that needs it.

--- a/docs/ssr.mdx
+++ b/docs/ssr.mdx
@@ -258,7 +258,15 @@ export const wrapRootElement = ({ element }) => (
 
 ## Puppeteer
 
-If you are using Puppeteer to prerender your application, emotion's `speedy` option has to be disabled so that the CSS is rendered into the DOM.
+If you are using Puppeteer to prerender your application, emotion's [`speedy`](/docs/speedy) option has to be disabled so that the CSS is rendered into the DOM as text instead of being inserted directly into the CSSOM.
+
+If you're creating your own cache with [`createCache`](/packages/cache#options), you can just pass `speedy: false` to it instead of using the runtime toggle below:
+
+```js
+createCache({ key: 'my-cache', speedy: false })
+```
+
+If you're using `@emotion/css`'s default cache, use the runtime `sheet.speedy(...)` toggle instead, since there's no `createCache` call to pass an option to:
 
 index.js
 

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -55,8 +55,42 @@ The prefix before class names. It will also be set as the value of the `data-emo
 
 A DOM node that emotion will insert all of its style tags into. This is useful for inserting styles into iframes or windows.
 
+### `speedy`
+
+`boolean`
+
+A boolean representing whether to use [`insertRule`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/insertRule) (`true`) or text nodes (`false`) to insert styles into the stylesheet. `insertRule` is much faster but the inserted styles can't be edited in browser devtools. By default, `speedy` is enabled in production and disabled in development.
+
+> Note:
+>
+> `speedy` has a few known caveats, e.g. around Shadow DOM in Safari and prerendering tools that read the DOM as text. See the [Speedy docs](https://emotion.sh/docs/speedy) for the full explanation and workarounds.
+
+### `insertionPoint`
+
+`HTMLElement`
+
+A DOM node after which emotion will insert all of its style tags into the `container`. This is useful for controlling the order in which your styles are inserted relative to other stylesheets, e.g. to ensure a certain precedence when overriding styles.
+
+```jsx
+const head = document.querySelector('head')
+
+// <meta name="emotion-insertion-point" content="">
+const emotionInsertionPoint = document.createElement('meta')
+emotionInsertionPoint.setAttribute('name', 'emotion-insertion-point')
+emotionInsertionPoint.setAttribute('content', '')
+
+head.appendChild(emotionInsertionPoint)
+
+const cache = createCache({
+  key: 'my-app',
+  insertionPoint: emotionInsertionPoint
+})
+```
+
 ### `prepend`
 
 `boolean`
+
+**Deprecated:** Please use [`insertionPoint`](#insertionpoint) instead.
 
 A boolean representing whether to prepend rather than append style tags into the specified container DOM node.


### PR DESCRIPTION
What:

Added documentation for the speedy cache option and updated packages/cache/README.md's options list to include the previously-undocumented speedy and insertionPoint options, and marked prepend as deprecated.

Why:

speedy is enabled by default in production but had no dedicated documentation anywhere on emotion.sh — the only mention was a narrow aside in the SSR/Puppeteer docs. This has led to confusion behind several open issues (Shadow DOM styles not applying reliably in Safari, forced reflows, CSP nonce interactions, vendor-prefix console errors). Separately, packages/cache/README.md — the page linked from the CacheProvider docs as "the full list of options" — was missing speedy and insertionPoint entirely and didn't note that prepend is deprecated in favor of insertionPoint, even though that deprecation already exists internally in packages/cache/src/index.ts.

How:

- Added a new docs/speedy.mdx page explaining what speedy does, its default (on in production, off in development), how to configure it via createCache({ speedy }) or sheet.speedy(...), and a "Known caveats" section linking the relevant open issues (#2508, #3109, #2708, #3111).
- Added speedy to the Advanced section of docs/docs.yaml.
- Updated the Puppeteer sss-link the new page andshow createCache({ speedy: false }) as an alternative to the existing sheet.speedy(false) runtime toggle.
- Added ### speedy and ### insertionPoint entries to packages/cache/README.md's
Options section, and addeisting ### prepend entrypointing at insertionPoint.

Checklist:
- [x] Documentation
- [ ] Tests — N/A (docs-only change)
- [x] Code complete
- [ ] Changeset — N/A (docs-only change, no package behavior changed)

resolve #3394 