### PR TITLE
fix(cache): preserve CSS variable names in inline margin/padding prefixer

### DIFF
--- a/.changeset/fix-prefixer-inline-property-regex.md
+++ b/.changeset/fix-prefixer-inline-property-regex.md
@@ -1,0 +1,5 @@
+---
+'@emotion/cache': patch
+---
+
+Fixed greedy `-inline` regex in prefixer so CSS variable names like `--my-margin-inline-end` are not stripped when prefixing logical margin/padding properties

--- a/packages/cache/__tests__/index.js
+++ b/packages/cache/__tests__/index.js
@@ -58,33 +58,37 @@ test('should accept container option', () => {
 test('should correctly prefix margin-inline and padding-inline properties without stripping CSS variable names', () => {
   const cache = createCache({ key: 'test-inline-prefix' })
 
-  cache.insert(
-    '.test1',
-    { name: '1', styles: 'margin-inline-end: var(--my-margin-inline-end);' },
-    cache.sheet,
-    true
-  )
-  cache.insert(
-    '.test2',
-    {
-      name: '2',
-      styles: 'padding-inline-start: var(--my-padding-inline-start);'
-    },
-    cache.sheet,
-    true
-  )
+  try {
+    cache.insert(
+      '.test1',
+      { name: '1', styles: 'margin-inline-end: var(--my-margin-inline-end);' },
+      cache.sheet,
+      true
+    )
+    cache.insert(
+      '.test2',
+      {
+        name: '2',
+        styles: 'padding-inline-start: var(--my-padding-inline-start);'
+      },
+      cache.sheet,
+      true
+    )
 
-  expect(
-    cache.sheet.tags
-      .map(
-        tag =>
-          tag.textContent ||
-          Array.from(tag.sheet.cssRules)
-            .map(r => r.cssText)
-            .join('')
-      )
-      .join('')
-  ).toMatchInlineSnapshot(
-    `".test1{-webkit-margin-end:var(--my-margin-inline-end);margin-inline-end:var(--my-margin-inline-end);}.test2{-webkit-padding-start:var(--my-padding-inline-start);padding-inline-start:var(--my-padding-inline-start);}"`
-  )
+    expect(
+      cache.sheet.tags
+        .map(
+          tag =>
+            tag.textContent ||
+            Array.from(tag.sheet.cssRules)
+              .map(r => r.cssText)
+              .join('')
+        )
+        .join('')
+    ).toMatchInlineSnapshot(
+      `".test1{-webkit-margin-end:var(--my-margin-inline-end);margin-inline-end:var(--my-margin-inline-end);}.test2{-webkit-padding-start:var(--my-padding-inline-start);padding-inline-start:var(--my-padding-inline-start);}"`
+    )
+  } finally {
+    cache.sheet.flush()
+  }
 })

--- a/packages/cache/__tests__/index.js
+++ b/packages/cache/__tests__/index.js
@@ -54,3 +54,37 @@ test('should accept container option', () => {
 
   expect(document.body).toMatchSnapshot()
 })
+
+test('should correctly prefix margin-inline and padding-inline properties without stripping CSS variable names', () => {
+  const cache = createCache({ key: 'test-inline-prefix' })
+
+  cache.insert(
+    '.test1',
+    { name: '1', styles: 'margin-inline-end: var(--my-margin-inline-end);' },
+    cache.sheet,
+    true
+  )
+  cache.insert(
+    '.test2',
+    {
+      name: '2',
+      styles: 'padding-inline-start: var(--my-padding-inline-start);'
+    },
+    cache.sheet,
+    true
+  )
+
+  expect(
+    cache.sheet.tags
+      .map(
+        tag =>
+          tag.textContent ||
+          Array.from(tag.sheet.cssRules)
+            .map(r => r.cssText)
+            .join('')
+      )
+      .join('')
+  ).toMatchInlineSnapshot(
+    `".test1{-webkit-margin-end:var(--my-margin-inline-end);margin-inline-end:var(--my-margin-inline-end);}.test2{-webkit-padding-start:var(--my-padding-inline-start);padding-inline-start:var(--my-padding-inline-start);}"`
+  )
+})

--- a/packages/cache/src/prefixer.ts
+++ b/packages/cache/src/prefixer.ts
@@ -168,7 +168,7 @@ function prefix(value: string, length: number): string {
     case 3583:
     case 4068:
     case 2532:
-      return replace(value, /(.+)-inline(.+)/, WEBKIT + '$1$2') + value
+      return replace(value, /([^:]+)-inline-([^:]+:)/, WEBKIT + '$1-$2') + value
     // (min|max)?(width|height|inline-size|block-size)
     case 8116:
     case 7059:


### PR DESCRIPTION
## Summary

Fixes #3309 — prevents prefixer from corrupting CSS variable names in `margin-inline-*` and `padding-inline-*` property values.

## Background

When prefixing logical margin/padding properties (`margin-inline-start`, `margin-inline-end`, `padding-inline-start`, `padding-inline-end`), the prefixer in `@emotion/cache` used a greedy regex:

```ts
replace(value, /(.+)-inline(.+)/, WEBKIT + '$1$2') + value
```

When the property value uses a CSS custom property containing `-inline` (e.g. `margin-inline-end: var(--my-margin-inline-end)`), the greedy regex matched `-inline` inside the custom property name rather than the CSS property name before the colon. This generated malformed `-webkit` declarations with the variable name corrupted (e.g. `-webkit-margin-inline-end:var(--my-margin-end)`).

Restricting the pattern to match `-inline-` before the colon (`/([^:]+)-inline-([^:]+:)/`) ensures only the CSS property name is transformed into `-webkit-margin-*` / `-webkit-padding-*`.

## Verification

- Added unit test in `packages/cache/__tests__/index.js` asserting that `margin-inline-end` and `padding-inline-start` with custom properties containing `-inline` keep their variable names intact in the generated CSS rules.
- Added changeset patch for `@emotion/cache`.
- Ran full test suite: all 98 test suites pass (890 tests, 782 snapshots, 0 failures).

**Checklist**:
- [x] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset