### PR TITLE
Remove the babel-plugin-macros dependency by rewrite createMacro

### DIFF
--- a/.changeset/friendly-files-relate.md
+++ b/.changeset/friendly-files-relate.md
@@ -1,0 +1,5 @@
+---
+'@emotion/babel-plugin': major
+---
+
+Removed the `babel-plugin-macros` dependency by inlining the tiny part of it that was actually used (`createMacro`). This drops `cosmiconfig` and the vulnerable `yaml@1.x` ([GHSA-48c2-rrv3-qjmp](https://github.com/advisories/GHSA-48c2-rrv3-qjmp)) from `@emotion/babel-plugin`'s dependency tree. The exported macros remain fully compatible with `babel-plugin-macros`-based setups (such as Create React App) — `@emotion/react/macro` and friends keep working unchanged.

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
     "babel-jest": "^29.7.0",
     "babel-plugin-codegen": "^4.1.5",
     "babel-plugin-jsx-pragmatic": "^1.0.2",
+    "babel-plugin-macros": "^3.1.0",
     "benchmark": "^2.1.4",
     "bolt-check": "^0.3.0",
     "bundlesize": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -196,7 +196,6 @@
     "babel-jest": "^29.7.0",
     "babel-plugin-codegen": "^4.1.5",
     "babel-plugin-jsx-pragmatic": "^1.0.2",
-    "babel-plugin-macros": "^3.1.0",
     "benchmark": "^2.1.4",
     "bolt-check": "^0.3.0",
     "bundlesize": "^0.13.2",

--- a/packages/babel-plugin/__tests__/create-macro.js
+++ b/packages/babel-plugin/__tests__/create-macro.js
@@ -1,0 +1,59 @@
+import { macros } from '@emotion/babel-plugin'
+import { createMacro, MacroError } from '../src/utils/create-macro'
+
+// The real babel-plugin-macros package checks `macro.isBabelMacro` and reads
+// `configName` from `macro.options` when users consume our /macro entrypoints
+// (e.g. @emotion/react/macro) through it. These tests pin that contract.
+test('macros expose the babel-plugin-macros interop contract', () => {
+  expect(Object.keys(macros).length).toBeGreaterThan(0)
+  Object.keys(macros).forEach(name => {
+    expect(macros[name].isBabelMacro).toBe(true)
+    expect(macros[name].options).toEqual({})
+  })
+})
+
+test('calling a macro outside of a macros-aware compilation throws MacroError', () => {
+  const macro = createMacro(() => {})
+  expect(() => macro({ source: 'some/macro' })).toThrow(
+    /is being executed outside the context of compilation/
+  )
+  let error
+  try {
+    macro({ source: 'some/macro' })
+  } catch (e) {
+    error = e
+  }
+  expect(error.name).toBe('MacroError')
+  // the same guard protects the shipped macros (e.g. @emotion/react/macro)
+  expect(() => macros.core({ source: '@emotion/react/macro' })).toThrow(
+    /is being executed outside the context of compilation/
+  )
+})
+
+test('invokes the wrapped macro and returns its result when isBabelMacrosCall is set', () => {
+  const inner = jest.fn(() => ({ keepImports: true }))
+  const macro = createMacro(inner)
+  const args = { source: 'some/macro', isBabelMacrosCall: true }
+  expect(macro(args)).toEqual({ keepImports: true })
+  expect(inner).toHaveBeenCalledTimes(1)
+  expect(inner).toHaveBeenCalledWith(args)
+})
+
+test('stamps the provided options on the wrapper', () => {
+  const macro = createMacro(() => {}, { configName: 'emotion' })
+  expect(macro.isBabelMacro).toBe(true)
+  expect(macro.options).toEqual({ configName: 'emotion' })
+})
+
+test('throws when the reserved configName "options" is used', () => {
+  expect(() => createMacro(() => {}, { configName: 'options' })).toThrow(
+    /You cannot use the configName "options"/
+  )
+})
+
+test('MacroError is an Error subclass with the correct name and message', () => {
+  const error = new MacroError('boom')
+  expect(error).toBeInstanceOf(Error)
+  expect(error.name).toBe('MacroError')
+  expect(error.message).toBe('boom')
+})

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -27,7 +27,6 @@
     "@emotion/hash": "^0.9.2",
     "@emotion/memoize": "^0.9.0",
     "@emotion/serialize": "^1.3.3",
-    "babel-plugin-macros": "^3.1.0",
     "convert-source-map": "^1.5.0",
     "escape-string-regexp": "^4.0.0",
     "find-root": "^1.1.0",

--- a/packages/babel-plugin/src/utils/create-macro.js
+++ b/packages/babel-plugin/src/utils/create-macro.js
@@ -1,0 +1,50 @@
+/*
+Vendored from babel-plugin-macros v3.1.0
+https://github.com/kentcdodds/babel-plugin-macros/blob/v3.1.0/src/index.js
+The MIT License (MIT) — Copyright (c) 2020 Kent C. Dodds
+
+Only `createMacro` and `MacroError` are vendored — @emotion/babel-plugin never
+used the config-loading (cosmiconfig) or module-resolution features of
+babel-plugin-macros.
+
+The `isBabelMacro` and `options` properties stamped on the wrapper are part of
+the babel-plugin-macros interop contract: the real babel-plugin-macros package
+checks `macro.isBabelMacro` and destructures `configName` from `macro.options`
+when users consume our `/macro` entrypoints (e.g. `@emotion/react/macro`)
+through it, such as in Create React App. `options` must always be an object.
+*/
+
+export class MacroError extends Error {
+  constructor(message /*: string */) {
+    super(message)
+    this.name = 'MacroError'
+    /* istanbul ignore else */
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor)
+    }
+  }
+}
+
+export function createMacro(macro /*: Function */, options /*: Object */ = {}) {
+  if (options.configName === 'options') {
+    throw new Error(
+      `You cannot use the configName "options". It is reserved for babel-plugin-macros.`
+    )
+  }
+  macroWrapper.isBabelMacro = true
+  macroWrapper.options = options
+  return macroWrapper
+
+  function macroWrapper(args /*: Object */) {
+    const { source, isBabelMacrosCall } = args
+    if (!isBabelMacrosCall) {
+      throw new MacroError(
+        `The macro you imported from "${source}" is being executed outside the context of compilation with babel-plugin-macros (or @emotion/babel-plugin). ` +
+          `This indicates that you don't have the babel plugin "babel-plugin-macros" (or "@emotion/babel-plugin") configured correctly. ` +
+          `Please see the documentation for how to configure babel-plugin-macros properly: ` +
+          'https://github.com/kentcdodds/babel-plugin-macros/blob/main/other/docs/user.md'
+      )
+    }
+    return macro(args)
+  }
+}

