### PR TITLE
fix: add explicit React import to type declarations to prevent UMD global shadowing (fixes #3377)

### DIFF
--- a/packages/react/src/jsx-namespace.ts
+++ b/packages/react/src/jsx-namespace.ts
@@ -1,4 +1,5 @@
 import 'react'
+import * as React from 'react'
 import { Interpolation } from '@emotion/serialize'
 import { Theme } from './theming'
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,4 +1,5 @@
 import { ReactJSX } from './jsx-namespace'
+import * as React from 'react'
 
 /**
  * @desc Utility type for getting props type of React component.

--- a/packages/styled/src/jsx-namespace.ts
+++ b/packages/styled/src/jsx-namespace.ts
@@ -2,6 +2,7 @@
 // it helps to avoid issues when combining newer `@emotion/styled` and older `@emotion/react` versions
 // in such setup, ReactJSX namespace won't exist in `@emotion/react` and that would lead to errors
 import 'react'
+import * as React from 'react'
 
 type IsPreReact19 = 2 extends Parameters<React.FunctionComponent<any>>['length']
   ? true

--- a/packages/styled/src/types.ts
+++ b/packages/styled/src/types.ts
@@ -1,6 +1,7 @@
 import { ComponentSelector, Interpolation } from '@emotion/serialize'
 import { ReactJSXIntrinsicElements } from './jsx-namespace'
 import { PropsOf, Theme } from '@emotion/react'
+import * as React from 'react'
 
 /** Same as StyledOptions but shouldForwardProp must be a type guard */
 export interface FilteringStyledOptions<


### PR DESCRIPTION
## Summary

Fixes #3377 — `@emotion/styled` and `@emotion/react` type declarations rely on the UMD global `React` exposed by `@types/react` via `export as namespace React`. This breaks whenever a project declares a global `const React: typeof import('react')` (common in SSR/hydration or legacy interop setups): the value binding shadows the namespace, `StyledComponent extends React.FC<...>` loses its call signature, and every styled component fails TS2604 / TS2786 as a JSX element.

## Change

Add an explicit `import * as React from 'react'` to the four affected type source files so they resolve `React` from the module import rather than the ambient UMD global:

- `packages/styled/src/types.ts`
- `packages/styled/src/jsx-namespace.ts`
- `packages/react/src/types.ts`
- `packages/react/src/jsx-namespace.ts`

## Verification

Reproduced using the author's own repro repo (`pciarach/react-import-repro`) — published `@emotion/styled@11.14.1` fails with TS2604/TS2786 when a global `var React` is declared. The locally built declarations pass cleanly with the fix applied.

- `tsc --noEmit` at root: clean
- `packages/react/__tests__/warnings.js`: 48/48 pass (no regression)
- Built declarations (`preconstruct build`) now emit `import * as React from 'react'`