--- a/packages/babel-plugin/src/utils/transformer-macro.js
+++ b/packages/babel-plugin/src/utils/transformer-macro.js
@@ -1,4 +1,4 @@
-import { createMacro } from 'babel-plugin-macros'
+import { createMacro } from './create-macro'
 
 /*
 type Transformer = Function

--- a/scripts/babel-tester/package.json
+++ b/scripts/babel-tester/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "@babel/plugin-syntax-class-properties": "^7.12.13",
     "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-    "babel-check-duplicated-nodes": "^1.0.0"
+    "babel-check-duplicated-nodes": "^1.0.0",
+    "babel-plugin-macros": "^3.1.0"
   },
   "devDependencies": {
     "@types/jest-in-case": "^1.0.5"

--- a/scripts/babel-tester/src/index.ts
+++ b/scripts/babel-tester/src/index.ts
@@ -41,7 +41,9 @@ const tester = (allOpts: TesterOptions) => async (opts: TestCase) => {
   }
   const { code, ast } = babel.transformSync(rawCode!, {
     plugins: [
-      'macros',
+      // resolved explicitly so the interop suites run against this package's
+      // babel-plugin-macros version, not whichever copy got hoisted to the root
+      require.resolve('babel-plugin-macros'),
       '@babel/plugin-syntax-jsx',
       '@babel/plugin-syntax-class-properties',
       '@babel/plugin-syntax-object-rest-spread',

--- a/site/module-stubs/cosmiconfig.cjs
+++ b/site/module-stubs/cosmiconfig.cjs
@@ -1,1 +1,0 @@
-module.exports = () => ({})

--- a/site/module-stubs/resolve.cjs
+++ b/site/module-stubs/resolve.cjs
@@ -1,1 +1,0 @@
-module.exports = () => 'FAKE_PATH'

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -39,9 +39,7 @@ module.exports = withBundleAnalyzer({
           ...config.resolve.alias,
 
           // See site/module-stubs/README.md
-          cosmiconfig: path.resolve(__dirname, 'module-stubs/cosmiconfig.cjs'),
-          'find-root': path.resolve(__dirname, 'module-stubs/find-root.cjs'),
-          resolve: path.resolve(__dirname, 'module-stubs/resolve.cjs')
+          'find-root': path.resolve(__dirname, 'module-stubs/find-root.cjs')
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2681,7 +2681,6 @@ __metadata:
     "@emotion/memoize": ^0.9.0
     "@emotion/serialize": ^1.3.3
     babel-check-duplicated-nodes: ^1.0.0
-    babel-plugin-macros: ^3.1.0
     convert-source-map: ^1.5.0
     escape-string-regexp: ^4.0.0
     find-root: ^1.1.0
@@ -12723,6 +12722,7 @@ __metadata:
     babel-jest: ^29.7.0
     babel-plugin-codegen: ^4.1.5
     babel-plugin-jsx-pragmatic: ^1.0.2
+    babel-plugin-macros: ^3.1.0
     benchmark: ^2.1.4
     bolt-check: ^0.3.0
     bundlesize: ^0.13.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -9126,6 +9126,7 @@ __metadata:
     "@babel/plugin-syntax-object-rest-spread": ^7.8.3
     "@types/jest-in-case": ^1.0.5
     babel-check-duplicated-nodes: ^1.0.0
+    babel-plugin-macros: ^3.1.0
   languageName: unknown
   linkType: soft
 
@@ -12722,7 +12723,6 @@ __metadata:
     babel-jest: ^29.7.0
     babel-plugin-codegen: ^4.1.5
     babel-plugin-jsx-pragmatic: ^1.0.2
-    babel-plugin-macros: ^3.1.0
     benchmark: ^2.1.4
     bolt-check: ^0.3.0
     bundlesize: ^0.13.2


### PR DESCRIPTION


**What**:
 fixes #3379 by vendoring createMacro + MacroError (the only API emotion used) into packages/babel-plugin/src/utils/create-macro.js, per Andarist's fork-and-inline suggestion.

**Why**:
kills the babel-plugin-macros → cosmiconfig@7 → yaml@1.x (GHSA-48c2-rrv3-qjmp) audit chain permanently, with zero new dependencies — stronger than the cosmiconfig 9 bump originally requested.

**How**:
explains the single-import swap, the preserved CRA/babel-plugin-macros duck-typed interop contract, the new test file with 100% coverage of the vendored module, the root-level babel-plugin-macros pin for deterministic interop tests, and the docs-site stub cleanup.

**Checklist**:
Tests, Code complete, and Changeset checked; Documentation marked N/A (the existing docs describe the real-babel-plugin-macros usage path, which keeps working).

- [x] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
